### PR TITLE
fix(salary): subtract advance from netSalary in adjustment route

### DIFF
--- a/src/app/api/salary/[id]/adjustment/route.ts
+++ b/src/app/api/salary/[id]/adjustment/route.ts
@@ -30,7 +30,9 @@ export async function POST(
       return new NextResponse('Can only update adjustments for pending salary', { status: 400 })
     }
 
-    // Calculate new net salary by replacing the old adjustments with new ones
+    // Calculate new net salary by replacing the old adjustments with new ones.
+    // advanceDeduction holds the planned advance for PENDING (and approved-only for PROCESSING);
+    // it must be subtracted here too — adjustment used to silently drop it.
     const recurringTotal = sumRecurringDeductions(
       salary.recurringDeductions as RecurringDeductionEntry[] | null
     )
@@ -39,6 +41,7 @@ export async function POST(
                         salary.overtimeBonus +
                         (bonusAmount || 0) -
                         (deductionAmount || 0) -
+                        salary.advanceDeduction -
                         recurringTotal
 
     const updatedSalary = await prisma.salary.update({


### PR DESCRIPTION
## Summary

Closes review item #5 from PR #16.

`src/app/api/salary/[id]/adjustment/route.ts` recomputed `netSalary` from base + overtime + bonus − deduction − recurring, but **silently dropped `advanceDeduction`**. Whenever HR added a manual bonus or deduction to a PENDING salary that already had an advance, the saved net came out too high.

Adds `- salary.advanceDeduction` to the formula. Matches the PROCESSING transition formula in `salary/generate/route.ts`, which already subtracts advance.

## Risk

**Existing prod salaries: zero impact.** Verified against the local prod copy:

| Status | rows | with_advance | adjusted |
|---|---:|---:|---:|
| PAID | 938 | 108 | 127 |
| PENDING | 213 | **0** | 1 |
| PROCESSING | 183 | 40 | 47 |

The route only allows adjustments on `status = 'PENDING'`. **No PENDING salary in prod currently has an advance**, so no in-flight row is affected. Past PAID/PROCESSING rows are stored values and aren't recomputed.

**Future impact:** when HR adjusts a PENDING salary that has a planned advance, `netSalary` will correctly subtract the advance. This will produce a *lower* net than today (today's net is silently wrong by the advance amount).

## Test plan

- [ ] `npm test` passes (24 tests)
- [ ] `npx tsc --noEmit` clean
- [ ] Manual: generate a PENDING salary with a pending advance for a test user, then add a ₹1,000 bonus via the adjustment endpoint. Verify saved `netSalary = base + overtime + 1000 - advanceDeduction - recurring` (advance now correctly subtracted).
- [ ] Adjust a PENDING salary with **no** advance — netSalary unchanged from current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)