### PR TITLE
fix(salary): subtract otherDeductions in PROCESSING formula

### DIFF
--- a/src/app/api/salary/bulk-update-status/route.ts
+++ b/src/app/api/salary/bulk-update-status/route.ts
@@ -72,7 +72,7 @@ export async function PATCH(request: Request) {
               status: 'PROCESSING',
               paidAt: null,
               advanceDeduction: totalApprovedDeductions,
-              netSalary: salary.baseSalary + salary.overtimeBonus + salary.otherBonuses - totalApprovedDeductions - salary.deductions - recurringTotal
+              netSalary: salary.baseSalary + salary.overtimeBonus + salary.otherBonuses - salary.otherDeductions - totalApprovedDeductions - salary.deductions - recurringTotal
             }
           })
 

--- a/src/app/api/salary/generate/route.ts
+++ b/src/app/api/salary/generate/route.ts
@@ -325,6 +325,7 @@ export async function PATCH(req: Request) {
             netSalary: existingSalary.baseSalary +
                       existingSalary.overtimeBonus +
                       existingSalary.otherBonuses -
+                      existingSalary.otherDeductions -
                       totalApprovedDeductions -
                       existingSalary.deductions -
                       recurringTotal
@@ -400,6 +401,7 @@ export async function PATCH(req: Request) {
               netSalary: installment.salary.baseSalary +
                         installment.salary.overtimeBonus +
                         installment.salary.otherBonuses -
+                        installment.salary.otherDeductions -
                         totalDeductions -
                         installment.salary.deductions -
                         recurringTotal
@@ -515,6 +517,7 @@ export async function PATCH(req: Request) {
             netSalary: existingSalary.baseSalary +
                       existingSalary.overtimeBonus +
                       existingSalary.otherBonuses -
+                      existingSalary.otherDeductions -
                       totalDeductions -
                       existingSalary.deductions -
                       recurringTotalForAdvance
@@ -608,6 +611,7 @@ export async function PUT(request: Request) {
           netSalary: installment.salary.baseSalary +
                      installment.salary.overtimeBonus +
                      installment.salary.otherBonuses -
+                     installment.salary.otherDeductions -
                      totalDeductions -
                      installment.salary.deductions -
                      recurringTotal


### PR DESCRIPTION
## Summary

Closes the underlying source of the ₹1.45L overpayment surfaced after PR #18.

The PROCESSING transition formulas in `salary/generate/route.ts` (and `salary/bulk-update-status/route.ts`) added `otherBonuses` to `netSalary` but **silently dropped `otherDeductions`**. Any deduction HR added via the adjustment route never reached the paid amount — `netSalary` was rewritten by the PROCESSING transition without it.

This adds `- otherDeductions` to all 5 affected formulas.

## Why PR #18 wasn't enough

PR #18 fixed the *adjustment route* itself to subtract `advanceDeduction`. But every PENDING salary that gets an adjustment subsequently transitions through PROCESSING — and PROCESSING immediately overwrites `netSalary` with its own (separately broken) formula. So the adjustment-route fix was correct in isolation but the bleed continued via the downstream rewrite. This PR closes that.

## Affected sites

| File | Line | Path |
|---|---:|---|
| `salary/generate/route.ts` | 327 | PROCESSING transition |
| `salary/generate/route.ts` | 403 | REJECT installment path |
| `salary/generate/route.ts` | 519 | advance update path |
| `salary/generate/route.ts` | 613 | PUT paid-installment path |
| `salary/bulk-update-status/route.ts` | 75 | PROCESSING transition |

## Risk

- **Existing paid salaries:** zero impact. `Salary.netSalary` is a stored column, not derived. The 127 rows already overpaid stay overpaid — recovery is an HR decision (see `reports/adjustment-overpayments.csv` from prior analysis).
- **Future processing:** any PENDING salary that has `otherDeductions > 0` and transitions to PROCESSING will now have `otherDeductions` correctly subtracted from net pay. Verified against prod data — for example salary `cmhsqa1wa00k4ljmkcmx9g4gw` would compute to ₹11,812.55 instead of the previously-stored ₹18,000.

## Test plan

- [ ] `npm test` (24 tests) passes
- [ ] `npx tsc --noEmit` clean
- [ ] Generate a PENDING salary for a test user, add a ₹1,000 deduction via adjustment route, transition to PROCESSING → confirm stored `netSalary` is base + overtime − ₹1,000 − advance − recurring (correctly subtracts the ₹1,000)
- [ ] Same flow but with a recurring PT entry → both PT and the manual deduction subtract
- [ ] Bulk-update-status PROCESSING transition on a salary with `otherDeductions > 0` → same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)