### PR TITLE
fix(salary): preserve HR adjustments on attendance / user recompute paths

### DIFF
--- a/src/app/api/attendance/[id]/route.ts
+++ b/src/app/api/attendance/[id]/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/auth";
 import {Attendance} from "@/models/models";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { ActivityType } from "@prisma/client";
+import { computeNetFromStoredSalary, daysInMonth } from "@/lib/services/salary-math";
 
 export async function PATCH(
   req: Request,
@@ -432,7 +433,17 @@ export async function PUT(
           halfDays: salaryDetails.halfDays,
           leavesEarned: salaryDetails.leavesEarned,
           leaveSalary: salaryDetails.leaveSalary,
-          netSalary: salaryDetails.netSalary
+          netSalary: computeNetFromStoredSalary({
+            baseSalary: existingSalary.baseSalary,
+            daysInMonth: daysInMonth(existingSalary.year, existingSalary.month),
+            presentDays: salaryDetails.presentDays,
+            overtimeDays: salaryDetails.overtimeDays,
+            leavesEarned: salaryDetails.leavesEarned,
+            otherBonuses: existingSalary.otherBonuses,
+            otherDeductions: existingSalary.otherDeductions,
+            advanceTotal: salaryDetails.deductions,
+            recurringTotal: salaryDetails.recurringDeductionTotal,
+          }),
         }
       });
     }
@@ -526,7 +537,17 @@ export async function DELETE(
           halfDays: salaryDetails.halfDays,
           leavesEarned: salaryDetails.leavesEarned,
           leaveSalary: salaryDetails.leaveSalary,
-          netSalary: salaryDetails.netSalary
+          netSalary: computeNetFromStoredSalary({
+            baseSalary: existingSalary.baseSalary,
+            daysInMonth: daysInMonth(existingSalary.year, existingSalary.month),
+            presentDays: salaryDetails.presentDays,
+            overtimeDays: salaryDetails.overtimeDays,
+            leavesEarned: salaryDetails.leavesEarned,
+            otherBonuses: existingSalary.otherBonuses,
+            otherDeductions: existingSalary.otherDeductions,
+            advanceTotal: salaryDetails.deductions,
+            recurringTotal: salaryDetails.recurringDeductionTotal,
+          }),
         }
       });
     }

--- a/src/app/api/attendance/bulk-approve/route.ts
+++ b/src/app/api/attendance/bulk-approve/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { ActivityType, Prisma } from "@prisma/client";
+import { computeNetFromStoredSalary, daysInMonth } from "@/lib/services/salary-math";
 
 export async function POST(req: Request) {
   try {
@@ -107,6 +108,9 @@ export async function POST(req: Request) {
             status: true,
             month: true,
             year: true,
+            baseSalary: true,
+            otherBonuses: true,
+            otherDeductions: true,
           }
         });
         return salaries;
