### PR TITLE
feat: Week Off Balance & Encashment System

### DIFF
--- a/docs/plans/2026-03-29-week-off-balance-design.md
+++ b/docs/plans/2026-03-29-week-off-balance-design.md
@@ -1,0 +1,205 @@
+# Week Off Balance & Encashment System
+
+**Date:** 2026-03-29
+**Status:** Approved
+
+## Problem
+
+Employees with weekly off have no tracking of unused week-offs. There is no mechanism to:
+- Pay employees extra when they work on their off day
+- Allow managers to accumulate unused week-offs for future use
+- Enforce a cap on how many week-offs can be taken per month
+
+## Design
+
+### Core Concept: Ledger-Based Tracking
+
+All week-off credits and debits are tracked in a `WeekOffCredit` ledger table. Balance is always computed (never stored as a mutable counter), eliminating drift and enabling full audit trails.
+
+### Schema Changes
+
+#### New Model: `WeekOffCredit`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | String | Primary key |
+| userId | String | FK to User |
+| date | DateTime | Date this entry is for |
+| type | String | CREDIT or DEBIT |
+| reason | String | WEEKLY_GRANT, WEEK_OFF_TAKEN, ENCASHMENT, MANUAL_ADJUSTMENT, DELETION_REVERSAL |
+| amount | Float | +1, -1, -0.5, etc. |
+| attendanceId | String? | Linked attendance record (for DEBIT/REVERSAL) |
+| salaryId | String? | Linked salary record (for ENCASHMENT) |
+| createdAt | DateTime | When this entry was created |
+| createdBy | String? | Who triggered it (cron/HR/system) |
+
+#### User Model: New Field
+
+- `encashWeekOffs Boolean @default(true)` - When true, unused week-offs are paid out at salary time. When false, they carry forward.
+
+#### Salary Model: New Fields
+
+- `weeklyOffDays Int @default(0)` - Week-off days taken that month
+- `unusedWeekOffs Int @default(0)` - Unused week-offs that month
+- `weekOffAdjustment Float @default(0)` - Payout amount for unused week-offs
+
+### Balance Computation
+
+Balance is always derived from the ledger:
+
+```
+weekOffBalance = SUM(amount) FROM WeekOffCredit WHERE userId = X
+```
+
+Monthly unused calculation:
+
+```
+creditsThisMonth = SUM(amount) WHERE type = CREDIT AND date in month
+debitsThisMonth  = SUM(amount) WHERE type = DEBIT AND reason = WEEK_OFF_TAKEN AND date in month
+unusedThisMonth  = creditsThisMonth + debitsThisMonth (debits are negative)
+```
+
+### Ledger Entries by Scenario
+
+| Event | Type | Reason | Amount |
+|-------|------|--------|--------|
+| Sunday cron grants weekly credit | CREDIT | WEEKLY_GRANT | +1 |
+| Employee takes a week-off | DEBIT | WEEK_OFF_TAKEN | -1 |
+| Fixed user works half day on off day | DEBIT | WEEK_OFF_TAKEN | -0.5 |
+| Salary encashment (encash users only) | DEBIT | ENCASHMENT | -(unused count) |
+| HR deletes a week-off attendance | CREDIT | DELETION_REVERSAL | +1 |
+| HR manual balance adjustment | CREDIT/DEBIT | MANUAL_ADJUSTMENT | +/-N |
+
+### Weekly Cron Job (Sundays)
+
+A new cron job runs every Sunday for all ACTIVE users with `hasWeeklyOff = true`:
+- Creates a CREDIT entry with reason WEEKLY_GRANT and amount +1
+- Idempotent: checks if a WEEKLY_GRANT for that user+date already exists before inserting
+- Only credits users whose activation/join date is on or before that Sunday
+
+### Attendance Changes
+
+#### When creating/updating attendance with `isWeeklyOff: true`:
+1. Compute `weekOffBalance` from ledger
+2. If balance <= 0, reject the request (return 400: "No week-off balance available. Mark as absent or present.")
+3. If balance > 0, create attendance AND insert DEBIT entry (reason: WEEK_OFF_TAKEN, amount: -1)
+
+#### Fixed weekly off users - HR override:
+- Currently, the PUT handler auto-forces `isWeeklyOff = true` for fixed users on their off day
+- Change: allow HR/Management to explicitly set `isWeeklyOff: false` when the employee worked
+- The auto-detection becomes the default only when `isWeeklyOff` is not explicitly provided
+
+#### Attendance deletion:
+- When a `isWeeklyOff` attendance is deleted, create a CREDIT entry (reason: DELETION_REVERSAL, amount: +1)
+
+### Salary Calculation Changes
+
+In `salary-calculator.ts`:
+
+1. Query ledger for the month: count WEEKLY_GRANT credits and WEEK_OFF_TAKEN debits
+2. Compute `unusedWeekOffs = credits + debits` (debits are negative)
+3. For fixed users who worked on their off day: those days already count in `presentDays`. The week-off adjustment accounts for the extra pay.
+4. For `encashWeekOffs = true` users:
+   - `weekOffAdjustment = unusedWeekOffs * perDaySalary`
+   - Create ENCASHMENT debit in ledger (does NOT reset balance - balance stays as-is for future months)
+5. For `encashWeekOffs = false` users:
+   - `weekOffAdjustment = 0`
+   - No encashment debit - balance naturally carries forward
+
+**Important:** Encashment debits are computed from monthly attendance data, not from the running balance. The balance field is only used for real-time "can I take a week-off?" checks.
+
+#### Updated net salary formula:
+
+```
+netSalary = (presentDays * perDaySalary)
+          + (overtimeDays * 0.5 * perDaySalary)
+          + leaveSalary
+          + weekOffAdjustment
+          + otherBonuses
+          - advanceDeductions
+          - otherDeductions
+```
+
+### Payslip Display
+
+- Line item labeled "Week Off Adjustment" (not "bonus")
+- Only shown when `weekOffAdjustment > 0`
+- Hidden for all other users to discourage gaming the system
+
+### Employee-Facing UI
+
+Simple card on dashboard/attendance screen:
+
+```
+Week Off
+Available: 2
+Used this month: 3
+```
+
+Two numbers only. No mention of encashment, credits, or balance mechanics. Designed for clarity with labour-class workforce.
+
+### Backfill Strategy (March 2026)
+
+Since this is a new feature, a migration script will backfill March 2026:
+
+1. For each active user with `hasWeeklyOff = true`:
+   - Count Sundays in March (1, 8, 15, 22, 29) = 5, filtered to only Sundays on or after user's join date
+   - Create WEEKLY_GRANT CREDIT entries for each eligible Sunday
+2. For each `isWeeklyOff` attendance in March:
+   - Create WEEK_OFF_TAKEN DEBIT entries
+3. Validation: computed balance should match expected (credits - debits)
+
+Backfill only writes to the new `WeekOffCredit` table. No existing data is modified.
+
+### Test Plan
+
+#### Flexible Week-Off Users:
+1. 4-week month, takes all 4 week-offs - adjustment = 0
+2. 4-week month, takes 3 week-offs - adjustment = 1 * perDaySalary
+3. 4-week month, takes 0 week-offs - adjustment = 4 * perDaySalary
+4. 5-week month, takes 4 week-offs - adjustment = 1 * perDaySalary
+5. 5-week month, takes 3 week-offs - adjustment = 2 * perDaySalary
+
+#### Fixed Week-Off Users:
+6. All off days taken as weekly off - adjustment = 0
+7. HR overrides 1 off day to present (working) - adjustment = 1 * perDaySalary
+8. Works on 2 off days in 5-week month - adjustment = 2 * perDaySalary
+9. Half day on off day - adjustment = 0.5 * perDaySalary
+
+#### Balance & Cap:
+10. Balance = 0, tries to take week-off - rejected (400 error)
+11. Sunday cron credits balance correctly
+12. Cron is idempotent (running twice on same Sunday doesn't double-credit)
+13. Mid-month joiner only gets credits for Sundays after join date
+
+#### Encashment:
+14. Encash user: salary pays out unused, balance unaffected for next month
+15. Non-encash user: no payout, balance carries forward
+16. March encashment doesn't prevent April 1st week-off (balance preserved)
+17. Salary regeneration doesn't double-count encashment
+
+#### Edge Cases:
+18. Attendance deletion returns credit to balance
+19. Retroactive attendance for past date creates correct debit
+20. Deactivated user mid-month: final salary encashes remaining balance
+21. Month boundary: week spanning two months credits/debits to correct month
+
+### Files Impacted
+
+| File | Change |
+|------|--------|
+| `prisma/schema.prisma` | WeekOffCredit model, User.encashWeekOffs, Salary new fields |
+| `src/lib/services/salary-calculator.ts` | Unused week-off calc, adjustment, encashment debit |
+| `src/app/api/attendance/route.ts` (POST) | Balance check from ledger, create DEBIT |
+| `src/app/api/attendance/[id]/route.ts` (PUT) | HR override for fixed users, balance check |
+| `src/app/api/attendance/[id]/route.ts` (DELETE) | DELETION_REVERSAL credit |
+| `src/app/api/salary/generate/route.ts` | Save new fields, encashment debit |
+| `src/app/api/salary/[id]/payslip/route.ts` | Conditional "Week Off Adjustment" line |
+| `src/app/api/salary/[id]/stats/route.ts` | Include new fields in response |
+| `src/models/models.ts` | Update TypeScript interfaces |
+| New: `src/app/api/cron/weekly-off-credit/route.ts` | Sunday cron for WEEKLY_GRANT |
+| New: `src/lib/services/week-off-balance.ts` | Balance computation + availability check |
+| New: `src/lib/services/__tests__/week-off-balance.test.ts` | Balance tests |
+| New: `src/lib/services/__tests__/salary-calculator.test.ts` | Salary + encashment tests |
+| New: `scripts/backfill-march-week-off-credits.ts` | March 2026 backfill |
+| UI: employee dashboard component | "Available / Used this month" card |

--- a/docs/plans/2026-03-29-week-off-balance-implementation.md
+++ b/docs/plans/2026-03-29-week-off-balance-implementation.md
@@ -1,0 +1,1640 @@
+# Week Off Balance & Encashment — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement a ledger-based week-off credit/debit system that tracks weekly off usage, enforces balance limits at attendance creation, and optionally encashes unused week-offs at salary time.
+
+**Architecture:** A new `WeekOffCredit` ledger table records all credits (Sunday cron grants) and debits (week-off taken, encashment). Balance is always derived via `SUM(amount)`, never cached. Attendance APIs check balance before allowing week-offs. Salary calculator reads the ledger to compute "Week Off Adjustment" payouts.
+
+**Tech Stack:** Next.js 15, Prisma ORM (PostgreSQL), TypeScript, pdf-lib (payslips). No test framework is currently set up — we'll add Vitest.
+
+---
+
+### Task 1: Set up Vitest test framework
+
+**Files:**
+- Create: `vitest.config.ts`
+- Modify: `package.json` (add vitest + test script)
+
+**Step 1: Install Vitest**
+
+Run: `npm install --save-dev vitest`
+Expected: vitest added to devDependencies
+
+**Step 2: Create vitest config**
+
+Create `vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})
+```
+
+**Step 3: Add test script to package.json**
+
+Add to `"scripts"`:
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+**Step 4: Verify setup**
+
+Run: `npx vitest run`
+Expected: "No test files found" (confirms vitest works)
+
+**Step 5: Commit**
+
+```bash
+git add vitest.config.ts package.json package-lock.json
+git commit -m "chore: add Vitest test framework"
+```
+
+---
+
+### Task 2: Prisma schema changes
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+- Modify: `src/models/models.ts`
+
+**Step 1: Add WeekOffCredit model to schema.prisma**
+
+Add after the `ActivityLog` model (before the Job Offer section):
+
+```prisma
+// --- Week Off Credit Ledger ---
+
+model WeekOffCredit {
+  id           String   @id @default(cuid())
+  numId        Int      @default(autoincrement()) @map("num_id")
+  userId       String   @map("user_id")
+  date         DateTime
+  type         String   // CREDIT or DEBIT
+  reason       String   // WEEKLY_GRANT, WEEK_OFF_TAKEN, ENCASHMENT, MANUAL_ADJUSTMENT, DELETION_REVERSAL
+  amount       Float    // +1, -1, -0.5, etc.
+  attendanceId String?  @map("attendance_id")
+  salaryId     String?  @map("salary_id")
+  createdBy    String?  @map("created_by")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  // Relations
+  user       User        @relation("UserWeekOffCredits", fields: [userId], references: [id], onDelete: Cascade)
+  attendance Attendance? @relation(fields: [attendanceId], references: [id], onDelete: SetNull)
+  salary     Salary?     @relation("SalaryWeekOffCredits", fields: [salaryId], references: [id], onDelete: SetNull)
+
+  @@index([userId])
+  @@index([userId, date])
+  @@index([userId, type])
+  @@index([attendanceId])
+  @@index([salaryId])
+  @@map("week_off_credits")
+}
+```
+
+**Step 2: Add `encashWeekOffs` field to User model**
+
+Add after the `weeklyOffDay` field (line ~150 area):
+
+```prisma
+  encashWeekOffs      Boolean  @default(true) @map("encash_week_offs")
+```
+
+**Step 3: Add relation to User model**
+
+Add in the User relations section:
+
+```prisma
+  weekOffCredits     WeekOffCredit[] @relation("UserWeekOffCredits")
+```
+
+**Step 4: Add new fields to Salary model**
+
+Add after the `leaveSalary` field:
+
+```prisma
+  weeklyOffDays    Int   @default(0) @map("weekly_off_days")
+  unusedWeekOffs   Int   @default(0) @map("unused_week_offs")
+  weekOffAdjustment Float @default(0) @map("week_off_adjustment")
+```
+
+**Step 5: Add relation to Salary model**
+
+Add in the Salary relations section:
+
+```prisma
+  weekOffCredits   WeekOffCredit[] @relation("SalaryWeekOffCredits")
+```
+
+**Step 6: Add relation to Attendance model**
+
+Add in the Attendance relations section:
+
+```prisma
+  weekOffCredits   WeekOffCredit[]
+```
+
+**Step 7: Update TypeScript interfaces in `src/models/models.ts`**
+
+Add to Salary interface after `leaveSalary`:
+```ts
+  weeklyOffDays: number;
+  unusedWeekOffs: number;
+  weekOffAdjustment: number;
+```
+
+Add to User interface:
+```ts
+  encashWeekOffs: boolean;
+  weekOffCredits?: WeekOffCredit[];
+```
+
+Add new interface:
+```ts
+export interface WeekOffCredit {
+  id: string;
+  numId: number;
+  userId: string;
+  date: Date;
+  type: string;
+  reason: string;
+  amount: number;
+  attendanceId?: string | null;
+  salaryId?: string | null;
+  createdBy?: string | null;
+  createdAt: Date;
+  user?: User;
+  attendance?: Attendance | null;
+  salary?: Salary | null;
+}
+```
+
+**Step 8: Generate and run migration**
+
+Run: `npx prisma migrate dev --name add-week-off-credit-ledger`
+Expected: Migration created and applied successfully
+
+**Step 9: Verify Prisma client generation**
+
+Run: `npx prisma generate`
+Expected: Prisma client generated successfully
+
+**Step 10: Commit**
+
+```bash
+git add prisma/ src/models/models.ts
+git commit -m "feat: add WeekOffCredit ledger model, User.encashWeekOffs, Salary week-off fields"
+```
+
+---
+
+### Task 3: Week-off balance service
+
+**Files:**
+- Create: `src/lib/services/week-off-balance.ts`
+- Create: `src/lib/services/__tests__/week-off-balance.test.ts`
+
+**Step 1: Write the failing tests**
+
+Create `src/lib/services/__tests__/week-off-balance.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock prisma
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    weekOffCredit: {
+      aggregate: vi.fn(),
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+import { prisma } from '@/lib/prisma'
+import {
+  getWeekOffBalance,
+  getMonthlyWeekOffSummary,
+  createWeekOffCredit,
+  checkWeekOffAvailability,
+} from '../week-off-balance'
+
+const mockedPrisma = vi.mocked(prisma)
+
+describe('getWeekOffBalance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns sum of all credits and debits for a user', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: 3 },
+      _count: { amount: 0 },
+      _avg: { amount: 0 },
+      _min: { amount: 0 },
+      _max: { amount: 0 },
+    } as any)
+
+    const balance = await getWeekOffBalance('user-1')
+    expect(balance).toBe(3)
+    expect(mockedPrisma.weekOffCredit.aggregate).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      _sum: { amount: true },
+    })
+  })
+
+  it('returns 0 when no credits exist', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: null },
+      _count: { amount: 0 },
+      _avg: { amount: 0 },
+      _min: { amount: 0 },
+      _max: { amount: 0 },
+    } as any)
+
+    const balance = await getWeekOffBalance('user-1')
+    expect(balance).toBe(0)
+  })
+})
+
+describe('getMonthlyWeekOffSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns credits and debits for a given month', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+    ] as any)
+
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.creditsThisMonth).toBe(4)
+    expect(summary.debitsThisMonth).toBe(3)
+    expect(summary.unusedThisMonth).toBe(1)
+  })
+
+  it('handles 5-week month with all credits used', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+    ] as any)
+
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.creditsThisMonth).toBe(5)
+    expect(summary.debitsThisMonth).toBe(5)
+    expect(summary.unusedThisMonth).toBe(0)
+  })
+
+  it('handles half-day debit', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -0.5 },
+    ] as any)
+
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.creditsThisMonth).toBe(1)
+    expect(summary.debitsThisMonth).toBe(0.5)
+    expect(summary.unusedThisMonth).toBe(0.5)
+  })
+
+  it('excludes encashment debits from monthly usage count', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'ENCASHMENT', amount: -1 },
+    ] as any)
+
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.creditsThisMonth).toBe(2)
+    expect(summary.debitsThisMonth).toBe(1) // only WEEK_OFF_TAKEN
+    expect(summary.unusedThisMonth).toBe(1)
+  })
+})
+
+describe('checkWeekOffAvailability', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns available when balance > 0', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: 2 },
+      _count: { amount: 0 },
+      _avg: { amount: 0 },
+      _min: { amount: 0 },
+      _max: { amount: 0 },
+    } as any)
+
+    const result = await checkWeekOffAvailability('user-1')
+    expect(result.available).toBe(true)
+    expect(result.balance).toBe(2)
+  })
+
+  it('returns unavailable when balance is 0', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: 0 },
+      _count: { amount: 0 },
+      _avg: { amount: 0 },
+      _min: { amount: 0 },
+      _max: { amount: 0 },
+    } as any)
+
+    const result = await checkWeekOffAvailability('user-1')
+    expect(result.available).toBe(false)
+    expect(result.balance).toBe(0)
+  })
+
+  it('returns unavailable when balance is negative', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: -1 },
+      _count: { amount: 0 },
+      _avg: { amount: 0 },
+      _min: { amount: 0 },
+      _max: { amount: 0 },
+    } as any)
+
+    const result = await checkWeekOffAvailability('user-1')
+    expect(result.available).toBe(false)
+    expect(result.balance).toBe(-1)
+  })
+
+  it('checks for half-day availability (balance >= 0.5)', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: 0.5 },
+      _count: { amount: 0 },
+      _avg: { amount: 0 },
+      _min: { amount: 0 },
+      _max: { amount: 0 },
+    } as any)
+
+    const result = await checkWeekOffAvailability('user-1', 0.5)
+    expect(result.available).toBe(true)
+  })
+})
+
+describe('createWeekOffCredit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a WEEKLY_GRANT credit entry', async () => {
+    const date = new Date('2026-03-01')
+    mockedPrisma.weekOffCredit.create.mockResolvedValue({
+      id: 'credit-1',
+      userId: 'user-1',
+      date,
+      type: 'CREDIT',
+      reason: 'WEEKLY_GRANT',
+      amount: 1,
+    } as any)
+
+    const result = await createWeekOffCredit({
+      userId: 'user-1',
+      date,
+      type: 'CREDIT',
+      reason: 'WEEKLY_GRANT',
+      amount: 1,
+    })
+
+    expect(result.type).toBe('CREDIT')
+    expect(result.amount).toBe(1)
+  })
+
+  it('creates a WEEK_OFF_TAKEN debit entry with attendanceId', async () => {
+    const date = new Date('2026-03-10')
+    mockedPrisma.weekOffCredit.create.mockResolvedValue({
+      id: 'debit-1',
+      userId: 'user-1',
+      date,
+      type: 'DEBIT',
+      reason: 'WEEK_OFF_TAKEN',
+      amount: -1,
+      attendanceId: 'att-1',
+    } as any)
+
+    const result = await createWeekOffCredit({
+      userId: 'user-1',
+      date,
+      type: 'DEBIT',
+      reason: 'WEEK_OFF_TAKEN',
+      amount: -1,
+      attendanceId: 'att-1',
+    })
+
+    expect(result.type).toBe('DEBIT')
+    expect(result.amount).toBe(-1)
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/services/__tests__/week-off-balance.test.ts`
+Expected: FAIL — module `../week-off-balance` not found
+
+**Step 3: Write the implementation**
+
+Create `src/lib/services/week-off-balance.ts`:
+
+```ts
+import { prisma } from '@/lib/prisma'
+
+export type WeekOffCreditType = 'CREDIT' | 'DEBIT'
+export type WeekOffCreditReason =
+  | 'WEEKLY_GRANT'
+  | 'WEEK_OFF_TAKEN'
+  | 'ENCASHMENT'
+  | 'MANUAL_ADJUSTMENT'
+  | 'DELETION_REVERSAL'
+
+interface CreateWeekOffCreditParams {
+  userId: string
+  date: Date
+  type: WeekOffCreditType
+  reason: WeekOffCreditReason
+  amount: number
+  attendanceId?: string
+  salaryId?: string
+  createdBy?: string
+}
+
+/**
+ * Get the current week-off balance for a user.
+ * Balance = SUM(amount) of all WeekOffCredit entries.
+ */
+export async function getWeekOffBalance(userId: string): Promise<number> {
+  const result = await prisma.weekOffCredit.aggregate({
+    where: { userId },
+    _sum: { amount: true },
+  })
+  return result._sum.amount ?? 0
+}
+
+/**
+ * Get monthly week-off summary: credits granted, week-offs taken, and unused count.
+ * Excludes ENCASHMENT debits from "debits this month" since those aren't usage.
+ */
+export async function getMonthlyWeekOffSummary(
+  userId: string,
+  month: number,
+  year: number
+) {
+  const startDate = new Date(year, month - 1, 1)
+  const endDate = new Date(year, month, 0, 23, 59, 59, 999)
+
+  const entries = await prisma.weekOffCredit.findMany({
+    where: {
+      userId,
+      date: { gte: startDate, lte: endDate },
+    },
+  })
+
+  const creditsThisMonth = entries
+    .filter((e) => e.type === 'CREDIT')
+    .reduce((sum, e) => sum + e.amount, 0)
+
+  // Only count WEEK_OFF_TAKEN debits as "usage" (not ENCASHMENT)
+  const debitsThisMonth = entries
+    .filter((e) => e.type === 'DEBIT' && e.reason === 'WEEK_OFF_TAKEN')
+    .reduce((sum, e) => sum + Math.abs(e.amount), 0)
+
+  const unusedThisMonth = creditsThisMonth - debitsThisMonth
+
+  return { creditsThisMonth, debitsThisMonth, unusedThisMonth }
+}
+
+/**
+ * Check if a user has enough week-off balance to take a day off.
+ * @param requiredAmount - defaults to 1, use 0.5 for half-day
+ */
+export async function checkWeekOffAvailability(
+  userId: string,
+  requiredAmount: number = 1
+): Promise<{ available: boolean; balance: number }> {
+  const balance = await getWeekOffBalance(userId)
+  return {
+    available: balance >= requiredAmount,
+    balance,
+  }
+}
+
+/**
+ * Create a week-off credit/debit ledger entry.
+ */
+export async function createWeekOffCredit(params: CreateWeekOffCreditParams) {
+  return prisma.weekOffCredit.create({
+    data: {
+      userId: params.userId,
+      date: params.date,
+      type: params.type,
+      reason: params.reason,
+      amount: params.amount,
+      attendanceId: params.attendanceId,
+      salaryId: params.salaryId,
+      createdBy: params.createdBy,
+    },
+  })
+}
+
+/**
+ * Check if a WEEKLY_GRANT credit already exists for a user on a given date.
+ * Used for idempotent cron execution.
+ */
+export async function hasWeeklyGrantForDate(
+  userId: string,
+  date: Date
+): Promise<boolean> {
+  const startOfDay = new Date(date)
+  startOfDay.setHours(0, 0, 0, 0)
+  const endOfDay = new Date(date)
+  endOfDay.setHours(23, 59, 59, 999)
+
+  const existing = await prisma.weekOffCredit.findFirst({
+    where: {
+      userId,
+      date: { gte: startOfDay, lte: endOfDay },
+      type: 'CREDIT',
+      reason: 'WEEKLY_GRANT',
+    },
+  })
+
+  return !!existing
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/services/__tests__/week-off-balance.test.ts`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/services/week-off-balance.ts src/lib/services/__tests__/week-off-balance.test.ts
+git commit -m "feat: add week-off balance service with ledger queries"
+```
+
+---
+
+### Task 4: Sunday cron job for weekly credits
+
+**Files:**
+- Create: `src/app/api/cron/weekly-off-credit/route.ts`
+
+**Step 1: Create the cron endpoint**
+
+Create `src/app/api/cron/weekly-off-credit/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { createWeekOffCredit, hasWeeklyGrantForDate } from '@/lib/services/week-off-balance'
+
+/**
+ * Cron job endpoint for crediting weekly off balance every Sunday.
+ * For all ACTIVE users with hasWeeklyOff = true, adds +1 WEEKLY_GRANT.
+ * Idempotent: skips users who already have a grant for today.
+ *
+ * Recommended schedule: Every Sunday at 1:00 AM (0 1 * * 0)
+ * Security: Protected by CRON_SECRET environment variable
+ */
+export async function GET(request: NextRequest) {
+  const startTime = Date.now()
+  const timestamp = new Date().toISOString()
+  const istTime = new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' })
+
+  // Security: Verify the request is from an authorized source
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: 'Unauthorized', message: 'Invalid or missing CRON_SECRET', timestamp },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    // Get all active users with weekly off enabled, joined on or before today
+    const users = await prisma.user.findMany({
+      where: {
+        hasWeeklyOff: true,
+        status: 'ACTIVE',
+        createdAt: { lte: today },
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+    })
+
+    let credited = 0
+    let skipped = 0
+    const creditedUsers: Array<{ id: string; name: string | null }> = []
+
+    for (const user of users) {
+      // Idempotent: check if grant already exists for today
+      const alreadyGranted = await hasWeeklyGrantForDate(user.id, today)
+      if (alreadyGranted) {
+        skipped++
+        continue
+      }
+
+      await createWeekOffCredit({
+        userId: user.id,
+        date: today,
+        type: 'CREDIT',
+        reason: 'WEEKLY_GRANT',
+        amount: 1,
+        createdBy: 'system:weekly-off-credit-cron',
+      })
+
+      credited++
+      creditedUsers.push({ id: user.id, name: user.name })
+    }
+
+    const duration = Date.now() - startTime
+
+    return NextResponse.json({
+      success: true,
+      message: `Credited ${credited} users, skipped ${skipped}`,
+      credited,
+      skipped,
+      totalEligible: users.length,
+      duration: `${duration}ms`,
+      timestamp,
+      istTime,
+      creditedUsers,
+    })
+  } catch (error) {
+    const duration = Date.now() - startTime
+    console.error('Weekly off credit cron error:', error)
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to credit weekly off balance',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp,
+        istTime,
+        duration: `${duration}ms`,
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return GET(request)
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/api/cron/weekly-off-credit/route.ts
+git commit -m "feat: add Sunday cron job for weekly off credit grants"
+```
+
+---
+
+### Task 5: Attendance POST — balance check + debit on week-off
+
+**Files:**
+- Modify: `src/app/api/attendance/route.ts:134-189` (POST handler, weekly off section)
+
+**Step 1: Add imports at the top of `src/app/api/attendance/route.ts`**
+
+Add after existing imports:
+
+```ts
+import { checkWeekOffAvailability, createWeekOffCredit } from '@/lib/services/week-off-balance'
+```
+
+**Step 2: Add balance check after flexible weekly off validation**
+
+In the POST handler, find the section where `isWeeklyOff` is validated (around lines 145-189). After the existing flexible weekly off validation (the `if (existingWeeklyOff)` block that returns 400), and BEFORE the `if (isWeeklyOff) { data.isPresent = true; ... }` block, add:
+
+```ts
+      // Check week-off balance before allowing weekly off
+      if (isWeeklyOff) {
+        const { available, balance } = await checkWeekOffAvailability(data.userId)
+        if (!available) {
+          return NextResponse.json(
+            {
+              error: 'No week-off balance available. Employee must be marked as present or absent.',
+              currentBalance: balance,
+            },
+            { status: 400 }
+          )
+        }
+      }
+```
+
+**Step 3: Create debit entry after attendance is created**
+
+After the attendance create call (around line 222: `const attendance = await prisma.attendance.create({...})`), and before the salary recalculation block, add:
+
+```ts
+    // Create week-off debit in ledger
+    if (isWeeklyOff && attendance) {
+      await createWeekOffCredit({
+        userId: data.userId,
+        date: attendanceDate,
+        type: 'DEBIT',
+        reason: 'WEEK_OFF_TAKEN',
+        amount: -1,
+        attendanceId: attendance.id,
+        createdBy: creatorId,
+      })
+    }
+```
+
+**Step 4: Commit**
+
+```bash
+git add src/app/api/attendance/route.ts
+git commit -m "feat: enforce week-off balance check and create debit on attendance POST"
+```
+
+---
+
+### Task 6: Attendance PUT — HR override for fixed users + balance check
+
+**Files:**
+- Modify: `src/app/api/attendance/[id]/route.ts:306-371` (PUT handler, weekly off section)
+
+**Step 1: Add imports**
+
+Add at the top:
+
+```ts
+import { checkWeekOffAvailability, createWeekOffCredit } from '@/lib/services/week-off-balance'
+```
+
+**Step 2: Modify fixed weekly off auto-detection to allow override**
+
+In the PUT handler, find the fixed weekly off section (around lines 320-323):
+
+```ts
+      if (userWithWeeklyOff.weeklyOffType === "FIXED") {
+        // For fixed weekly off, check if the date matches the weekly off day
+        const dayOfWeek = updateDate.getDay();
+        isWeeklyOff = userWithWeeklyOff.weeklyOffDay === dayOfWeek;
+      }
+```
+
+Replace with:
+
+```ts
+      if (userWithWeeklyOff.weeklyOffType === "FIXED") {
+        const dayOfWeek = updateDate.getDay();
+        const isOffDay = userWithWeeklyOff.weeklyOffDay === dayOfWeek;
+        // Allow HR/Management to override: if they explicitly set isWeeklyOff to false
+        // on the employee's off day, respect it (employee worked that day)
+        if (isOffDay && body.isWeeklyOff === false) {
+          isWeeklyOff = false; // HR override: employee worked on off day
+        } else {
+          isWeeklyOff = isOffDay;
+        }
+      }
+```
+
+**Step 3: Add balance check before allowing week-off (same pattern as POST)**
+
+After the flexible weekly off validation block and before the `if (isWeeklyOff) { body.isPresent = true; ... }` block, add:
+
+```ts
+      // Check week-off balance before allowing weekly off
+      if (isWeeklyOff) {
+        const { available, balance } = await checkWeekOffAvailability(currentAttendance.userId)
+
+        // If the current attendance was already a week-off, the balance already includes
+        // the debit from the original creation, so we need to account for that
+        const currentAttendanceRecord = await prisma.attendance.findUnique({
+          where: { id },
+          select: { isWeeklyOff: true },
+        })
+        const wasAlreadyWeeklyOff = currentAttendanceRecord?.isWeeklyOff ?? false
+        const effectiveBalance = wasAlreadyWeeklyOff ? balance + 1 : balance
+
+        if (effectiveBalance <= 0) {
+          return NextResponse.json(
+            {
+              error: 'No week-off balance available. Employee must be marked as present or absent.',
+              currentBalance: balance,
+            },
+            { status: 400 }
+          )
+        }
+      }
+```
+
+**Step 4: Handle ledger entries for changed week-off status**
+
+After the attendance update call, add logic to handle ledger changes:
+
+```ts
+    // Handle week-off ledger entries when isWeeklyOff status changes
+    const previousAttendance = await prisma.attendance.findUnique({
+      where: { id },
+      select: { isWeeklyOff: true },
+    })
+    // Note: We need to check BEFORE the update. Since the update already happened,
+    // we rely on comparing the new isWeeklyOff with what was there before.
+    // This logic should be placed BEFORE the prisma.attendance.update call.
+```
+
+**Important implementation note:** The ledger entry logic needs to compare old vs new `isWeeklyOff`. Read the current attendance BEFORE the update, then after the update:
+- If changing from `isWeeklyOff: false` → `isWeeklyOff: true`: create DEBIT (-1)
+- If changing from `isWeeklyOff: true` → `isWeeklyOff: false`: create CREDIT (+1, reason: DELETION_REVERSAL)
+- If no change: do nothing
+
+Restructure the PUT handler to:
+1. Read current attendance state (already done at line 182-194)
+2. Perform all validations
+3. Update the attendance
+4. Compare old vs new `isWeeklyOff` and create ledger entries accordingly
+
+```ts
+    // After attendance update, handle ledger entries
+    const wasWeeklyOff = currentAttendance.isWeeklyOff ?? false  // from the earlier query
+    const isNowWeeklyOff = isWeeklyOff
+
+    if (!wasWeeklyOff && isNowWeeklyOff) {
+      // Changed to weekly off — create debit
+      await createWeekOffCredit({
+        userId: currentAttendance.userId,
+        date: updateDate,
+        type: 'DEBIT',
+        reason: 'WEEK_OFF_TAKEN',
+        amount: -1,
+        attendanceId: id,
+        createdBy: sessionUserId ?? undefined,
+      })
+    } else if (wasWeeklyOff && !isNowWeeklyOff) {
+      // Changed from weekly off to working — return credit
+      await createWeekOffCredit({
+        userId: currentAttendance.userId,
+        date: updateDate,
+        type: 'CREDIT',
+        reason: 'DELETION_REVERSAL',
+        amount: 1,
+        attendanceId: id,
+        createdBy: sessionUserId ?? undefined,
+      })
+    }
+```
+
+**Note:** The `currentAttendance` query at line 182-194 needs to also select `isWeeklyOff`. Add it to the select:
+
+```ts
+    const currentAttendance = await prisma.attendance.findUnique({
+      where: { id },
+      select: {
+        // ...existing fields...
+        isWeeklyOff: true,  // ADD THIS
+      }
+    });
+```
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/attendance/[id]/route.ts
+git commit -m "feat: allow HR override for fixed weekly off + balance check on PUT"
+```
+
+---
+
+### Task 7: Attendance DELETE — return credit on week-off deletion
+
+**Files:**
+- Modify: `src/app/api/attendance/[id]/route.ts:447-542` (DELETE handler)
+
+**Step 1: Add week-off credit reversal after attendance deletion**
+
+After the `await prisma.attendance.delete(...)` call and before the salary recalculation, add:
+
+```ts
+    // If deleted attendance was a weekly off, return the credit
+    if (attendance.isWeeklyOff) {
+      await createWeekOffCredit({
+        userId: attendance.userId,
+        date: new Date(attendance.date),
+        type: 'CREDIT',
+        reason: 'DELETION_REVERSAL',
+        amount: 1,
+        attendanceId: id,
+        createdBy: sessionUserId ?? undefined,
+      })
+    }
+```
+
+**Note:** The existing attendance query at line 459-465 needs to also select `isWeeklyOff`:
+
+```ts
+    const attendance = await prisma.attendance.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+        date: true,
+        isWeeklyOff: true,  // ADD THIS
+      }
+    });
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/api/attendance/[id]/route.ts
+git commit -m "feat: return week-off credit on attendance deletion"
+```
+
+---
+
+### Task 8: Salary calculator — week-off adjustment + encashment
+
+**Files:**
+- Modify: `src/lib/services/salary-calculator.ts`
+- Create: `src/lib/services/__tests__/salary-calculator.test.ts`
+
+**Step 1: Write failing tests for salary calculator week-off logic**
+
+Create `src/lib/services/__tests__/salary-calculator.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    attendance: { findMany: vi.fn() },
+    advancePayment: { findMany: vi.fn() },
+    weekOffCredit: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      aggregate: vi.fn(),
+    },
+  },
+}))
+
+import { prisma } from '@/lib/prisma'
+import { calculateSalary } from '../salary-calculator'
+
+const mockedPrisma = vi.mocked(prisma)
+
+describe('calculateSalary - week off adjustment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: no advance payments
+    mockedPrisma.advancePayment.findMany.mockResolvedValue([])
+  })
+
+  it('calculates weekOffAdjustment for encash user with unused week-offs', async () => {
+    // March 2026: 31 days, 5 Sundays
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000,
+      hasWeeklyOff: true,
+      encashWeekOffs: true,
+      weeklyOffType: 'FLEXIBLE',
+      weeklyOffDay: null,
+    } as any)
+
+    // 28 attendance records: 25 regular + 3 weekly off
+    const regularDays = Array.from({ length: 25 }, (_, i) => ({
+      isPresent: true, isWeeklyOff: false, isHalfDay: false, overtime: false,
+      isWorkFromHome: false, status: 'APPROVED',
+    }))
+    const weeklyOffDays = Array.from({ length: 3 }, () => ({
+      isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false,
+      isWorkFromHome: false, status: 'APPROVED',
+    }))
+    mockedPrisma.attendance.findMany.mockResolvedValue([...regularDays, ...weeklyOffDays] as any)
+
+    // Ledger: 5 credits (5 Sundays), 3 debits (3 week-offs taken)
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+    ] as any)
+
+    const result = await calculateSalary('user-1', 3, 2026)
+
+    // perDaySalary = 31000 / 31 = 1000
+    // unused = 5 credits - 3 debits = 2
+    // weekOffAdjustment = 2 * 1000 = 2000
+    expect(result.weekOffAdjustment).toBe(2000)
+    expect(result.unusedWeekOffs).toBe(2)
+    expect(result.weeklyOffDays).toBe(3)
+  })
+
+  it('returns 0 weekOffAdjustment for non-encash user', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000,
+      hasWeeklyOff: true,
+      encashWeekOffs: false,
+      weeklyOffType: 'FLEXIBLE',
+      weeklyOffDay: null,
+    } as any)
+
+    mockedPrisma.attendance.findMany.mockResolvedValue([
+      { isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+    ] as any)
+
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+    ] as any)
+
+    const result = await calculateSalary('user-1', 3, 2026)
+    expect(result.weekOffAdjustment).toBe(0)
+    expect(result.unusedWeekOffs).toBe(1) // still tracked, just not paid
+  })
+
+  it('returns 0 weekOffAdjustment for user without weekly off', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000,
+      hasWeeklyOff: false,
+      encashWeekOffs: true,
+    } as any)
+
+    mockedPrisma.attendance.findMany.mockResolvedValue([
+      { isPresent: true, isWeeklyOff: false, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+    ] as any)
+
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([])
+
+    const result = await calculateSalary('user-1', 3, 2026)
+    expect(result.weekOffAdjustment).toBe(0)
+    expect(result.unusedWeekOffs).toBe(0)
+  })
+
+  it('handles 4-week month with all week-offs taken', async () => {
+    // April 2026: 30 days
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 30000,
+      hasWeeklyOff: true,
+      encashWeekOffs: true,
+      weeklyOffType: 'FLEXIBLE',
+      weeklyOffDay: null,
+    } as any)
+
+    const weeklyOffs = Array.from({ length: 4 }, () => ({
+      isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false,
+      isWorkFromHome: false, status: 'APPROVED',
+    }))
+    mockedPrisma.attendance.findMany.mockResolvedValue(weeklyOffs as any)
+
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+    ] as any)
+
+    const result = await calculateSalary('user-1', 4, 2026)
+    expect(result.weekOffAdjustment).toBe(0)
+    expect(result.unusedWeekOffs).toBe(0)
+  })
+
+  it('handles half-day on off day for fixed user', async () => {
+    // March 2026: 31 days
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000,
+      hasWeeklyOff: true,
+      encashWeekOffs: true,
+      weeklyOffType: 'FIXED',
+      weeklyOffDay: 2, // Tuesday
+    } as any)
+
+    mockedPrisma.attendance.findMany.mockResolvedValue([
+      // 4 normal weekly offs
+      { isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+      { isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+      { isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+      { isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+    ] as any)
+
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -0.5 }, // half day on off day
+    ] as any)
+
+    const result = await calculateSalary('user-1', 3, 2026)
+    // 5 credits - 4.5 debits = 0.5 unused
+    // weekOffAdjustment = 0.5 * 1000 = 500
+    expect(result.weekOffAdjustment).toBe(500)
+    expect(result.unusedWeekOffs).toBe(0.5)
+  })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/services/__tests__/salary-calculator.test.ts`
+Expected: FAIL — `weekOffAdjustment` not in return value
+
+**Step 3: Modify `src/lib/services/salary-calculator.ts`**
+
+Add import at top:
+```ts
+import { getMonthlyWeekOffSummary } from '@/lib/services/week-off-balance'
+```
+
+Add to the `select` in the user query:
+```ts
+    select: {
+      salary: true,
+      hasWeeklyOff: true,
+      encashWeekOffs: true,  // ADD
+      weeklyOffType: true,   // ADD
+      weeklyOffDay: true,    // ADD
+    },
+```
+
+After the existing attendance counting loop (after line 66), add the week-off adjustment calculation:
+
+```ts
+  // Calculate week-off adjustment from ledger
+  let unusedWeekOffs = 0
+  let weekOffAdjustment = 0
+
+  if (employee.hasWeeklyOff) {
+    const summary = await getMonthlyWeekOffSummary(userId, month, year)
+    unusedWeekOffs = summary.unusedThisMonth
+
+    if (employee.encashWeekOffs && unusedWeekOffs > 0) {
+      weekOffAdjustment = parseFloat((unusedWeekOffs * perDaySalary).toFixed(2))
+    }
+  }
+```
+
+Update the net salary calculation (around line 138):
+```ts
+  const netSalary = totalSalaryWithLeaves + weekOffAdjustment + otherBonuses - deductions;
+```
+
+Add new fields to the return object:
+```ts
+  return {
+    // ...existing fields...
+    weeklyOffDays,
+    unusedWeekOffs,
+    weekOffAdjustment,
+  }
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/services/__tests__/salary-calculator.test.ts`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/lib/services/salary-calculator.ts src/lib/services/__tests__/salary-calculator.test.ts
+git commit -m "feat: add week-off adjustment calculation to salary calculator"
+```
+
+---
+
+### Task 9: Salary generation — save new fields + encashment debit
+
+**Files:**
+- Modify: `src/app/api/salary/generate/route.ts:143-196` (inside the transaction)
+
+**Step 1: Import createWeekOffCredit**
+
+Add at top:
+```ts
+import { createWeekOffCredit } from '@/lib/services/week-off-balance'
+```
+
+**Step 2: Save new fields in salary creation**
+
+In the `tx.salary.create` data (around line 145-162), add after `leaveSalary`:
+
+```ts
+            weeklyOffDays: salaryDetails.weeklyOffDays,
+            unusedWeekOffs: salaryDetails.unusedWeekOffs,
+            weekOffAdjustment: salaryDetails.weekOffAdjustment,
+```
+
+**Step 3: Create encashment debit after salary creation**
+
+After the salary creation (after `const salary = await tx.salary.create({...})`), add:
+
+```ts
+        // Create encashment debit in ledger for users with encash enabled
+        if (salaryDetails.weekOffAdjustment > 0 && salaryDetails.unusedWeekOffs > 0) {
+          await createWeekOffCredit({
+            userId: user.id,
+            date: new Date(year, month - 1, endDate.getDate()), // last day of month
+            type: 'DEBIT',
+            reason: 'ENCASHMENT',
+            amount: -salaryDetails.unusedWeekOffs,
+            salaryId: salary.id,
+            createdBy: 'system:salary-generation',
+          })
+        }
+```
+
+**Step 4: Also update the net salary formula in PATCH handler**
+
+The PATCH handler (status changes) recalculates net salary in several places. Find all instances where `netSalary` is computed and add `weekOffAdjustment`:
+
+In the PROCESSING status change (around line 318):
+```ts
+            netSalary: existingSalary.baseSalary +
+                      existingSalary.overtimeBonus +
+                      existingSalary.weekOffAdjustment +  // ADD THIS
+                      existingSalary.otherBonuses -
+                      totalApprovedDeductions -
+                      existingSalary.deductions
+```
+
+Do the same for all other netSalary recalculations in this file (there are ~4 instances).
+
+**Step 5: Commit**
+
+```bash
+git add src/app/api/salary/generate/route.ts
+git commit -m "feat: save week-off fields in salary generation + encashment debit"
+```
+
+---
+
+### Task 10: Salary stats — include new fields
+
+**Files:**
+- Modify: `src/app/api/salary/[id]/stats/route.ts`
+
+**Step 1: Add weekOffAdjustment to stats response**
+
+In the stats object (around line 133-185), add to the `salary` section:
+
+```ts
+        weeklyOffDays: salary.weeklyOffDays,
+        unusedWeekOffs: salary.unusedWeekOffs,
+        weekOffAdjustment: salary.weekOffAdjustment,
+```
+
+And add `weekOffAdjustment` to the `baseSalaryEarned` calculation:
+```ts
+    const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary + salary.weekOffAdjustment;
+```
+
+**Step 2: Commit**
+
+```bash
+git add src/app/api/salary/[id]/stats/route.ts
+git commit -m "feat: include week-off adjustment in salary stats"
+```
+
+---
+
+### Task 11: Payslip — conditional "Week Off Adjustment" line
+
+**Files:**
+- Modify: `src/app/api/salary/[id]/payslip/route.ts`
+
+**Step 1: Add Week Off Adjustment to earnings section**
+
+In the earnings array (around line 286-299), add BEFORE the "Other Bonuses" entries:
+
+```ts
+			// Week Off Adjustment — only show when > 0
+			if (salary.weekOffAdjustment > 0) {
+				earnings.push({ label: 'Week Off Adjustment', amount: salary.weekOffAdjustment });
+			}
+```
+
+**Step 2: Update totalEarnings to include weekOffAdjustment**
+
+Update the `baseSalaryEarned` calculation:
+```ts
+			const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary + salary.weekOffAdjustment;
+```
+
+**Step 3: Commit**
+
+```bash
+git add src/app/api/salary/[id]/payslip/route.ts
+git commit -m "feat: show Week Off Adjustment on payslip when applicable"
+```
+
+---
+
+### Task 12: Fix all netSalary recalculation sites
+
+**Files:**
+- Modify: `src/app/api/salary/generate/route.ts` (PATCH handler, ~4 locations)
+- Modify: `src/lib/services/salary-calculator.ts:271-298` (`calculateNetSalaryFromObject`)
+
+**Step 1: Update `calculateNetSalaryFromObject`**
+
+In `src/lib/services/salary-calculator.ts`, update the function:
+
+```ts
+export function calculateNetSalaryFromObject(salary: Salary) {
+  const daysInMonth = new Date(salary.year, salary.month, 0).getDate();
+  const perDaySalary = Math.round((salary.baseSalary / daysInMonth) * 100) / 100;
+  const presentDaysSalary = salary.presentDays * perDaySalary;
+  const overtimeSalary = salary.overtimeDays * 0.5 * perDaySalary;
+  const leaveSalary = salary.leavesEarned * perDaySalary;
+
+  const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary + salary.weekOffAdjustment;
+
+  let totalAdvanceDeductions = 0;
+  if (salary.installments) {
+    totalAdvanceDeductions = salary.installments
+      .filter(i => i.status === 'APPROVED')
+      .reduce((sum, i) => sum + i.amountPaid, 0);
+  }
+
+  const totalDeductions = totalAdvanceDeductions + salary.otherDeductions;
+  return Math.round(baseSalaryEarned - totalDeductions);
+}
+```
+
+**Step 2: Audit all netSalary formulas in `salary/generate/route.ts`**
+
+Search for all `netSalary:` assignments in the PATCH handler and add `+ existingSalary.weekOffAdjustment` (or equivalent) to each. There are approximately 4 locations that need updating.
+
+**Step 3: Commit**
+
+```bash
+git add src/lib/services/salary-calculator.ts src/app/api/salary/generate/route.ts
+git commit -m "fix: include weekOffAdjustment in all netSalary recalculation sites"
+```
+
+---
+
+### Task 13: March 2026 backfill script
+
+**Files:**
+- Create: `scripts/backfill-march-week-off-credits.ts`
+
+**Step 1: Create the backfill script**
+
+Create `scripts/backfill-march-week-off-credits.ts`:
+
+```ts
+/**
+ * Backfill script: Generate WeekOffCredit ledger entries for March 2026
+ *
+ * For each active user with hasWeeklyOff = true:
+ * 1. Create WEEKLY_GRANT CREDIT entries for each Sunday in March
+ *    (only Sundays on or after user's createdAt date)
+ * 2. Create WEEK_OFF_TAKEN DEBIT entries for each isWeeklyOff attendance in March
+ *
+ * Usage: npx tsx scripts/backfill-march-week-off-credits.ts [--dry-run]
+ */
+
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  const isDryRun = process.argv.includes('--dry-run')
+
+  if (isDryRun) {
+    console.log('=== DRY RUN MODE — no data will be written ===\n')
+  }
+
+  const year = 2026
+  const month = 3 // March
+  const startDate = new Date(year, month - 1, 1) // March 1
+  const endDate = new Date(year, month, 0) // March 31
+
+  // Find all Sundays in March 2026
+  const sundays: Date[] = []
+  const current = new Date(startDate)
+  while (current <= endDate) {
+    if (current.getDay() === 0) { // Sunday
+      sundays.push(new Date(current))
+    }
+    current.setDate(current.getDate() + 1)
+  }
+  console.log(`Sundays in March ${year}: ${sundays.map(d => d.getDate()).join(', ')}`)
+  console.log(`Total: ${sundays.length} Sundays\n`)
+
+  // Get all users with weekly off
+  const users = await prisma.user.findMany({
+    where: {
+      hasWeeklyOff: true,
+      status: { in: ['ACTIVE', 'PARTIAL_INACTIVE'] },
+    },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      createdAt: true,
+      weeklyOffType: true,
+      weeklyOffDay: true,
+    },
+  })
+
+  console.log(`Found ${users.length} users with weekly off\n`)
+
+  let totalCredits = 0
+  let totalDebits = 0
+
+  for (const user of users) {
+    console.log(`--- ${user.name || user.email || user.id} (${user.weeklyOffType}) ---`)
+
+    // Check if entries already exist (idempotent)
+    const existingCredits = await prisma.weekOffCredit.count({
+      where: {
+        userId: user.id,
+        date: { gte: startDate, lte: endDate },
+      },
+    })
+
+    if (existingCredits > 0) {
+      console.log(`  SKIPPED: Already has ${existingCredits} ledger entries for March`)
+      continue
+    }
+
+    // 1. Create WEEKLY_GRANT credits for eligible Sundays
+    const userCreatedAt = new Date(user.createdAt)
+    userCreatedAt.setHours(0, 0, 0, 0)
+
+    const eligibleSundays = sundays.filter(s => s >= userCreatedAt)
+    console.log(`  Credits: ${eligibleSundays.length} Sundays (joined ${user.createdAt.toISOString().split('T')[0]})`)
+
+    if (!isDryRun) {
+      for (const sunday of eligibleSundays) {
+        await prisma.weekOffCredit.create({
+          data: {
+            userId: user.id,
+            date: sunday,
+            type: 'CREDIT',
+            reason: 'WEEKLY_GRANT',
+            amount: 1,
+            createdBy: 'system:backfill-march-2026',
+          },
+        })
+      }
+    }
+    totalCredits += eligibleSundays.length
+
+    // 2. Create WEEK_OFF_TAKEN debits for existing weekly off attendance
+    const weeklyOffAttendance = await prisma.attendance.findMany({
+      where: {
+        userId: user.id,
+        date: { gte: startDate, lte: endDate },
+        isWeeklyOff: true,
+        status: 'APPROVED',
+      },
+      select: { id: true, date: true, isHalfDay: true },
+    })
+
+    console.log(`  Debits: ${weeklyOffAttendance.length} week-off days taken`)
+
+    if (!isDryRun) {
+      for (const att of weeklyOffAttendance) {
+        const amount = att.isHalfDay ? -0.5 : -1
+        await prisma.weekOffCredit.create({
+          data: {
+            userId: user.id,
+            date: att.date,
+            type: 'DEBIT',
+            reason: 'WEEK_OFF_TAKEN',
+            amount,
+            attendanceId: att.id,
+            createdBy: 'system:backfill-march-2026',
+          },
+        })
+      }
+    }
+    totalDebits += weeklyOffAttendance.length
+
+    const balance = eligibleSundays.length - weeklyOffAttendance.length
+    console.log(`  Balance: ${balance}`)
+    console.log('')
+  }
+
+  console.log('=== SUMMARY ===')
+  console.log(`Total CREDIT entries: ${totalCredits}`)
+  console.log(`Total DEBIT entries: ${totalDebits}`)
+  console.log(`Net balance across all users: ${totalCredits - totalDebits}`)
+
+  if (isDryRun) {
+    console.log('\n=== DRY RUN — no data was written. Remove --dry-run to execute. ===')
+  }
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect())
+```
+
+**Step 2: Test with dry run**
+
+Run: `npx tsx scripts/backfill-march-week-off-credits.ts --dry-run`
+Expected: Lists all users and what would be created, without writing data
+
+**Step 3: Commit**
+
+```bash
+git add scripts/backfill-march-week-off-credits.ts
+git commit -m "feat: add March 2026 backfill script for week-off credits"
+```
+
+---
+
+### Task 14: Run full test suite and verify build
+
+**Step 1: Run all tests**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+**Step 2: Verify the app builds**
+
+Run: `npx prisma generate && npm run build`
+Expected: Build succeeds with no TypeScript errors
+
+**Step 3: Fix any build errors**
+
+Address TypeScript errors, missing imports, or type mismatches found during build.
+
+**Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: resolve build errors for week-off balance feature"
+```
+
+---
+
+### Task 15: UI — Employee week-off balance card (optional, can defer)
+
+This task adds the simple "Available / Used this month" card to the employee dashboard. Since it requires identifying the correct dashboard component and understanding the frontend patterns, **this can be done as a follow-up after the backend is validated against prod data.**
+
+**Files to identify:**
+- The employee dashboard/attendance page component
+- Create an API endpoint: `src/app/api/week-off-balance/route.ts` that returns `{ available: number, usedThisMonth: number }`
+
+---
+
+## Implementation Notes
+
+- **Timezone awareness:** All date comparisons use `setHours(0,0,0,0)` to normalize. The cron job should run in IST context (matching existing crons).
+- **Idempotency:** The Sunday cron checks for existing grants before creating. The backfill script checks for existing entries before writing.
+- **No data migration risk:** All changes add new columns with defaults or create new tables. Existing data is untouched.
+- **Encashment does NOT reset balance:** The encashment DEBIT is recorded in the ledger, which naturally reduces the running balance. But it's computed from monthly data, not from the running total.

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,8 @@
         "prisma": "^6.4.1",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.7.1",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1195,9 +1196,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -1219,6 +1220,25 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@next/env": {
@@ -1428,6 +1448,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@panva/hkdf": {
@@ -4469,6 +4499,268 @@
         "@react-pdf/stylesheet": "^6.1.0"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4480,6 +4772,13 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4537,6 +4836,17 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/bcrypt": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.2.tgz",
@@ -4567,6 +4877,17 @@
       "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
@@ -4629,6 +4950,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -4923,6 +5251,119 @@
       "os": [
         "darwin"
       ]
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -5345,6 +5786,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -5729,6 +6180,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -5941,6 +6402,13 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
       "license": "ISC"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -6537,6 +7005,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7100,6 +7575,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7152,6 +7637,16 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-csv": {
@@ -7239,6 +7734,24 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -8740,6 +9253,267 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -8919,6 +9693,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -9426,6 +10210,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9598,6 +10393,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pdf-lib": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
@@ -9666,9 +10468,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -9686,7 +10488,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -10357,6 +11159,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+      }
+    },
     "node_modules/rspack-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/rspack-resolver/-/rspack-resolver-1.2.2.tgz",
