### PR TITLE
fix: Mobile-friendly dialogs — margins, scroll, overflow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -90,6 +90,7 @@
 @layer base {
   html {
     font-size: calc(var(--app-scale) * 100%);
+    overflow-x: hidden;
   }
   * {
     @apply border-border outline-ring/50;

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed inset-4 z-50 grid w-auto max-w-lg mx-auto gap-4 border bg-background p-6 shadow-lg duration-200 overflow-y-auto rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:inset-auto sm:w-full sm:max-h-[calc(100vh-4rem)]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- **Dialog component**: Uses `inset-4` on mobile for proper margins from all edges, centered via translate on desktop (`sm:` breakpoint)
- **Dialog scroll**: `overflow-y-auto` allows tall forms (like attendance) to scroll
- **Rounded corners**: Applied on all screen sizes (was only `sm:rounded-lg`)
- **Horizontal overflow**: Added `overflow-x: hidden` on html to prevent page content (wide tables) from causing horizontal scroll that clips dialog edges

## Before → After

| Issue | Before | After |
|-------|--------|-------|
| Dialog on mobile | Edge-to-edge, switches clipped on right | Proper margins, all content visible |
| Tall forms | Overflow off-screen, Save button unreachable | Scrollable, Save button accessible |
| Corners | Square on mobile, rounded on desktop | Rounded everywhere |

## Test plan

- [x] Attendance form on Android — switches visible, scrollable, Save button reachable
- [ ] Verify other dialogs (warning form, advance payment, uniform form) look correct on mobile
- [ ] Verify desktop dialogs still centered properly
- [ ] Check that `overflow-x: hidden` doesn't break any horizontal scroll tables

## Concern

The `overflow-x: hidden` on `html` is a global fix. The root cause is wide tables causing horizontal scroll on the attendance page. If this causes issues elsewhere, we can scope it to only apply when a dialog is open instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)