### PR TITLE
fix(offer-letter): move page footer into normal flow

### DIFF
--- a/src/app/(print)/job-offers/[id]/offer-letter.css
+++ b/src/app/(print)/job-offers/[id]/offer-letter.css
@@ -507,12 +507,15 @@
     border-top: 1px solid var(--ink-2);
   }
 
-  /* ---------- Page footer (small) ---------- */
+  /* ---------- Page footer (small) ----------
+     Lives in normal flow at the end of each .page so it never collides
+     mid-content when the .page grows beyond 297mm and the browser
+     splits it across multiple printed sheets. (Earlier `position:
+     absolute; bottom: 8mm` anchored the footer to the bottom of the
+     GROWN .page element, which the browser rendered mid-content on
+     printed page 1.) */
   .page-foot {
-    position: absolute;
-    left: 18mm;
-    right: 18mm;
-    bottom: 8mm;
+    margin-top: 24px;
     display: flex;
     justify-content: space-between;
     font-size: 8.5px;


### PR DESCRIPTION
## Summary
- The \`.page-foot\` was \`position: absolute; bottom: 8mm\` of its parent \`.page\`. When HR's termsHtml grows the \`.page\` element past 297mm, the browser splits the printed output across multiple physical sheets, but the absolutely-positioned footer stays anchored to the bottom of the *grown* \`.page\` — landing mid-content on printed page 1 (as visible in the screenshots).
- Switch to normal flow with \`margin-top: 24px\`. Footer now sits at the natural end of each \`.page\`'s content; no more mid-content overlap.

Trade-off: footer appears at content end rather than at the sheet's bottom edge when content is short. Matches typical formal-letter behaviour.

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Open offer print view → \`Ctrl+P\` → confirm footer no longer overlaps clause 03 / 04 content on page 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)