@@ -10713,6 +11549,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -10763,6 +11606,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11219,15 +12076,32 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-      "integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.3",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11236,25 +12110,10 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11262,6 +12121,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -11664,6 +12533,84 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.12",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-compatible-readable-stream": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
@@ -11676,6 +12623,114 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/webidl-conversions": {
@@ -11797,6 +12852,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "seed:attendance": "tsx scripts/seed-attendance.ts",
     "reset:passwords": "tsx scripts/reset-passwords.ts",
     "seed:attendance-duplicates": "tsx scripts/create-duplicate-attendance.ts",
-    "delete:todays-weekly-off": "tsx scripts/delete-todays-weekly-off-attendance.ts"
+    "delete:todays-weekly-off": "tsx scripts/delete-todays-weekly-off-attendance.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.8.0",
@@ -85,7 +87,8 @@
     "prisma": "^6.4.1",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.7.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.2"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,6 +148,7 @@ model User {
   hasWeeklyOff        Boolean  @default(false) @map("has_weekly_off")
   weeklyOffType      String?  @map("weekly_off_type") // "FIXED" or "FLEXIBLE"
   weeklyOffDay        Int?     @map("weekly_off_day") // Day of week (0=Sunday, 1=Monday, etc.) for fixed weekly off
+  encashWeekOffs      Boolean  @default(true) @map("encash_week_offs")
 
   // Work From Home
   hasWorkFromHome     Boolean  @default(false) @map("has_work_from_home")
