### PR TITLE
fix(build): drop unused PUT import in terms-html test

### DIFF
--- a/src/app/api/job-offers/__tests__/terms-html.test.ts
+++ b/src/app/api/job-offers/__tests__/terms-html.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { POST } from '@/app/api/job-offers/route'
-import { PUT } from '@/app/api/job-offers/[id]/route'
 import { auth } from '@/auth'
 import { prisma } from '@/lib/prisma'
 


### PR DESCRIPTION
## Summary
- One-line build fix. \`npm run build\` was failing on \`@typescript-eslint/no-unused-vars\` because the offer-letter PR's terms-html test imported \`PUT\` from \`/api/job-offers/[id]/route\` but only exercised \`POST\`. The PUT path is covered indirectly by the existing offer flow; the import was leftover scaffolding from the plan.

## Test plan
- [x] \`npm run build\` succeeds
- [x] \`npm run test\` — 124 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)