### PR TITLE
fix(offer-letter): hide print toolbar and trim Annexure notes

### DIFF
--- a/src/app/(print)/job-offers/[id]/offer-letter.css
+++ b/src/app/(print)/job-offers/[id]/offer-letter.css
@@ -14,6 +14,19 @@
     margin: 0;
   }
 
+  /* Floating "Download PDF" button on screen — hidden when printing so the
+     button doesn't appear in the rendered PDF nor steal vertical layout
+     space on page 1. */
+  .print-toolbar {
+    position: fixed;
+    top: 12px;
+    right: 12px;
+    z-index: 9999;
+  }
+  @media print {
+    .print-toolbar { display: none !important; }
+  }
+
   :root {
     --green:        hsl(147 41% 16%);
     --green-deep:   hsl(147 45% 12%);

--- a/src/app/(print)/job-offers/[id]/page.tsx
+++ b/src/app/(print)/job-offers/[id]/page.tsx
@@ -92,7 +92,7 @@ export default async function OfferLetterPrintPage({ params }: PageProps) {
 
   return (
     <>
-      <div style={{ position: 'fixed', top: 12, right: 12, zIndex: 9999 }}>
+      <div className="print-toolbar">
         <PrintButton />
       </div>
 
@@ -370,9 +370,7 @@ export default async function OfferLetterPrintPage({ params }: PageProps) {
         <div className="annex-note">
           <strong>Notes:</strong> &nbsp;
           (i) The above structure is indicative and may be revised annually based on Company policy and statutory norms.
-          (ii) PF deductions apply once you complete EPFO on-boarding, generally from the second month of joining.
-          (iii) Bonus is payable in accordance with the Payment of Bonus Act, 1965, subject to statutory thresholds.
-          (iv) Income Tax shall be deducted at source, if applicable.
+          (ii) Income Tax shall be deducted at source, if applicable.
         </div>
 
         <div className="page-foot">


### PR DESCRIPTION
## Summary
- The floating "Download PDF" button at the top-right of the print page was visible in the printed/saved PDF and pushed the page-1 content down by ~50px because \`position: fixed\` elements often render as static during print. Move the styling to a \`.print-toolbar\` class and hide it with \`@media print { display: none !important }\`. Fixes both the misalignment AND the visible-button.
- Trim the Annexure A footnote: keep "(i) indicative structure" and the Income Tax point; drop the PF-onboarding and Statutory-Bonus points that aren't applicable to current payroll.

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Open an offer's print view → \`Ctrl+P\` → verify Download button is gone in the preview AND the letterhead sits at the top of page 1
- [ ] Confirm Annexure A renumbers (i) → (ii) cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)