@@ -132,7 +136,7 @@ export async function POST(req: Request) {
       
       for (const salary of salariesToUpdate) {
         const salaryDetails = await calculateSalary(salary.userId, salary.month, salary.year);
-        
+
         await prisma.salary.update({
           where: { id: salary.id },
           data: {
@@ -141,7 +145,17 @@ export async function POST(req: Request) {
             halfDays: salaryDetails.halfDays,
             leavesEarned: salaryDetails.leavesEarned,
             leaveSalary: salaryDetails.leaveSalary,
-            netSalary: salaryDetails.netSalary
+            netSalary: computeNetFromStoredSalary({
+              baseSalary: salary.baseSalary,
+              daysInMonth: daysInMonth(salary.year, salary.month),
+              presentDays: salaryDetails.presentDays,
+              overtimeDays: salaryDetails.overtimeDays,
+              leavesEarned: salaryDetails.leavesEarned,
+              otherBonuses: salary.otherBonuses,
+              otherDeductions: salary.otherDeductions,
+              advanceTotal: salaryDetails.deductions,
+              recurringTotal: salaryDetails.recurringDeductionTotal,
+            }),
           }
         });
       }

--- a/src/app/api/attendance/route.ts
+++ b/src/app/api/attendance/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { ActivityType, AttendanceStatus } from "@prisma/client";
+import { computeNetFromStoredSalary, daysInMonth } from "@/lib/services/salary-math";
 
 export async function POST(req: Request) {
   try {
@@ -234,7 +235,17 @@ export async function POST(req: Request) {
           halfDays: salaryDetails.halfDays,
           leavesEarned: salaryDetails.leavesEarned,
           leaveSalary: salaryDetails.leaveSalary,
-          netSalary: salaryDetails.netSalary
+          netSalary: computeNetFromStoredSalary({
+            baseSalary: existingSalary.baseSalary,
+            daysInMonth: daysInMonth(existingSalary.year, existingSalary.month),
+            presentDays: salaryDetails.presentDays,
+            overtimeDays: salaryDetails.overtimeDays,
+            leavesEarned: salaryDetails.leavesEarned,
+            otherBonuses: existingSalary.otherBonuses,
+            otherDeductions: existingSalary.otherDeductions,
+            advanceTotal: salaryDetails.deductions,
+            recurringTotal: salaryDetails.recurringDeductionTotal,
+          }),
         }
       });
     }
@@ -359,7 +370,17 @@ export async function PATCH(req: Request) {
           halfDays: salaryDetails.halfDays,
           leavesEarned: salaryDetails.leavesEarned,
           leaveSalary: salaryDetails.leaveSalary,
-          netSalary: salaryDetails.netSalary
+          netSalary: computeNetFromStoredSalary({
+            baseSalary: existingSalary.baseSalary,
+            daysInMonth: daysInMonth(existingSalary.year, existingSalary.month),
+            presentDays: salaryDetails.presentDays,
+            overtimeDays: salaryDetails.overtimeDays,
+            leavesEarned: salaryDetails.leavesEarned,
+            otherBonuses: existingSalary.otherBonuses,
+            otherDeductions: existingSalary.otherDeductions,
+            advanceTotal: salaryDetails.deductions,
+            recurringTotal: salaryDetails.recurringDeductionTotal,
+          }),
         }
       });
     }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -7,6 +7,7 @@ import {Prisma} from "@prisma/client";
 import { logTargetUserActivity, logUserActivity } from "@/lib/services/activity-log";
 import { ActivityType } from "@prisma/client";
 import { recordSalaryAppraisal, logSalaryAppraisalActivity } from "@/lib/services/salary-appraisal";
+import { computeNetFromStoredSalary, daysInMonth } from "@/lib/services/salary-math";
 
 export async function GET(
   _request: Request,
@@ -334,7 +335,17 @@ export async function PUT(
               halfDays: salaryDetails.halfDays,
               leavesEarned: salaryDetails.leavesEarned,
               leaveSalary: salaryDetails.leaveSalary,
-              netSalary: salaryDetails.netSalary
+              netSalary: computeNetFromStoredSalary({
+                baseSalary: salaryRecord.baseSalary,
+                daysInMonth: daysInMonth(salaryRecord.year, salaryRecord.month),
+                presentDays: salaryDetails.presentDays,
+                overtimeDays: salaryDetails.overtimeDays,
+                leavesEarned: salaryDetails.leavesEarned,
+                otherBonuses: salaryRecord.otherBonuses,
+                otherDeductions: salaryRecord.otherDeductions,
+                advanceTotal: salaryDetails.deductions,
+                recurringTotal: salaryDetails.recurringDeductionTotal,
+              }),
             }
           });
         } catch (error) {

--- a/src/lib/services/__tests__/salary-math.test.ts
+++ b/src/lib/services/__tests__/salary-math.test.ts
@@ -197,6 +197,119 @@ describe('computeNetFromStoredSalary — canonical net (must match ENET)', () =>
   })
 })
 