@@ -213,6 +214,9 @@ model User {
   // --- Appraisal Relations ---
   appraisals    SalaryAppraisal[] @relation("UserAppraisals")
   appraisalsMade SalaryAppraisal[] @relation("AppraisalChangedBy")
+
+  // --- Week Off Credit Relations ---
+  weekOffCredits     WeekOffCredit[] @relation("UserWeekOffCredits")
 
   // --- Job Offer Relations ---
   jobOffer JobOffer?
@@ -405,6 +409,7 @@ model Attendance {
   // Relations
   user       User   @relation("UserAttendance", fields: [userId], references: [id])
   verifiedBy User?  @relation("AttendanceVerifications", fields: [verifiedById], references: [id])
+  weekOffCredits WeekOffCredit[]
   branchId   String
   branch     Branch @relation(fields: [branchId], references: [id])
 
@@ -462,6 +467,9 @@ model Salary {
   halfDays         Int                         @default(0)
   leavesEarned     Int                         @default(0)
   leaveSalary      Float                       @default(0)
+  weeklyOffDays    Int                         @default(0) @map("weekly_off_days")
+  unusedWeekOffs   Int                         @default(0) @map("unused_week_offs")
+  weekOffAdjustment Float                      @default(0) @map("week_off_adjustment")
   status           String                      @default("PENDING")
   paidAt           DateTime?
   createdAt        DateTime                    @default(now())
@@ -469,6 +477,7 @@ model Salary {
   user             User                        @relation(fields: [userId], references: [id])
   installments     AdvancePaymentInstallment[]
   referrals        Referral[]
+  weekOffCredits   WeekOffCredit[] @relation("SalaryWeekOffCredits")
 
   @@unique([userId, month, year])
   @@index([userId])
@@ -741,6 +750,34 @@ model ActivityLog {
   @@index([createdAt])
   @@index([targetId])
   @@map("activity_logs")
+}
+
+// --- Week Off Credit Ledger ---
+
+model WeekOffCredit {
+  id           String   @id @default(cuid())
+  numId        Int      @default(autoincrement()) @map("num_id")
+  userId       String   @map("user_id")
+  date         DateTime
+  type         String   // CREDIT or DEBIT
+  reason       String   // WEEKLY_GRANT, WEEK_OFF_TAKEN, ENCASHMENT, MANUAL_ADJUSTMENT, DELETION_REVERSAL
+  amount       Float    // +1, -1, -0.5, etc.
+  attendanceId String?  @map("attendance_id")
+  salaryId     String?  @map("salary_id")
+  createdBy    String?  @map("created_by")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  // Relations
+  user       User        @relation("UserWeekOffCredits", fields: [userId], references: [id], onDelete: Cascade)
+  attendance Attendance? @relation(fields: [attendanceId], references: [id], onDelete: SetNull)
+  salary     Salary?     @relation("SalaryWeekOffCredits", fields: [salaryId], references: [id], onDelete: SetNull)
+
+  @@index([userId])
+  @@index([userId, date])
+  @@index([userId, type])
+  @@index([attendanceId])
+  @@index([salaryId])
+  @@map("week_off_credits")
 }
 
 // --- Job Offer Feature ---

--- a/scripts/backfill-march-week-off-credits.ts
+++ b/scripts/backfill-march-week-off-credits.ts
@@ -1,0 +1,148 @@
+/**
+ * Backfill script: Generate WeekOffCredit ledger entries for March 2026
+ *
+ * For each active user with hasWeeklyOff = true:
+ * 1. Create WEEKLY_GRANT CREDIT entries for each Sunday in March
+ *    (only Sundays on or after user's createdAt date)
+ * 2. Create WEEK_OFF_TAKEN DEBIT entries for each isWeeklyOff attendance in March
+ *
+ * Usage: npx tsx scripts/backfill-march-week-off-credits.ts [--dry-run]
+ */
+
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  const isDryRun = process.argv.includes('--dry-run')
+
+  if (isDryRun) {
+    console.log('=== DRY RUN MODE — no data will be written ===\n')
+  }
+
+  const year = 2026
+  const month = 3 // March
+  const startDate = new Date(year, month - 1, 1)
+  const endDate = new Date(year, month, 0)
+
+  // Find all Sundays in March 2026
+  const sundays: Date[] = []
+  const current = new Date(startDate)
+  while (current <= endDate) {
+    if (current.getDay() === 0) {
+      sundays.push(new Date(current))
+    }
+    current.setDate(current.getDate() + 1)
+  }
+  console.log(`Sundays in March ${year}: ${sundays.map(d => d.getDate()).join(', ')}`)
+  console.log(`Total: ${sundays.length} Sundays\n`)
+
+  // Get all users with weekly off
+  const users = await prisma.user.findMany({
+    where: {
+      hasWeeklyOff: true,
+      status: { in: ['ACTIVE', 'PARTIAL_INACTIVE'] },
+    },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      createdAt: true,
+      weeklyOffType: true,
+      weeklyOffDay: true,
+    },
+  })
+
+  console.log(`Found ${users.length} users with weekly off\n`)
+
+  let totalCredits = 0
+  let totalDebits = 0
+
+  for (const user of users) {
+    console.log(`--- ${user.name || user.email || user.id} (${user.weeklyOffType}) ---`)
+
+    // Check if entries already exist (idempotent)
+    const existingCredits = await prisma.weekOffCredit.count({
+      where: {
+        userId: user.id,
+        date: { gte: startDate, lte: endDate },
+      },
+    })
+
+    if (existingCredits > 0) {
+      console.log(`  SKIPPED: Already has ${existingCredits} ledger entries for March`)
+      continue
+    }
+
+    // 1. Create WEEKLY_GRANT credits for eligible Sundays
+    const userCreatedAt = new Date(user.createdAt)
+    userCreatedAt.setHours(0, 0, 0, 0)
+
+    const eligibleSundays = sundays.filter(s => s >= userCreatedAt)
+    console.log(`  Credits: ${eligibleSundays.length} Sundays (joined ${user.createdAt.toISOString().split('T')[0]})`)
+
+    if (!isDryRun) {
+      for (const sunday of eligibleSundays) {
+        await prisma.weekOffCredit.create({
+          data: {
+            userId: user.id,
+            date: sunday,
+            type: 'CREDIT',
+            reason: 'WEEKLY_GRANT',
+            amount: 1,
+            createdBy: 'system:backfill-march-2026',
+          },
+        })
+      }
+    }
+    totalCredits += eligibleSundays.length
+
+    // 2. Create WEEK_OFF_TAKEN debits for existing weekly off attendance
+    const weeklyOffAttendance = await prisma.attendance.findMany({
+      where: {
+        userId: user.id,
+        date: { gte: startDate, lte: endDate },
+        isWeeklyOff: true,
+        status: 'APPROVED',
+      },
+      select: { id: true, date: true, isHalfDay: true },
+    })
+
+    console.log(`  Debits: ${weeklyOffAttendance.length} week-off days taken`)
+
+    if (!isDryRun) {
+      for (const att of weeklyOffAttendance) {
+        const amount = att.isHalfDay ? -0.5 : -1
+        await prisma.weekOffCredit.create({
+          data: {
+            userId: user.id,
+            date: att.date,
+            type: 'DEBIT',
+            reason: 'WEEK_OFF_TAKEN',
+            amount,
+            attendanceId: att.id,
+            createdBy: 'system:backfill-march-2026',
+          },
+        })
+      }
+    }
+    totalDebits += weeklyOffAttendance.length
+
+    const balance = eligibleSundays.length - weeklyOffAttendance.length
+    console.log(`  Balance: ${balance}`)
+    console.log('')
+  }
+
+  console.log('=== SUMMARY ===')
+  console.log(`Total CREDIT entries: ${totalCredits}`)
+  console.log(`Total DEBIT entries: ${totalDebits}`)
+  console.log(`Net balance across all users: ${totalCredits - totalDebits}`)
+
+  if (isDryRun) {
+    console.log('\n=== DRY RUN — no data was written. Remove --dry-run to execute. ===')
+  }
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect())

--- a/src/app/api/attendance/[id]/route.ts
+++ b/src/app/api/attendance/[id]/route.ts
@@ -515,7 +515,8 @@ export async function DELETE(
       select: {
         id: true,
         userId: true,
-        date: true
+        date: true,
+        isWeeklyOff: true
       }
     });
 
@@ -562,6 +563,19 @@ export async function DELETE(
         },
         request
       );
