### PR TITLE
fix: add missing migration for SalaryAppraisal + activity types

### DIFF
--- a/prisma/migrations/20260430120000_add_salary_appraisals_and_activity_types/migration.sql
+++ b/prisma/migrations/20260430120000_add_salary_appraisals_and_activity_types/migration.sql
@@ -1,0 +1,38 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ActivityType" ADD VALUE 'SALARY_APPRAISAL';
+ALTER TYPE "ActivityType" ADD VALUE 'DAILY_ATTENDANCE_REPORT';
+
+-- CreateTable
+CREATE TABLE "salary_appraisals" (
+    "id" TEXT NOT NULL,
+    "num_id" SERIAL NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "previous_salary" DOUBLE PRECISION NOT NULL,
+    "new_salary" DOUBLE PRECISION NOT NULL,
+    "change_amount" DOUBLE PRECISION NOT NULL,
+    "change_percentage" DOUBLE PRECISION NOT NULL,
+    "effective_date" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "changed_by_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "salary_appraisals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "salary_appraisals_user_id_idx" ON "salary_appraisals"("user_id");
+
+-- CreateIndex
+CREATE INDEX "salary_appraisals_changed_by_id_idx" ON "salary_appraisals"("changed_by_id");
+
+-- AddForeignKey
+ALTER TABLE "salary_appraisals" ADD CONSTRAINT "salary_appraisals_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users1"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "salary_appraisals" ADD CONSTRAINT "salary_appraisals_changed_by_id_fkey" FOREIGN KEY ("changed_by_id") REFERENCES "users1"("id") ON DELETE SET NULL ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary

- Adds the missing migration for the `SalaryAppraisal` table and the `SALARY_APPRAISAL` / `DAILY_ATTENDANCE_REPORT` `ActivityType` enum values.
- These were added to `prisma/schema.prisma` in c130113 but no migration was generated, so prod DB was missing the table + enum values.
- Production result: every `PUT /api/users/[id]` that triggered the salary-appraisal create/log path (i.e. any user edit where salary changed) failed with `{"error":"Error updating user"}` — the user record actually did get updated inside the transaction, but the post-transaction `prisma.salaryAppraisal.create(...)` and `logTargetUserActivity(SALARY_APPRAISAL, ...)` calls threw and were swallowed by the generic catch.

## What's in the migration

- `CREATE TABLE "salary_appraisals"` matching the `SalaryAppraisal` model (incl. indexes on `user_id` / `changed_by_id`, FKs to `users1` with `ON DELETE CASCADE` / `SET NULL`).
- `ALTER TYPE "ActivityType" ADD VALUE 'SALARY_APPRAISAL'`
- `ALTER TYPE "ActivityType" ADD VALUE 'DAILY_ATTENDANCE_REPORT'`

## Scope note

There is *also* unmigrated schema drift for the in-progress Week Off Balance feature (`week_off_credits` table, `Salary.unused_week_offs` / `week_off_adjustment` / `weekly_off_days`, `users1.encash_week_offs`). It is intentionally **not** included here so this PR stays a narrow hotfix. That work needs its own migration before shipping.

## Test plan

- [ ] Merge → on prod: `npx prisma migrate deploy`
- [ ] Verify `\d salary_appraisals` shows the table
- [ ] Verify `SELECT unnest(enum_range(NULL::"ActivityType"));` lists `SALARY_APPRAISAL` and `DAILY_ATTENDANCE_REPORT`
- [ ] Edit a user's salary in the UI; confirm the request returns 200 and a row appears in `salary_appraisals`
- [ ] Confirm activity log entry with type `SALARY_APPRAISAL` is recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)