### PR TITLE
fix: resolve TypeScript build errors in salary routes and notes

### DIFF
--- a/src/app/api/salary/generate-enet/route.ts
+++ b/src/app/api/salary/generate-enet/route.ts
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
         },
         installments: true
       }
-    }) as Salary[];
+    }) as unknown as Salary[];
 
     if (salaries.length === 0) {
       return NextResponse.json(

--- a/src/app/api/salary/generate-report/route.ts
+++ b/src/app/api/salary/generate-report/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: Request) {
         },
         installments: true
       }
-    }) as Salary[];
+    }) as unknown as Salary[];
 
     if (salaries.length === 0) {
       return NextResponse.json(

--- a/src/lib/data/notes.ts
+++ b/src/lib/data/notes.ts
@@ -36,7 +36,7 @@ export async function getNote(id: string): Promise<Note | null> {
     throw new NotAuthorizedError();
   }
 
-  return note as Note;
+  return note as unknown as Note;
 }
 
 export async function updateNote(id: string, title: string, content: string) {


### PR DESCRIPTION
## Problem

Build was failing with TypeScript errors in 3 files. The `AlertTriangle` lint error mentioned in the ticket was already resolved — the actual blockers were type cast mismatches.

**Root cause:** Prisma queries using `select` return partial objects (subset of user fields). These don't structurally satisfy the full `Salary` / `Note` model types, so TypeScript rejects a direct `as Salary[]` / `as Note` cast.

## Files Fixed

| File | Change |
|---|---|
| `src/app/api/salary/generate-enet/route.ts` | `as Salary[]` → `as unknown as Salary[]` |
| `src/app/api/salary/generate-report/route.ts` | `as Salary[]` → `as unknown as Salary[]` |
| `src/lib/data/notes.ts` | `as Note` → `as unknown as Note` |

No runtime behaviour changes — these were compile-only errors.

## Verification

`npx next build` completes successfully with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)