### PR TITLE
fix: add Partial Active Users and All Users sheets to export

### DIFF
--- a/src/components/users/user-data-import-export.tsx
+++ b/src/components/users/user-data-import-export.tsx
@@ -84,15 +84,12 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
 
       const workbook = XLSX.utils.book_new();
 
-      // Create sheets per status + one sheet for all users
+      // Create sheets for active and non-active users
       const activeUsers = users.filter((user: User) => user.status === 'ACTIVE');
-      const inactiveUsers = users.filter((user: User) => user.status === 'INACTIVE');
-      const partialActiveUsers = users.filter((user: User) => user.status === 'PARTIAL_INACTIVE');
+      const nonActiveUsers = users.filter((user: User) => user.status !== 'ACTIVE');
 
       const activeSheet = XLSX.utils.json_to_sheet(activeUsers.map(formatUserData));
-      const inactiveSheet = XLSX.utils.json_to_sheet(inactiveUsers.map(formatUserData));
-      const partialActiveSheet = XLSX.utils.json_to_sheet(partialActiveUsers.map(formatUserData));
-      const allUsersSheet = XLSX.utils.json_to_sheet(users.map(formatUserData));
+      const nonActiveSheet = XLSX.utils.json_to_sheet(nonActiveUsers.map(formatUserData));
 
       // Set column width and format
       const columnWidths = [
@@ -120,14 +117,10 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
       ];
 
       activeSheet['!cols'] = columnWidths;
-      inactiveSheet['!cols'] = columnWidths;
-      partialActiveSheet['!cols'] = columnWidths;
-      allUsersSheet['!cols'] = columnWidths;
+      nonActiveSheet['!cols'] = columnWidths;
 
       XLSX.utils.book_append_sheet(workbook, activeSheet, 'Active Users');
-      XLSX.utils.book_append_sheet(workbook, inactiveSheet, 'Inactive Users');
-      XLSX.utils.book_append_sheet(workbook, partialActiveSheet, 'Partial Active Users');
-      XLSX.utils.book_append_sheet(workbook, allUsersSheet, 'All Users');
+      XLSX.utils.book_append_sheet(workbook, nonActiveSheet, 'Non Active Users');
       XLSX.writeFile(workbook, `users-data-${new Date().toLocaleDateString('en-GB')}.xlsx`);
     } catch (error) {
       console.error('Export failed:', error);

--- a/src/components/users/user-data-import-export.tsx
+++ b/src/components/users/user-data-import-export.tsx
@@ -83,13 +83,16 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
       });
 
       const workbook = XLSX.utils.book_new();
-      
-      // Create sheets for active and inactive users
+
+      // Create sheets per status + one sheet for all users
       const activeUsers = users.filter((user: User) => user.status === 'ACTIVE');
       const inactiveUsers = users.filter((user: User) => user.status === 'INACTIVE');
+      const partialActiveUsers = users.filter((user: User) => user.status === 'PARTIAL_INACTIVE');
 
       const activeSheet = XLSX.utils.json_to_sheet(activeUsers.map(formatUserData));
       const inactiveSheet = XLSX.utils.json_to_sheet(inactiveUsers.map(formatUserData));
+      const partialActiveSheet = XLSX.utils.json_to_sheet(partialActiveUsers.map(formatUserData));
+      const allUsersSheet = XLSX.utils.json_to_sheet(users.map(formatUserData));
 
       // Set column width and format
       const columnWidths = [
@@ -118,9 +121,13 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
 
       activeSheet['!cols'] = columnWidths;
       inactiveSheet['!cols'] = columnWidths;
+      partialActiveSheet['!cols'] = columnWidths;
+      allUsersSheet['!cols'] = columnWidths;
 
       XLSX.utils.book_append_sheet(workbook, activeSheet, 'Active Users');
       XLSX.utils.book_append_sheet(workbook, inactiveSheet, 'Inactive Users');
+      XLSX.utils.book_append_sheet(workbook, partialActiveSheet, 'Partial Active Users');
+      XLSX.utils.book_append_sheet(workbook, allUsersSheet, 'All Users');
       XLSX.writeFile(workbook, `users-data-${new Date().toLocaleDateString('en-GB')}.xlsx`);
     } catch (error) {
       console.error('Export failed:', error);


### PR DESCRIPTION
## Summary
- `PARTIAL_INACTIVE` users were silently dropped from the Excel download (only `ACTIVE` and `INACTIVE` were included)
- Added a dedicated **Partial Active Users** sheet for `PARTIAL_INACTIVE` status
- Added an **All Users** sheet covering every status so no user is ever missed

## Test plan
- [ ] Download the user export Excel from the Users page
- [ ] Verify the file has 4 sheets: `Active Users`, `Inactive Users`, `Partial Active Users`, `All Users`
- [ ] Confirm `PARTIAL_INACTIVE` users appear in `Partial Active Users` and `All Users`
- [ ] Confirm upload flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)