+    }
+
+    // If deleted attendance was a weekly off, return the credit
+    if (attendance.isWeeklyOff) {
+      await createWeekOffCredit({
+        userId: attendance.userId,
+        date: new Date(attendance.date),
+        type: 'CREDIT',
+        reason: 'DELETION_REVERSAL',
+        amount: 1,
+        attendanceId: id,
+        createdBy: sessionUserId ?? undefined,
+      })
     }
 
     if (existingSalary?.status === "PENDING") {

--- a/src/app/api/attendance/[id]/route.ts
+++ b/src/app/api/attendance/[id]/route.ts
@@ -447,12 +447,13 @@ export async function PUT(
 
     if (!wasWeeklyOff && isNowWeeklyOff) {
       // Changed to weekly off — create debit
+      const debitAmount = body.isHalfDay ? -0.5 : -1
       await createWeekOffCredit({
         userId: currentAttendance.userId,
         date: updateDate,
         type: 'DEBIT',
         reason: 'WEEK_OFF_TAKEN',
-        amount: -1,
+        amount: debitAmount,
         attendanceId: id,
         createdBy: sessionUserId ?? undefined,
       })

--- a/src/app/api/attendance/[id]/route.ts
+++ b/src/app/api/attendance/[id]/route.ts
@@ -369,7 +369,7 @@ export async function PUT(
       if (isWeeklyOff) {
         // If the attendance was already a week-off, balance already includes that debit
         const wasAlreadyWeeklyOff = currentAttendance.isWeeklyOff ?? false
-        const { available, balance } = await checkWeekOffAvailability(currentAttendance.userId)
+        const { balance } = await checkWeekOffAvailability(currentAttendance.userId)
         const effectiveBalance = wasAlreadyWeeklyOff ? balance + 1 : balance
 
         if (effectiveBalance <= 0) {

--- a/src/app/api/attendance/[id]/route.ts
+++ b/src/app/api/attendance/[id]/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/auth";
 import {Attendance} from "@/models/models";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { ActivityType } from "@prisma/client";
+import { checkWeekOffAvailability, createWeekOffCredit } from '@/lib/services/week-off-balance'
 
 export async function PATCH(
   req: Request,
@@ -189,7 +190,8 @@ export async function PUT(
         verifiedById: true,
         verifiedAt: true,
         verificationNote: true,
-        branchId: true
+        branchId: true,
+        isWeeklyOff: true
       }
     });
 
@@ -318,9 +320,15 @@ export async function PUT(
     if (userWithWeeklyOff?.hasWeeklyOff) {
       const updateDate = body.date ? new Date(body.date) : currentAttendance.date;
       if (userWithWeeklyOff.weeklyOffType === "FIXED") {
-        // For fixed weekly off, check if the date matches the weekly off day
         const dayOfWeek = updateDate.getDay();
-        isWeeklyOff = userWithWeeklyOff.weeklyOffDay === dayOfWeek;
+        const isOffDay = userWithWeeklyOff.weeklyOffDay === dayOfWeek;
+        // Allow HR/Management to override: if they explicitly set isWeeklyOff to false
+        // on the employee's off day, respect it (employee worked that day)
+        if (isOffDay && body.isWeeklyOff === false) {
+          isWeeklyOff = false; // HR override: employee worked on off day
+        } else {
+          isWeeklyOff = isOffDay;
+        }
       } else if (userWithWeeklyOff.weeklyOffType === "FLEXIBLE") {
         // For flexible weekly off, use the value from the request
         isWeeklyOff = body.isWeeklyOff || false;
@@ -357,6 +365,24 @@ export async function PUT(
         }
       }
       
+      // Check week-off balance before allowing weekly off
+      if (isWeeklyOff) {
+        // If the attendance was already a week-off, balance already includes that debit
+        const wasAlreadyWeeklyOff = currentAttendance.isWeeklyOff ?? false
+        const { available, balance } = await checkWeekOffAvailability(currentAttendance.userId)
+        const effectiveBalance = wasAlreadyWeeklyOff ? balance + 1 : balance
+
+        if (effectiveBalance <= 0) {
+          return NextResponse.json(
+            {
+              error: 'No week-off balance available. Employee must be marked as present or absent.',
+              currentBalance: balance,
+            },
+            { status: 400 }
+          )
+        }
+      }
+
       // Weekly off days are automatically marked as present and approved
       if (isWeeklyOff) {
         body.isPresent = true;
@@ -414,6 +440,34 @@ export async function PUT(
         ...verificationData
       }
     });
+
+    // Handle week-off ledger entries when isWeeklyOff status changes
+    const wasWeeklyOff = currentAttendance.isWeeklyOff ?? false
+    const isNowWeeklyOff = isWeeklyOff
+
+    if (!wasWeeklyOff && isNowWeeklyOff) {
+      // Changed to weekly off — create debit
+      await createWeekOffCredit({
+        userId: currentAttendance.userId,
+        date: updateDate,
+        type: 'DEBIT',
+        reason: 'WEEK_OFF_TAKEN',
+        amount: -1,
+        attendanceId: id,
+        createdBy: sessionUserId ?? undefined,
+      })
+    } else if (wasWeeklyOff && !isNowWeeklyOff) {
+      // Changed from weekly off to working — return credit
+      await createWeekOffCredit({
+        userId: currentAttendance.userId,
+        date: updateDate,
+        type: 'CREDIT',
+        reason: 'DELETION_REVERSAL',
+        amount: 1,
+        attendanceId: id,
+        createdBy: sessionUserId ?? undefined,
+      })
+    }
 
     // If salary exists and is in PENDING state, recalculate it
     if (existingSalary?.status === 'PENDING') {

--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { logEntityActivity } from "@/lib/services/activity-log";
-import { checkWeekOffAvailability, createWeekOffCredit } from "@/lib/services/week-off-balance";
+import { checkWeekOffAvailability } from "@/lib/services/week-off-balance";
 import { ActivityType, AttendanceStatus } from "@prisma/client";
 
 export async function POST(req: Request) {
@@ -210,44 +210,50 @@ export async function POST(req: Request) {
     }
 
     // Create attendance with the user's current branch
-    const attendance = await prisma.attendance.create({
-      data: {
-        date: attendanceDate,
-        isPresent: data.isPresent,
-        isHalfDay: data.isHalfDay,
-        overtime: isWorkFromHome ? false : (data.overtime || false),
-        isWeeklyOff: isWeeklyOff,
-        isWorkFromHome: isWorkFromHome,
-        checkIn: data.checkIn || null,
-        checkOut: data.checkOut || null,
-        shift1: data.shift1 || false,
-        shift2: data.shift2 || false,
-        shift3: data.shift3 || false,
-        notes: data.notes || null,
-        userId: data.userId,
-        branchId: user.branchId!,
-        status,
-        // If HR or MANAGEMENT is creating, set verification details
-        // Only set verifiedById if creatorId is valid and user exists
-        ...(status === AttendanceStatus.APPROVED && creatorId && creator ? {
-          verifiedById: creatorId,
-          verifiedAt: new Date()
-        } : {})
-      },
-    });
+    // Wrap in transaction to ensure attendance + ledger debit are atomic
+    const attendance = await prisma.$transaction(async (tx) => {
+      const att = await tx.attendance.create({
+        data: {
+          date: attendanceDate,
+          isPresent: data.isPresent,
+          isHalfDay: data.isHalfDay,
+          overtime: isWorkFromHome ? false : (data.overtime || false),
+          isWeeklyOff: isWeeklyOff,
+          isWorkFromHome: isWorkFromHome,
+          checkIn: data.checkIn || null,
+          checkOut: data.checkOut || null,
+          shift1: data.shift1 || false,
+          shift2: data.shift2 || false,
+          shift3: data.shift3 || false,
+          notes: data.notes || null,
+          userId: data.userId,
+          branchId: user.branchId!,
+          status,
+          ...(status === AttendanceStatus.APPROVED && creatorId && creator ? {
+            verifiedById: creatorId,
+            verifiedAt: new Date()
+          } : {})
+        },
+      });
 
-    // Create week-off debit in ledger
-    if (isWeeklyOff && attendance) {
-      await createWeekOffCredit({
-        userId: data.userId,
-        date: attendanceDate,
-        type: 'DEBIT',
-        reason: 'WEEK_OFF_TAKEN',
-        amount: -1,
-        attendanceId: attendance.id,
-        createdBy: creatorId,
-      })
-    }
+      // Create week-off debit in ledger (within same transaction)
+      if (isWeeklyOff) {
+        const debitAmount = data.isHalfDay ? -0.5 : -1
+        await tx.weekOffCredit.create({
+          data: {
+            userId: data.userId,
+            date: attendanceDate,
+            type: 'DEBIT',
+            reason: 'WEEK_OFF_TAKEN',
+            amount: debitAmount,
+            attendanceId: att.id,
+            createdBy: creatorId,
+          },
+        })
+      }
+
+      return att;
+    });
 
     // If salary exists and is in PENDING state, recalculate it
     if (existingSalary?.status === 'PENDING') {

--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { logEntityActivity } from "@/lib/services/activity-log";
+import { checkWeekOffAvailability, createWeekOffCredit } from "@/lib/services/week-off-balance";
 import { ActivityType, AttendanceStatus } from "@prisma/client";
 
 export async function POST(req: Request) {
@@ -181,6 +182,20 @@ export async function POST(req: Request) {
         }
       }
       
+      // Check week-off balance before allowing weekly off
+      if (isWeeklyOff) {
+        const { available, balance } = await checkWeekOffAvailability(data.userId)
+        if (!available) {
+          return NextResponse.json(
+            {
+              error: 'No week-off balance available. Employee must be marked as present or absent.',
+              currentBalance: balance,
+            },
+            { status: 400 }
+          )
+        }
+      }
+
       // Weekly off days are automatically marked as present and approved
       if (isWeeklyOff) {
         data.isPresent = true;
@@ -220,6 +235,19 @@ export async function POST(req: Request) {
         } : {})
       },
     });
+
+    // Create week-off debit in ledger
+    if (isWeeklyOff && attendance) {
+      await createWeekOffCredit({
+        userId: data.userId,
+        date: attendanceDate,
+        type: 'DEBIT',
+        reason: 'WEEK_OFF_TAKEN',
+        amount: -1,
+        attendanceId: attendance.id,
+        createdBy: creatorId,
+      })
+    }
 
     // If salary exists and is in PENDING state, recalculate it
     if (existingSalary?.status === 'PENDING') {

--- a/src/app/api/cron/weekly-off-credit/route.ts
+++ b/src/app/api/cron/weekly-off-credit/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { createWeekOffCredit, hasWeeklyGrantForDate } from '@/lib/services/week-off-balance'
+
+/**
+ * Cron job endpoint for crediting weekly off balance every Sunday.
+ * For all ACTIVE users with hasWeeklyOff = true, adds +1 WEEKLY_GRANT.
+ * Idempotent: skips users who already have a grant for today.
+ *
+ * Recommended schedule: Every Sunday at 1:00 AM (0 1 * * 0)
+ * Security: Protected by CRON_SECRET environment variable
+ */
+export async function GET(request: NextRequest) {
+  const startTime = Date.now()
+  const timestamp = new Date().toISOString()
+  const istTime = new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' })
+
+  // Security: Verify the request is from an authorized source
+  const authHeader = request.headers.get('authorization')
+  const cronSecret = process.env.CRON_SECRET
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: 'Unauthorized', message: 'Invalid or missing CRON_SECRET', timestamp },
+      { status: 401 }
+    )
+  }
+
+  try {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    // Get all active users with weekly off enabled, joined on or before today
+    const users = await prisma.user.findMany({
+      where: {
+        hasWeeklyOff: true,
+        status: 'ACTIVE',
+        createdAt: { lte: today },
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+    })
+
+    let credited = 0
+    let skipped = 0
+    const creditedUsers: Array<{ id: string; name: string | null }> = []
+
+    for (const user of users) {
+      // Idempotent: check if grant already exists for today
+      const alreadyGranted = await hasWeeklyGrantForDate(user.id, today)
+      if (alreadyGranted) {
+        skipped++
+        continue
+      }
+
+      await createWeekOffCredit({
+        userId: user.id,
+        date: today,
+        type: 'CREDIT',
+        reason: 'WEEKLY_GRANT',
+        amount: 1,
+        createdBy: 'system:weekly-off-credit-cron',
+      })
+
+      credited++
+      creditedUsers.push({ id: user.id, name: user.name })
+    }
+
+    const duration = Date.now() - startTime
+
+    return NextResponse.json({
+      success: true,
+      message: `Credited ${credited} users, skipped ${skipped}`,
+      credited,
+      skipped,
+      totalEligible: users.length,
+      duration: `${duration}ms`,
+      timestamp,
+      istTime,
+      creditedUsers,
+    })
+  } catch (error) {
+    const duration = Date.now() - startTime
+    console.error('Weekly off credit cron error:', error)
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to credit weekly off balance',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp,
+        istTime,
+        duration: `${duration}ms`,
+      },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  return GET(request)
+}

--- a/src/app/api/cron/weekly-off-credit/route.ts
+++ b/src/app/api/cron/weekly-off-credit/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization')
   const cronSecret = process.env.CRON_SECRET
 
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json(
       { error: 'Unauthorized', message: 'Invalid or missing CRON_SECRET', timestamp },
       { status: 401 }
@@ -35,7 +35,11 @@ export async function GET(request: NextRequest) {
       where: {
         hasWeeklyOff: true,
         status: 'ACTIVE',
-        createdAt: { lte: today },
+        // Use date of joining (doj) to determine eligibility; fall back to createdAt via OR
+        OR: [
+          { doj: { lte: today } },
+          { doj: null, createdAt: { lte: today } },
+        ],
       },
       select: {
         id: true,

--- a/src/app/api/salary/[id]/payslip/route.ts
+++ b/src/app/api/salary/[id]/payslip/route.ts
@@ -178,7 +178,7 @@ export async function GET(
 
 		// Calculate total earnings (matching stats endpoint logic exactly)
 		// Note: referral bonuses are already included in salary.otherBonuses
-		const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary;
+		const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary + (salary.weekOffAdjustment || 0);
 		const totalEarnings = baseSalaryEarned;
 		
 		// Calculate net salary (matching stats endpoint logic)
@@ -289,6 +289,11 @@ export async function GET(
 			{ label: 'Overtime Bonus', amount: overtimeSalary },
 			{ label: 'Leave Salary', amount: leaveSalary },
 		];
+
+		// Week Off Adjustment — only show when > 0
+		if (salary.weekOffAdjustment > 0) {
+			earnings.push({ label: 'Week Off Adjustment', amount: salary.weekOffAdjustment });
+		}
 
 		// Show other bonuses and referral bonus separately if referral bonus exists
 		if (totalReferralBonus > 0 && salary.otherBonuses > totalReferralBonus) {

--- a/src/app/api/salary/[id]/stats/route.ts
+++ b/src/app/api/salary/[id]/stats/route.ts
@@ -111,7 +111,7 @@ export async function GET(
     }
 
     // Base salary earned is present days salary plus overtime bonus
-    const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary;
+    const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary + (salary.weekOffAdjustment || 0);
     
     // Calculate total deductions from approved installments only
     const totalAdvanceDeductions = advanceInstallments
@@ -142,7 +142,10 @@ export async function GET(
         leavesEarned: salary.leavesEarned,
         leaveSalary: salary.leaveSalary,
         otherBonuses: salary.otherBonuses,
-        otherDeductions: salary.otherDeductions
+        otherDeductions: salary.otherDeductions,
+        weeklyOffDays: salary.weeklyOffDays,
+        unusedWeekOffs: salary.unusedWeekOffs,
+        weekOffAdjustment: salary.weekOffAdjustment,
       },
       employee: {
         id: salary.userId,

--- a/src/app/api/salary/generate/route.ts
+++ b/src/app/api/salary/generate/route.ts
@@ -96,7 +96,22 @@ export async function POST(request: Request) {
     const salaries = await Promise.all(usersToProcess.map(async (user) => {
       // Delete existing PENDING salary and its installments if exists
       if (existingSalaryMap.get(user.id) === 'PENDING') {
+        // Find existing PENDING salary IDs to clean up related records
+        const existingPendingSalaries = await prisma.salary.findMany({
+          where: { userId: user.id, month, year, status: 'PENDING' },
+          select: { id: true },
+        })
+        const pendingSalaryIds = existingPendingSalaries.map(s => s.id)
+
         await prisma.$transaction([
+          // Delete encashment ledger entries linked to old salary
+          prisma.weekOffCredit.deleteMany({
+            where: {
+              userId: user.id,
+              reason: 'ENCASHMENT',
+              salaryId: { in: pendingSalaryIds },
+            }
+          }),
           prisma.advancePaymentInstallment.deleteMany({
             where: {
               userId: user.id,
@@ -334,6 +349,7 @@ export async function PATCH(req: Request) {
             advanceDeduction: totalApprovedDeductions,
             netSalary: existingSalary.baseSalary +
                       existingSalary.overtimeBonus +
+                      existingSalary.leaveSalary +
                       existingSalary.weekOffAdjustment +
                       existingSalary.otherBonuses -
                       totalApprovedDeductions -
@@ -405,6 +421,7 @@ export async function PATCH(req: Request) {
               advanceDeduction: totalDeductions,
               netSalary: installment.salary.baseSalary +
                         installment.salary.overtimeBonus +
+                        installment.salary.leaveSalary +
                         installment.salary.weekOffAdjustment +
                         installment.salary.otherBonuses -
                         totalDeductions -
@@ -516,6 +533,7 @@ export async function PATCH(req: Request) {
             advanceDeduction: totalDeductions,
             netSalary: existingSalary.baseSalary +
                       existingSalary.overtimeBonus +
+                      existingSalary.leaveSalary +
                       existingSalary.weekOffAdjustment +
                       existingSalary.otherBonuses -
                       totalDeductions -
@@ -605,6 +623,7 @@ export async function PUT(request: Request) {
           advanceDeduction: totalDeductions,
           netSalary: installment.salary.baseSalary +
                      installment.salary.overtimeBonus +
+                     installment.salary.leaveSalary +
                      installment.salary.weekOffAdjustment +
                      installment.salary.otherBonuses -
                      totalDeductions -

--- a/src/app/api/salary/generate/route.ts
+++ b/src/app/api/salary/generate/route.ts
@@ -6,6 +6,7 @@ import { AdvancePaymentInstallment } from "@/models/models";
 import { hasAttendanceConflicts } from "@/lib/services/attendance-conflicts";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { ActivityType } from "@prisma/client";
+import { createWeekOffCredit } from '@/lib/services/week-off-balance'
 
 export async function POST(request: Request) {
   try {
@@ -158,9 +159,25 @@ export async function POST(request: Request) {
             halfDays: salaryDetails.halfDays,
             leavesEarned: salaryDetails.leavesEarned,
             leaveSalary: salaryDetails.leaveSalary,
+            weeklyOffDays: salaryDetails.weeklyOffDays,
+            unusedWeekOffs: salaryDetails.unusedWeekOffs,
+            weekOffAdjustment: salaryDetails.weekOffAdjustment,
             status: 'PENDING'
           }
         })
+
+        // Create encashment debit in ledger for users with encash enabled
+        if (salaryDetails.weekOffAdjustment > 0 && salaryDetails.unusedWeekOffs > 0) {
+          await createWeekOffCredit({
+            userId: user.id,
+            date: new Date(year, month - 1, endDate.getDate()), // last day of month
+            type: 'DEBIT',
+            reason: 'ENCASHMENT',
+            amount: -salaryDetails.unusedWeekOffs,
+            salaryId: salary.id,
+            createdBy: 'system:salary-generation',
+          })
+        }
 
         // Referral bonuses are processed explicitly via /api/salary/process-referrals.
         // This ensures that if referral bonuses are NOT processed in a given month,
@@ -315,10 +332,11 @@ export async function PATCH(req: Request) {
           data: {
             status: 'PROCESSING',
             advanceDeduction: totalApprovedDeductions,
-            netSalary: existingSalary.baseSalary + 
-                      existingSalary.overtimeBonus + 
-                      existingSalary.otherBonuses - 
-                      totalApprovedDeductions - 
+            netSalary: existingSalary.baseSalary +
+                      existingSalary.overtimeBonus +
+                      existingSalary.weekOffAdjustment +
+                      existingSalary.otherBonuses -
+                      totalApprovedDeductions -
                       existingSalary.deductions
           }
         })
@@ -385,10 +403,11 @@ export async function PATCH(req: Request) {
             where: { id: installment.salaryId },
             data: {
               advanceDeduction: totalDeductions,
-              netSalary: installment.salary.baseSalary + 
-                        installment.salary.overtimeBonus + 
-                        installment.salary.otherBonuses - 
-                        totalDeductions - 
+              netSalary: installment.salary.baseSalary +
+                        installment.salary.overtimeBonus +
+                        installment.salary.weekOffAdjustment +
+                        installment.salary.otherBonuses -
+                        totalDeductions -
                         installment.salary.deductions
             }
           })
@@ -495,10 +514,11 @@ export async function PATCH(req: Request) {
           where: { id: salaryId },
           data: {
             advanceDeduction: totalDeductions,
-            netSalary: existingSalary.baseSalary + 
-                      existingSalary.overtimeBonus + 
-                      existingSalary.otherBonuses - 
-                      totalDeductions - 
+            netSalary: existingSalary.baseSalary +
+                      existingSalary.overtimeBonus +
+                      existingSalary.weekOffAdjustment +
+                      existingSalary.otherBonuses -
+                      totalDeductions -
                       existingSalary.deductions
           }
         })
@@ -583,10 +603,11 @@ export async function PUT(request: Request) {
         where: { id: installment.salaryId },
         data: {
           advanceDeduction: totalDeductions,
-          netSalary: installment.salary.baseSalary + 
-                     installment.salary.overtimeBonus + 
-                     installment.salary.otherBonuses - 
-                     totalDeductions - 
+          netSalary: installment.salary.baseSalary +
+                     installment.salary.overtimeBonus +
+                     installment.salary.weekOffAdjustment +
+                     installment.salary.otherBonuses -
+                     totalDeductions -
                      installment.salary.deductions
         }
       })

--- a/src/lib/services/__tests__/salary-calculator.test.ts
+++ b/src/lib/services/__tests__/salary-calculator.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    attendance: { findMany: vi.fn() },
+    advancePayment: { findMany: vi.fn() },
+    weekOffCredit: { findMany: vi.fn() },
+  },
+}))
+
+vi.mock('@/lib/services/week-off-balance', () => ({
+  getMonthlyWeekOffSummary: vi.fn(),
+}))
+
+import { prisma } from '@/lib/prisma'
+import { getMonthlyWeekOffSummary } from '@/lib/services/week-off-balance'
+import { calculateSalary } from '../salary-calculator'
+
+const mockedPrisma = vi.mocked(prisma)
+const mockedGetMonthlyWeekOffSummary = vi.mocked(getMonthlyWeekOffSummary)
+
+describe('calculateSalary - week off adjustment', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedPrisma.advancePayment.findMany.mockResolvedValue([])
+    mockedGetMonthlyWeekOffSummary.mockResolvedValue({
+      creditsThisMonth: 0,
+      debitsThisMonth: 0,
+      unusedThisMonth: 0,
+    })
+  })
+
+  it('calculates weekOffAdjustment for encash user with unused week-offs', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000, hasWeeklyOff: true, encashWeekOffs: true,
+      weeklyOffType: 'FLEXIBLE', weeklyOffDay: null,
+    } as any)
+
+    const regularDays = Array.from({ length: 25 }, () => ({
+      isPresent: true, isWeeklyOff: false, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED',
+    }))
+    const weeklyOffs = Array.from({ length: 3 }, () => ({
+      isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED',
+    }))
+    mockedPrisma.attendance.findMany.mockResolvedValue([...regularDays, ...weeklyOffs] as any)
+
+    mockedGetMonthlyWeekOffSummary.mockResolvedValue({
+      creditsThisMonth: 5,
+      debitsThisMonth: 3,
+      unusedThisMonth: 2,
+    })
+
+    const result = await calculateSalary('user-1', 3, 2026)
+    // perDaySalary = 31000 / 31 = 1000, unused = 2, adjustment = 2000
+    expect(result.weekOffAdjustment).toBe(2000)
+    expect(result.unusedWeekOffs).toBe(2)
+  })
+
+  it('returns 0 weekOffAdjustment for non-encash user', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000, hasWeeklyOff: true, encashWeekOffs: false,
+      weeklyOffType: 'FLEXIBLE', weeklyOffDay: null,
+    } as any)
+
+    mockedPrisma.attendance.findMany.mockResolvedValue([
+      { isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+    ] as any)
+
+    mockedGetMonthlyWeekOffSummary.mockResolvedValue({
+      creditsThisMonth: 2,
+      debitsThisMonth: 1,
+      unusedThisMonth: 1,
+    })
+
+    const result = await calculateSalary('user-1', 3, 2026)
+    expect(result.weekOffAdjustment).toBe(0)
+    expect(result.unusedWeekOffs).toBe(1)
+  })
+
+  it('returns 0 weekOffAdjustment for user without weekly off', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000, hasWeeklyOff: false, encashWeekOffs: true,
+    } as any)
+
+    mockedPrisma.attendance.findMany.mockResolvedValue([
+      { isPresent: true, isWeeklyOff: false, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED' },
+    ] as any)
+
+    const result = await calculateSalary('user-1', 3, 2026)
+    expect(result.weekOffAdjustment).toBe(0)
+    expect(result.unusedWeekOffs).toBe(0)
+  })
+
+  it('handles 4-week month with all week-offs taken', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 30000, hasWeeklyOff: true, encashWeekOffs: true,
+      weeklyOffType: 'FLEXIBLE', weeklyOffDay: null,
+    } as any)
+
+    mockedPrisma.attendance.findMany.mockResolvedValue(
+      Array.from({ length: 4 }, () => ({
+        isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED',
+      })) as any
+    )
+
+    mockedGetMonthlyWeekOffSummary.mockResolvedValue({
+      creditsThisMonth: 4,
+      debitsThisMonth: 4,
+      unusedThisMonth: 0,
+    })
+
+    const result = await calculateSalary('user-1', 4, 2026)
+    expect(result.weekOffAdjustment).toBe(0)
+    expect(result.unusedWeekOffs).toBe(0)
+  })
+
+  it('handles half-day debit in ledger', async () => {
+    mockedPrisma.user.findUnique.mockResolvedValue({
+      salary: 31000, hasWeeklyOff: true, encashWeekOffs: true,
+      weeklyOffType: 'FIXED', weeklyOffDay: 2,
+    } as any)
+
+    mockedPrisma.attendance.findMany.mockResolvedValue(
+      Array.from({ length: 4 }, () => ({
+        isPresent: true, isWeeklyOff: true, isHalfDay: false, overtime: false, isWorkFromHome: false, status: 'APPROVED',
+      })) as any
+    )
+
+    mockedGetMonthlyWeekOffSummary.mockResolvedValue({
+      creditsThisMonth: 5,
+      debitsThisMonth: 4.5,
+      unusedThisMonth: 0.5,
+    })
+
+    const result = await calculateSalary('user-1', 3, 2026)
+    // 0.5 unused, perDaySalary = 31000/31 = 1000, adjustment = 500
+    expect(result.weekOffAdjustment).toBe(500)
+    expect(result.unusedWeekOffs).toBe(0.5)
+  })
+})

--- a/src/lib/services/__tests__/salary-calculator.test.ts
+++ b/src/lib/services/__tests__/salary-calculator.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@/lib/prisma', () => ({

--- a/src/lib/services/__tests__/week-off-balance.test.ts
+++ b/src/lib/services/__tests__/week-off-balance.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock prisma
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    weekOffCredit: {
+      aggregate: vi.fn(),
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+import { prisma } from '@/lib/prisma'
+import {
+  getWeekOffBalance,
+  getMonthlyWeekOffSummary,
+  createWeekOffCredit,
+  checkWeekOffAvailability,
+} from '../week-off-balance'
+
+const mockedPrisma = vi.mocked(prisma)
+
+describe('getWeekOffBalance', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('returns sum of all credits and debits for a user', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: 3 },
+    } as any)
+    const balance = await getWeekOffBalance('user-1')
+    expect(balance).toBe(3)
+  })
+
+  it('returns 0 when no credits exist', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({
+      _sum: { amount: null },
+    } as any)
+    const balance = await getWeekOffBalance('user-1')
+    expect(balance).toBe(0)
+  })
+})
+
+describe('getMonthlyWeekOffSummary', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('returns credits and debits for a given month', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+    ] as any)
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.creditsThisMonth).toBe(4)
+    expect(summary.debitsThisMonth).toBe(3)
+    expect(summary.unusedThisMonth).toBe(1)
+  })
+
+  it('handles 5-week month with all credits used', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      ...Array(5).fill({ type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 }),
+      ...Array(5).fill({ type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 }),
+    ] as any)
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.creditsThisMonth).toBe(5)
+    expect(summary.debitsThisMonth).toBe(5)
+    expect(summary.unusedThisMonth).toBe(0)
+  })
+
+  it('handles half-day debit', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -0.5 },
+    ] as any)
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.unusedThisMonth).toBe(0.5)
+  })
+
+  it('excludes encashment debits from monthly usage count', async () => {
+    mockedPrisma.weekOffCredit.findMany.mockResolvedValue([
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1 },
+      { type: 'DEBIT', reason: 'WEEK_OFF_TAKEN', amount: -1 },
+      { type: 'DEBIT', reason: 'ENCASHMENT', amount: -1 },
+    ] as any)
+    const summary = await getMonthlyWeekOffSummary('user-1', 3, 2026)
+    expect(summary.debitsThisMonth).toBe(1)
+    expect(summary.unusedThisMonth).toBe(1)
+  })
+})
+
+describe('checkWeekOffAvailability', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('returns available when balance > 0', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({ _sum: { amount: 2 } } as any)
+    const result = await checkWeekOffAvailability('user-1')
+    expect(result.available).toBe(true)
+    expect(result.balance).toBe(2)
+  })
+
+  it('returns unavailable when balance is 0', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({ _sum: { amount: 0 } } as any)
+    const result = await checkWeekOffAvailability('user-1')
+    expect(result.available).toBe(false)
+  })
+
+  it('checks half-day availability', async () => {
+    mockedPrisma.weekOffCredit.aggregate.mockResolvedValue({ _sum: { amount: 0.5 } } as any)
+    const result = await checkWeekOffAvailability('user-1', 0.5)
+    expect(result.available).toBe(true)
+  })
+})
+
+describe('createWeekOffCredit', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('creates a WEEKLY_GRANT credit entry', async () => {
+    const date = new Date('2026-03-01')
+    mockedPrisma.weekOffCredit.create.mockResolvedValue({
+      id: 'credit-1', userId: 'user-1', date, type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1,
+    } as any)
+    const result = await createWeekOffCredit({
+      userId: 'user-1', date, type: 'CREDIT', reason: 'WEEKLY_GRANT', amount: 1,
+    })
+    expect(result.type).toBe('CREDIT')
+    expect(result.amount).toBe(1)
+  })
+})

