### PR TITLE
fix: Improve touch targets and readability for mobile users

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
 
 @layer base {
   :root {
-    --app-scale: 0.85;
+    --app-scale: 1;
     --background: 39 100% 97%;            /* soft yellowish beige */
     --foreground: 147 41% 16%;            /* dark green */
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,10 +21,10 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-11 px-4 py-2",
+        sm: "h-9 rounded-md px-3 text-xs",
+        lg: "h-12 rounded-md px-8",
+        icon: "h-11 w-11",
       },
     },
     defaultVariants: {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-11 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "text-base font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
 const Label = React.forwardRef<

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-7 w-12 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
       className
     )}
     {...props}
@@ -19,7 +19,7 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0.5"
       )}
     />
   </SwitchPrimitives.Root>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}


### PR DESCRIPTION
## Summary

Phase 1 UI/UX improvements targeting mobile usability for labour-class workers:

- **Scale factor**: Removed 85% global scale that was shrinking all text and buttons
- **Buttons**: Default height 36px → 44px (WCAG AAA touch target minimum)
- **Inputs**: Height 36px → 44px, kept text-base (16px) on all screen sizes (was shrinking to 14px on desktop)
- **Switches**: Size 20x36px → 28x48px with larger thumb — much easier to tap
- **Labels**: Font size 14px → 16px for better readability
- **Textarea**: Min height 60px → 80px, kept text-base on all screens

All changes are to shared UI primitives (`/src/components/ui/`) so they propagate across the entire app automatically.

## Before → After

| Component | Before | After | Standard |
|-----------|--------|-------|----------|
| Button height | 36px | 44px | WCAG AAA: 44px |
| Input height | 36px | 44px | WCAG AAA: 44px |
| Switch | 20x36px | 28x48px | Easier to tap |
| Label text | 14px | 16px | Minimum readable |
| Scale factor | 85% | 100% | No shrinking |

## Test plan

- [ ] Test login page on mobile — buttons and inputs should feel comfortable to tap
- [ ] Test attendance form — switches should be easy to toggle
- [ ] Test dashboard — cards and text should be clearly readable
- [ ] Test on a phone outdoors in sunlight
- [ ] Verify no layout breaks on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)