+/**
+ * These scenarios cover the bug fixed in the attendance / user-update
+ * recompute paths: when attendance changes (or weekly-off changes), the
+ * recompute MUST preserve any HR adjustment already applied to the salary
+ * (otherBonuses / otherDeductions). The fix passes the existing salary's
+ * adjustment fields into computeNetFromStoredSalary alongside the fresh
+ * attendance counts. These tests pin the merged behavior.
+ */
+describe('attendance / user-update recompute scenarios — merge existing adjustments', () => {
+  const baseRow = {
+    baseSalary: 30000,
+    daysInMonth: 30,
+    advanceTotal: 0,
+    recurringTotal: 0,
+  }
+
+  it('attendance edit: 25 → 28 days present, ₹500 deduction stays subtracted', () => {
+    // perDay 1000. Before edit: 25 × 1000 - 500 = 24500. After: 28 × 1000 - 500 = 27500.
+    const before = computeNetFromStoredSalary({
+      ...baseRow, presentDays: 25, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 0, otherDeductions: 500,
+    })
+    const after = computeNetFromStoredSalary({
+      ...baseRow, presentDays: 28, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 0, otherDeductions: 500,
+    })
+    expect(before).toBe(24500)
+    expect(after).toBe(27500)
+    expect(after - before).toBe(3000) // exactly 3 days × ₹1000, deduction preserved
+  })
+
+  it('attendance edit: ₹1000 bonus stays added when presentDays changes', () => {
+    const before = computeNetFromStoredSalary({
+      ...baseRow, presentDays: 20, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 1000, otherDeductions: 0,
+    })
+    const after = computeNetFromStoredSalary({
+      ...baseRow, presentDays: 25, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 1000, otherDeductions: 0,
+    })
+    expect(before).toBe(21000) // 20 × 1000 + 1000
+    expect(after).toBe(26000)  // 25 × 1000 + 1000
+  })
+
+  it('attendance edit: both bonus AND deduction preserved', () => {
+    // 28 days × 1000 + 1000 bonus - 500 deduction = 28500
+    expect(computeNetFromStoredSalary({
+      ...baseRow, presentDays: 28, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 1000, otherDeductions: 500,
+    })).toBe(28500)
+  })
+
+  it('attendance delete reduces presentDays but does not undo HR adjustments', () => {
+    // Was 30 days × 1000 + 0 - 500 = 29500.
+    // After deleting 1 attendance day → 29 × 1000 - 500 = 28500.
+    expect(computeNetFromStoredSalary({
+      ...baseRow, presentDays: 29, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 0, otherDeductions: 500,
+    })).toBe(28500)
+  })
+
+  it('weekly-off change adds earned leaves but keeps existing deduction subtracted', () => {
+    // Same presentDays (28), gains 2 earned leaves after weekly-off enabled.
+    // 28 × 1000 + 2 × 1000 - 500 = 29500
+    expect(computeNetFromStoredSalary({
+      ...baseRow, presentDays: 28, overtimeDays: 0, leavesEarned: 2,
+      otherBonuses: 0, otherDeductions: 500,
+    })).toBe(29500)
+  })
+
+  it('full-absence edge case: 0 days present, ₹500 deduction → net is negative', () => {
+    // 0 × 1000 - 500 = -500. Caller is responsible for clamping/handling.
+    expect(computeNetFromStoredSalary({
+      ...baseRow, presentDays: 0, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 0, otherDeductions: 500,
+    })).toBe(-500)
+  })
+
+  it('attendance recompute with PT recurring + adjustment: all stack', () => {
+    // 28 days × 1000 + 1000 bonus - 200 deduction - 200 PT - 3000 advance = 25600
+    expect(computeNetFromStoredSalary({
+      ...baseRow, presentDays: 28, overtimeDays: 2, leavesEarned: 1,
+      otherBonuses: 1000, otherDeductions: 200,
+      advanceTotal: 3000, recurringTotal: 200,
+    })).toBe(
+      // 28 × 1000 + 2 × 0.5 × 1000 + 1 × 1000 + 1000 - 200 - 3000 - 200
+      // = 28000 + 1000 + 1000 + 1000 - 200 - 3000 - 200 = 27600
+      27600
+    )
+  })
+
+  it('user-PATCH weekly-off-changed scenario: adjustment from prior PENDING preserved', () => {
+    // Before user toggle: was 25 days, 0 leaves, ₹500 ded → 24500.
+    // After toggle (hasWeeklyOff true → leaves now earnable): 25 days, 2 leaves, ₹500 ded.
+    // 25 × 1000 + 2 × 1000 - 500 = 26500.
+    expect(computeNetFromStoredSalary({
+      ...baseRow, presentDays: 25, overtimeDays: 0, leavesEarned: 2,
+      otherBonuses: 0, otherDeductions: 500,
+    })).toBe(26500)
+  })
+
+  it('partial-month employee (20 days) with adjustment matches what ENET pays', () => {
+    // base 30000, 30 days month, presentDays 20, otherDeductions 1500.
+    // ENET: 20 × 1000 + 0 - 1500 = 18500.
+    // Before fix, stored net would have been baseSalary (30000) on PROCESSING — wrong by 11500.
+    // After fix, stored = ENET = 18500.
+    expect(computeNetFromStoredSalary({
+      ...baseRow, presentDays: 20, overtimeDays: 0, leavesEarned: 0,
+      otherBonuses: 0, otherDeductions: 1500,
+    })).toBe(18500)
+  })
+})
+
 describe('daysInMonth', () => {
   it('returns days for non-leap February', () => {
     expect(daysInMonth(2025, 2)).toBe(28)


### PR DESCRIPTION
## Summary

Closes the remaining 6 sites in the audit from PR #20: when a PENDING salary already had an HR adjustment applied (otherBonuses or otherDeductions), and an attendance event later triggered a salary recompute, the recompute silently dropped the adjustment fields. Stored `netSalary` then diverged from what ENET would compute.

## Affected paths

| File | Trigger |
|---|---|
| `attendance/route.ts` | POST attendance create |
| `attendance/route.ts` | PUT attendance update |
| `attendance/[id]/route.ts` | PUT attendance by id |
| `attendance/[id]/route.ts` | DELETE attendance |
| `attendance/bulk-approve/route.ts` | bulk approve recompute |
| `users/[id]/route.ts` | weekly-off / WFH change recomputes all PENDING salaries |

## Fix

Each path now uses the canonical `computeNetFromStoredSalary` helper from PR #20 — merging the fresh attendance fields (`presentDays`, `overtimeDays`, `leavesEarned`) with the salary row's existing `otherBonuses` / `otherDeductions` and the suggested-advance + recurring-deduction totals from `calculateSalary`.

`bulk-approve` also expanded its `select` to include `baseSalary`, `otherBonuses`, `otherDeductions` (needed for the helper).

## Tests

9 new unit tests under `attendance / user-update recompute scenarios` covering:

- attendance edit changes presentDays, ₹500 deduction stays subtracted
- attendance edit changes presentDays, ₹1000 bonus stays added
- both bonus AND deduction preserved across edits
- attendance delete reduces presentDays but doesn't undo HR adjustments
- weekly-off change enables earned leaves but keeps deduction subtracted
- full-absence (0 days) + ₹500 deduction → −₹500 (caller decides clamping)
- full stack: 28 days + 2 OT + 1 leave + ₹1000 bonus − ₹200 ded − ₹3000 advance − ₹200 PT = ₹27,600
- user-PATCH weekly-off scenario with prior adjustment preserved
- partial-month employee (20 days, ₹1500 ded) → ₹18,500 (matches ENET)

49/49 tests pass total. Typecheck clean.

## Risk

- **Existing stored values:** untouched. Only future recomputes are affected.
- **No ENET behavior change** — ENET reads salary fields directly via `calculateNetSalaryFromObject` and was always correct.
- **Behavior change:** future attendance edits / user-PATCH on a PENDING salary that has an HR adjustment will now preserve the adjustment in the stored `netSalary`. Previously the adjustment was silently reverted in the stored column. The UI was already showing the correct (ENET-computed) value, so users will see no visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)