--- a/src/lib/services/__tests__/week-off-balance.test.ts
+++ b/src/lib/services/__tests__/week-off-balance.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock prisma

--- a/src/lib/services/salary-calculator.ts
+++ b/src/lib/services/salary-calculator.ts
@@ -1,6 +1,7 @@
 import { AdvancePayment, Salary } from "@/models/models";
 import { prisma } from '@/lib/prisma'
 import { SalaryStatus } from "@prisma/client";
+import { getMonthlyWeekOffSummary } from '@/lib/services/week-off-balance'
 
 
 export async function calculateSalary(userId: string, month: number, year: number) {
@@ -10,6 +11,9 @@ export async function calculateSalary(userId: string, month: number, year: numbe
     select: {
       salary: true,
       hasWeeklyOff: true,
+      encashWeekOffs: true,
+      weeklyOffType: true,
+      weeklyOffDay: true,
     },
   })
 
@@ -68,6 +72,19 @@ export async function calculateSalary(userId: string, month: number, year: numbe
   // Calculate attendance-based salary
   const workingDays = endDate.getDate()
   const perDaySalary = Math.round((employee.salary.valueOf() / workingDays) * 100) / 100;
+
+  // Calculate week-off adjustment from ledger
+  let unusedWeekOffs = 0
+  let weekOffAdjustment = 0
+
+  if (employee.hasWeeklyOff) {
+    const summary = await getMonthlyWeekOffSummary(userId, month, year)
+    unusedWeekOffs = summary.unusedThisMonth
+
+    if (employee.encashWeekOffs && unusedWeekOffs > 0) {
+      weekOffAdjustment = parseFloat((unusedWeekOffs * perDaySalary).toFixed(2))
+    }
+  }
   
   // Regular days get 1x per day salary
   const presentDaysAmount = parseFloat((presentDays * perDaySalary).toFixed(2));
@@ -135,7 +152,7 @@ export async function calculateSalary(userId: string, month: number, year: numbe
   const totalSalaryWithLeaves = totalSalary + leaveSalary;
   
   // Update net salary calculation to include leave salary
-  const netSalary = totalSalaryWithLeaves + otherBonuses - deductions;
+  const netSalary = totalSalaryWithLeaves + weekOffAdjustment + otherBonuses - deductions;
   const roundedSalary = Math.round(netSalary);
 
   return {
@@ -156,6 +173,8 @@ export async function calculateSalary(userId: string, month: number, year: numbe
     overtimeDays,
     halfDays,
     weeklyOffDays,
+    unusedWeekOffs,
+    weekOffAdjustment,
     roundedSalary
   }
 }
@@ -281,7 +300,7 @@ export function calculateNetSalaryFromObject(salary: Salary) {
   const leaveSalary = salary.leavesEarned * perDaySalary;
   
   // Calculate base salary earned
-  const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary;
+  const baseSalaryEarned = presentDaysSalary + overtimeSalary + salary.otherBonuses + leaveSalary + (salary.weekOffAdjustment || 0);
   
   // Calculate total deductions
   let totalAdvanceDeductions = 0;

--- a/src/lib/services/week-off-balance.ts
+++ b/src/lib/services/week-off-balance.ts
@@ -1,0 +1,123 @@
+import { prisma } from '@/lib/prisma'
+
+export type WeekOffCreditType = 'CREDIT' | 'DEBIT'
+export type WeekOffCreditReason =
+  | 'WEEKLY_GRANT'
+  | 'WEEK_OFF_TAKEN'
+  | 'ENCASHMENT'
+  | 'MANUAL_ADJUSTMENT'
+  | 'DELETION_REVERSAL'
+
+interface CreateWeekOffCreditParams {
+  userId: string
+  date: Date
+  type: WeekOffCreditType
+  reason: WeekOffCreditReason
+  amount: number
+  attendanceId?: string
+  salaryId?: string
+  createdBy?: string
+}
+
+/**
+ * Get the current week-off balance for a user.
+ * Balance = SUM(amount) of all WeekOffCredit entries.
+ */
+export async function getWeekOffBalance(userId: string): Promise<number> {
+  const result = await prisma.weekOffCredit.aggregate({
+    where: { userId },
+    _sum: { amount: true },
+  })
+  return result._sum.amount ?? 0
+}
+
+/**
+ * Get monthly week-off summary: credits granted, week-offs taken, and unused count.
+ * Excludes ENCASHMENT debits from "debits this month" since those aren't usage.
+ */
+export async function getMonthlyWeekOffSummary(
+  userId: string,
+  month: number,
+  year: number
+) {
+  const startDate = new Date(year, month - 1, 1)
+  const endDate = new Date(year, month, 0, 23, 59, 59, 999)
+
+  const entries = await prisma.weekOffCredit.findMany({
+    where: {
+      userId,
+      date: { gte: startDate, lte: endDate },
+    },
+  })
+
+  const creditsThisMonth = entries
+    .filter((e) => e.type === 'CREDIT')
+    .reduce((sum, e) => sum + e.amount, 0)
+
+  // Only count WEEK_OFF_TAKEN debits as "usage" (not ENCASHMENT)
+  const debitsThisMonth = entries
+    .filter((e) => e.type === 'DEBIT' && e.reason === 'WEEK_OFF_TAKEN')
+    .reduce((sum, e) => sum + Math.abs(e.amount), 0)
+
+  const unusedThisMonth = creditsThisMonth - debitsThisMonth
+
+  return { creditsThisMonth, debitsThisMonth, unusedThisMonth }
+}
+
+/**
+ * Check if a user has enough week-off balance to take a day off.
+ * @param requiredAmount - defaults to 1, use 0.5 for half-day
+ */
+export async function checkWeekOffAvailability(
+  userId: string,
+  requiredAmount: number = 1
+): Promise<{ available: boolean; balance: number }> {
+  const balance = await getWeekOffBalance(userId)
+  return {
+    available: balance >= requiredAmount,
+    balance,
+  }
+}
+
+/**
+ * Create a week-off credit/debit ledger entry.
+ */
+export async function createWeekOffCredit(params: CreateWeekOffCreditParams) {
+  return prisma.weekOffCredit.create({
+    data: {
+      userId: params.userId,
+      date: params.date,
+      type: params.type,
+      reason: params.reason,
+      amount: params.amount,
+      attendanceId: params.attendanceId,
+      salaryId: params.salaryId,
+      createdBy: params.createdBy,
+    },
+  })
+}
+
+/**
+ * Check if a WEEKLY_GRANT credit already exists for a user on a given date.
+ * Used for idempotent cron execution.
+ */
+export async function hasWeeklyGrantForDate(
+  userId: string,
+  date: Date
+): Promise<boolean> {
+  const startOfDay = new Date(date)
+  startOfDay.setHours(0, 0, 0, 0)
+  const endOfDay = new Date(date)
+  endOfDay.setHours(23, 59, 59, 999)
+
+  const existing = await prisma.weekOffCredit.findFirst({
+    where: {
+      userId,
+      date: { gte: startOfDay, lte: endOfDay },
+      type: 'CREDIT',
+      reason: 'WEEKLY_GRANT',
+    },
+  })
+
+  return !!existing
+}

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -74,6 +74,7 @@ export interface User {
   hasWeeklyOff?: boolean;
   weeklyOffType?: string | null;
   weeklyOffDay?: number | null;
+  encashWeekOffs: boolean;
   hasWorkFromHome?: boolean;
   joiningFormSignedAt?: Date | null;
   joiningFormSignedBy?: string | null;
@@ -298,6 +299,9 @@ export interface Salary {
   halfDays: number;
   leavesEarned: number;
   leaveSalary: number;
+  weeklyOffDays: number;
+  unusedWeekOffs: number;
+  weekOffAdjustment: number;
   status: SalaryStatus;
   paidAt?: Date | null;
   createdAt: Date;
@@ -445,4 +449,21 @@ export interface JobOffer {
   updatedAt: Date;
   user: User;
   department?: Department | null;
+}
+
+export interface WeekOffCredit {
+  id: string;
+  numId: number;
+  userId: string;
+  date: Date;
+  type: string;
+  reason: string;
+  amount: number;
+  attendanceId?: string | null;
+  salaryId?: string | null;
+  createdBy?: string | null;
+  createdAt: Date;
+  user?: User;
+  attendance?: Attendance | null;
+  salary?: Salary | null;
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- **Ledger-based week-off tracking** via new `WeekOffCredit` model — all credits/debits are immutable entries, balance is always derived via `SUM(amount)`
- **Sunday cron job** (`/api/cron/weekly-off-credit`) credits +1 per eligible user weekly, idempotent
- **Attendance enforcement** — balance checked before allowing `isWeeklyOff`, debits created on week-off attendance, credits returned on deletion
- **HR override for fixed users** — HR/Management can mark a fixed-off-day employee as "present (working)" to earn extra pay
- **Salary calculator** computes "Week Off Adjustment" for users with `encashWeekOffs: true`, creates ENCASHMENT debit in ledger
- **Payslip** conditionally shows "Week Off Adjustment" line only when amount > 0
- **Backfill script** for March 2026 with `--dry-run` support, validated against prod data
- **15 unit tests** (Vitest) covering balance service and salary calculator

### New Schema
- `WeekOffCredit` model (ledger table)
- `User.encashWeekOffs` (Boolean, default true)
- `Salary.weeklyOffDays`, `Salary.unusedWeekOffs`, `Salary.weekOffAdjustment`

### Files Changed (18 files, ~3,900 lines)
- `prisma/schema.prisma` — new model + fields
- `src/lib/services/week-off-balance.ts` — balance service (5 functions)
- `src/app/api/cron/weekly-off-credit/route.ts` — Sunday cron
- `src/app/api/attendance/route.ts` — POST balance check + debit
- `src/app/api/attendance/[id]/route.ts` — PUT HR override + DELETE credit reversal
- `src/lib/services/salary-calculator.ts` — week-off adjustment calc
- `src/app/api/salary/generate/route.ts` — save fields + encashment debit + netSalary fixes
- `src/app/api/salary/[id]/stats/route.ts` — include new fields
- `src/app/api/salary/[id]/payslip/route.ts` — conditional adjustment line
- `scripts/backfill-march-week-off-credits.ts` — March 2026 backfill

## Test plan

- [x] All 15 unit tests pass (`npx vitest run`)
- [x] Build succeeds (`npm run build`)
- [x] Backfill dry-run validated against prod data (19 users, 95 credits, 46 debits)
- [ ] HR fixes flexible weekly off attendance discrepancies in prod
- [ ] Re-run backfill dry-run against fresh prod dump to verify
- [ ] Run actual backfill on prod after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)