### PR TITLE
Bulk salary uploads create appraisal entries + delete dead createOrUpdateSalary

### DIFF
--- a/src/app/api/job-offers/[id]/accept/route.ts
+++ b/src/app/api/job-offers/[id]/accept/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
+import { recordSalaryAppraisal, logSalaryAppraisalActivity } from '@/lib/services/salary-appraisal';
 
 export async function POST(
   request: NextRequest,
@@ -78,6 +79,23 @@ export async function POST(
         doj: jobOffer.joiningDate || new Date(),
       },
     });
+
+    // Track salary change as an appraisal (no-ops for net-new users with null prior salary)
+    const changedById = (session.user as { id?: string }).id ?? null;
+    const change = await recordSalaryAppraisal({
+      userId: jobOffer.userId,
+      previousSalary: jobOffer.user?.salary ?? null,
+      newSalary: jobOffer.totalSalary,
+      changedById,
+    });
+    if (change && changedById) {
+      await logSalaryAppraisalActivity({
+        change,
+        changedById,
+        source: 'job offer acceptance',
+        request,
+      });
+    }
 
     return NextResponse.json(updatedJobOffer);
   } catch (error) {

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -6,6 +6,7 @@ import { hasAccess } from "@/lib/access-control";
 import {Prisma} from "@prisma/client";
 import { logTargetUserActivity, logUserActivity } from "@/lib/services/activity-log";
 import { ActivityType } from "@prisma/client";
+import { recordSalaryAppraisal, logSalaryAppraisalActivity } from "@/lib/services/salary-appraisal";
 
 export async function GET(
   _request: Request,
@@ -417,38 +418,16 @@ export async function PUT(
     }
 
     // Create salary appraisal record if salary changed
-    const newSalary = salary ? parseFloat(salary) : null;
-    if (oldUser.salary !== null && newSalary !== null && oldUser.salary !== newSalary) {
-      const changeAmount = newSalary - oldUser.salary;
-      const changePercentage = oldUser.salary > 0
-        ? Math.round((changeAmount / oldUser.salary) * 10000) / 100
-        : 0;
-
-      await prisma.salaryAppraisal.create({
-        data: {
-          userId: id,
-          previousSalary: oldUser.salary,
-          newSalary,
-          changeAmount,
-          changePercentage,
-          changedById: logUserId,
-        },
+    if (salary) {
+      const change = await recordSalaryAppraisal({
+        userId: id,
+        previousSalary: oldUser.salary,
+        newSalary: parseFloat(salary),
+        changedById: logUserId ?? null,
       });
-
-      await logTargetUserActivity(
-        ActivityType.SALARY_APPRAISAL,
-        logUserId,
-        user.id,
-        `Salary changed from ₹${oldUser.salary.toLocaleString()} to ₹${newSalary.toLocaleString()} (${changePercentage > 0 ? "+" : ""}${changePercentage}%)`,
-        {
-          userId: user.id,
-          previousSalary: oldUser.salary,
-          newSalary,
-          changeAmount,
-          changePercentage,
-        },
-        request
-      );
+      if (change && logUserId) {
+        await logSalaryAppraisalActivity({ change, changedById: logUserId, request });
+      }
     }
 
     // Log statutory opt-in changes (HR/MANAGEMENT-only writes — affect take-home pay)

--- a/src/app/api/users/import/route.ts
+++ b/src/app/api/users/import/route.ts
@@ -2,6 +2,11 @@ import {prisma} from '@/lib/prisma'
 import {NextResponse} from 'next/server'
 import {auth} from "@/auth"
 import {hash} from 'bcryptjs'
+import {
+  recordSalaryAppraisal,
+  logSalaryAppraisalActivity,
+  type SalaryAppraisalChange,
+} from "@/lib/services/salary-appraisal"
 
 // Helper function to convert Excel date or DD/MM/YYYY string to Date object
 function parseDate(dateValue: string | number): Date {
@@ -30,6 +35,13 @@ export async function POST(request: Request) {
     }
 
     const {users} = await request.json()
+
+    const logUserId = (session.user as { id?: string }).id
+    if (!logUserId) {
+      return NextResponse.json({error: 'Unauthorized'}, {status: 401})
+    }
+
+    const salaryChanges: SalaryAppraisalChange[] = []
 
     await prisma.$transaction(async (tx) => {
       for (const userData of users) {
@@ -131,6 +143,16 @@ export async function POST(request: Request) {
             data: userCommonData
           });
 
+          // Track salary change → appraisal record + activity log (logged after commit)
+          const change = await recordSalaryAppraisal({
+            tx,
+            userId: existingUser.id,
+            previousSalary: existingUser.salary,
+            newSalary: userCommonData.salary,
+            changedById: logUserId,
+          });
+          if (change) salaryChanges.push(change);
+
           // Delete existing references
           await tx.reference.deleteMany({
             where: { userId: existingUser.id }
@@ -166,7 +188,20 @@ export async function POST(request: Request) {
       maxWait: 10000,
     });
 
-    return NextResponse.json({message: 'Users imported successfully'})
+    // Activity logs are written outside the transaction to keep the tx short
+    for (const change of salaryChanges) {
+      await logSalaryAppraisalActivity({
+        change,
+        changedById: logUserId,
+        source: "bulk import",
+        request,
+      });
+    }
+
+    return NextResponse.json({
+      message: 'Users imported successfully',
+      appraisalsCreated: salaryChanges.length,
+    })
   } catch (error) {
     console.error('Import failed:', error)
     return NextResponse.json(

--- a/src/lib/services/salary-appraisal.ts
+++ b/src/lib/services/salary-appraisal.ts
@@ -1,0 +1,69 @@
+import {Prisma, ActivityType} from "@prisma/client"
+import {prisma} from "@/lib/prisma"
+import {logTargetUserActivity} from "@/lib/services/activity-log"
+
+export interface SalaryAppraisalChange {
+  userId: string
+  previousSalary: number
+  newSalary: number
+  changeAmount: number
+  changePercentage: number
+}
+
+type DbClient = Prisma.TransactionClient | typeof prisma
+
+export async function recordSalaryAppraisal(params: {
+  userId: string
+  previousSalary: number | null
+  newSalary: number
+  changedById: string | null
+  tx?: DbClient
+}): Promise<SalaryAppraisalChange | null> {
+  const {userId, previousSalary, newSalary, changedById} = params
+  const db = params.tx ?? prisma
+
+  if (
+    previousSalary === null ||
+    Number.isNaN(newSalary) ||
+    previousSalary === newSalary
+  ) {
+    return null
+  }
+
+  const changeAmount = newSalary - previousSalary
+  const changePercentage = previousSalary > 0
+    ? Math.round((changeAmount / previousSalary) * 10000) / 100
+    : 0
+
+  await db.salaryAppraisal.create({
+    data: {
+      userId,
+      previousSalary,
+      newSalary,
+      changeAmount,
+      changePercentage,
+      changedById,
+    },
+  })
+
+  return {userId, previousSalary, newSalary, changeAmount, changePercentage}
+}
+
+export async function logSalaryAppraisalActivity(params: {
+  change: SalaryAppraisalChange
+  changedById: string
+  source?: string
+  request?: Request
+}): Promise<void> {
+  const {change, changedById, source, request} = params
+  const sourceSuffix = source ? ` via ${source}` : ""
+  const sign = change.changePercentage > 0 ? "+" : ""
+  await logTargetUserActivity(
+    ActivityType.SALARY_APPRAISAL,
+    changedById,
+    change.userId,
+    `Salary changed from ₹${change.previousSalary.toLocaleString()} to ₹${change.newSalary.toLocaleString()} (${sign}${change.changePercentage}%)${sourceSuffix}`,
+    {...change},
+    request
+  )
+}

--- a/src/lib/services/salary-calculator.ts
+++ b/src/lib/services/salary-calculator.ts
@@ -1,6 +1,5 @@
 import { AdvancePayment, Salary } from "@/models/models";
 import { prisma } from '@/lib/prisma'
-import { SalaryStatus } from "@prisma/client";
 import { computeRecurringDeductions, sumRecurringDeductions } from '@/lib/services/recurring-deductions'
 import { computeSalaryBreakdown } from '@/lib/services/salary-math'
 import type { RecurringDeductionEntry } from '@/models/models'
@@ -156,116 +155,6 @@ export async function calculateSalary(userId: string, month: number, year: numbe
     recurringDeductions,
     recurringDeductionTotal: breakdown.recurringTotal,
   }
-}
-
-// New function to create/update salary with advance deductions
-export async function createOrUpdateSalary({
-  userId,
-  month,
-  year,
-  advanceDeductions,
-  salaryId,
-  status,
-  updateAdvanceRemaining = false
-}: {
-  userId: string;
-  month: number;
-  year: number;
-  advanceDeductions: Array<{ advanceId: string; amount: number }>;
-  salaryId?: string;
-  status?: string;
-  updateAdvanceRemaining?: boolean;
-}) {
-  const salaryDetails = await calculateSalary(userId, month, year);
-  
-  // Calculate total deductions from advance payments
-  const totalAdvanceDeduction = advanceDeductions.reduce(
-    (sum, deduction) => sum + deduction.amount, 
-    0
-  );
-  
-  await prisma.$transaction(async (tx) => {
-    // Create or update salary record
-    const salary = await tx.salary.upsert({
-      where: { 
-        id: salaryId ?? 'new',
-      },
-      create: {
-        userId,
-        month,
-        year,
-        baseSalary: salaryDetails.baseSalary,
-        advanceDeduction: totalAdvanceDeduction,
-        deductions: totalAdvanceDeduction,
-        overtimeBonus: salaryDetails.overtimeAmount,
-        otherBonuses: 0,
-        otherDeductions: 0,
-        recurringDeductions: salaryDetails.recurringDeductions as unknown as object,
-        netSalary: salaryDetails.netSalary,
-        presentDays: salaryDetails.presentDays,
-        overtimeDays: salaryDetails.overtimeDays || 0,
-        halfDays: salaryDetails.halfDays || 0,
-        leavesEarned: salaryDetails.leavesEarned,
-        leaveSalary: salaryDetails.leaveSalary,
-        status: 'PENDING',
-      },
-      update: {
-        deductions: totalAdvanceDeduction,
-        advanceDeduction: totalAdvanceDeduction,
-        recurringDeductions: salaryDetails.recurringDeductions as unknown as object,
-        netSalary: salaryDetails.netSalary,
-        status: status as SalaryStatus ?? 'PENDING',
-        presentDays: salaryDetails.presentDays,
-        overtimeDays: salaryDetails.overtimeDays || 0,
-        halfDays: salaryDetails.halfDays || 0,
-        leavesEarned: salaryDetails.leavesEarned,
-        leaveSalary: salaryDetails.leaveSalary
-      }
-    });
-
-    // Delete existing advance installments if updating
-    if (salaryId) {
-      await tx.advancePaymentInstallment.deleteMany({
-        where: { salaryId }
-      });
-    }
-
-    // Create advance installments
-    for (const deduction of advanceDeductions) {
-      if (deduction.amount > 0) {
-        await tx.advancePaymentInstallment.create({
-          data: {
-            userId,
-            status: 'PENDING',
-            advanceId: deduction.advanceId,
-            amountPaid: deduction.amount,
-            paidAt: new Date(),
-            salaryId: salary.id
-          }
-        });
-
-        if (updateAdvanceRemaining) {
-          await tx.advancePayment.update({
-            where: { id: deduction.advanceId },
-            data: {
-              remainingAmount: {
-                decrement: deduction.amount
-              },
-              isSettled: {
-                set: !!(await tx.advancePayment.findUnique({
-                  where: { id: deduction.advanceId }
-                }).then(advance => 
-                  advance && advance.remainingAmount - deduction.amount <= 0
-                ))
-              }
-            }
-          });
-        }
-      }
-    }
-
-    return salary;
-  });
 }
 
 export function calculateNetSalaryFromObject(salary: Salary) {


### PR DESCRIPTION
## Summary

Two related changes that close the loop on bulk salary edits and clean up adjacent dead code.

### 1. Bulk salary uploads now create appraisal entries
The existing users export → edit → import flow updated `User.salary` but **silently skipped** appraisal-row and activity-log creation, leaving a broken audit trail whenever HR did a bulk salary change. This PR adds appraisal tracking by extracting the logic into a small util and wiring it into all three salary-write paths.

**New util** — `src/lib/services/salary-appraisal.ts`
- `recordSalaryAppraisal({ userId, previousSalary, newSalary, changedById, tx? })` — creates the `SalaryAppraisal` row. No-ops if `previousSalary` is `null`, `newSalary` is `NaN`, or salary is unchanged. Accepts an optional Prisma transaction client.
- `logSalaryAppraisalActivity({ change, changedById, source?, request? })` — writes the `SALARY_APPRAISAL` activity log entry. Optional `source` adds " via X" suffix (e.g., "via bulk import").

**Refactored / extended call sites:**
| Path | Change |
|---|---|
| `users/[id]` PATCH | 35 lines of inline appraisal logic → util. Same behavior. |
| `users/import` POST | Now creates appraisal rows + activity logs for every salary change in the upload. Returns `appraisalsCreated` count. Activity logs are flushed after the transaction commits. |
| `job-offers/[id]/accept` POST | Tracks salary changes when an offer is re-accepted at a different amount. No-ops for net-new hires (null prior salary). |

### 2. Delete unused `createOrUpdateSalary`
`src/lib/services/salary-calculator.ts` exported a 100-line `createOrUpdateSalary` function with zero call sites in the codebase. The actual salary generation path uses `prisma.salary.create` directly in `salary/generate/route.ts`, and the PROCESSING transition rewrites `netSalary` from approved installments. The dead function also carried a known suggested-vs-edited mismatch (PR #16 review item #4) that would have been a footgun if anyone wired it up. Deleted, along with its now-unused `SalaryStatus` import.

## Risk

- **Existing salaries:** untouched. `Salary.netSalary` is a stored column, not derived.
- **Bulk-import behavior change:** uploads with salary changes will now produce one `SalaryAppraisal` row + one activity log entry per changed user. Previously these were silently dropped. This is the intended fix.
- **Job-offer accept:** for net-new hires (typical case), no behavior change — the util no-ops because `previousSalary` is null. Only re-accepts at a different salary now produce an appraisal entry.
- **Dead-code removal:** zero behavior change — the function had no callers.

## Test plan

- [ ] `npm test` passes (24 tests)
- [ ] `npx tsc --noEmit` clean
- [ ] Single-user PATCH with salary change → confirm one new `SalaryAppraisal` row + one `SALARY_APPRAISAL` activity log (regression check)
- [ ] Bulk import with one user's salary changed → exactly one new appraisal row + one activity log; response includes `appraisalsCreated: 1`
- [ ] Bulk import with no salary changes → zero appraisal rows / activity logs created
- [ ] Bulk import with multiple salary changes in one file → all are recorded; transaction wraps the user updates, logs flush after commit
- [ ] Re-accept a job offer at a different salary for an existing employee → appraisal entry created
- [ ] Net-new hire accepts a job offer (`User.salary` was null) → no appraisal entry (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)