### PR TITLE
fix(offer-letter): repeating gold stripe and clause break-inside grouping

### DIFF
--- a/prisma/seed-offer-snippets.ts
+++ b/prisma/seed-offer-snippets.ts
@@ -21,37 +21,37 @@ const SEEDS: Seed[] = [
     title: 'Working Hours & Location',
     category: 'WORKING_HOURS',
     sortOrder: 10,
-    htmlBody: `<h3><span class="num-mark">03</span>Working Hours &amp; Location</h3><ul><li>Place of work: <strong>Thepla House Office, 309, Crescent Business Square, Khairani Rd, Saki Naka, Mumbai, Maharashtra 400072</strong>. The Company reserves the right to transfer you to any of its other branches in Mumbai with reasonable notice.</li><li>Working hours: <strong>09:30 to 18:30 hrs</strong>, with one 30-minute meal break and one 15-minute tea break.</li></ul>`,
+    htmlBody: `<section class="clause"><h3><span class="num-mark">03</span>Working Hours &amp; Location</h3><ul><li>Place of work: <strong>Thepla House Office, 309, Crescent Business Square, Khairani Rd, Saki Naka, Mumbai, Maharashtra 400072</strong>. The Company reserves the right to transfer you to any of its other branches in Mumbai with reasonable notice.</li><li>Working hours: <strong>09:30 to 18:30 hrs</strong>, with one 30-minute meal break and one 15-minute tea break.</li></ul></section>`,
   },
   {
     title: 'Weekly Off',
     category: 'WORKING_HOURS',
     sortOrder: 15,
-    htmlBody: `<h3><span class="num-mark">04</span>Weekly Off</h3><ul><li><strong>Sunday</strong> will be the fixed weekly off.</li><li><strong>Saturday</strong> will be a half-day work-from-home working day.</li><li>You may be required to work additional hours during festivals, special events or business exigencies; overtime shall be compensated as per Company policy.</li></ul>`,
+    htmlBody: `<section class="clause"><h3><span class="num-mark">04</span>Weekly Off</h3><ul><li><strong>Sunday</strong> will be the fixed weekly off.</li><li><strong>Saturday</strong> will be a half-day work-from-home working day.</li><li>You may be required to work additional hours during festivals, special events or business exigencies; overtime shall be compensated as per Company policy.</li></ul></section>`,
   },
   {
     title: 'Probation — 3 months',
     category: 'PROBATION',
     sortOrder: 20,
-    htmlBody: `<h3><span class="num-mark">05</span>Probation Period</h3><p>You shall be on probation for a period of <strong>three (3) months</strong> from the date of joining. During this period, your services may be terminated by either party by giving <strong>seven (7) days' written notice</strong>, without assigning any reason. On satisfactory completion of probation, your appointment shall be confirmed in writing.</p>`,
+    htmlBody: `<section class="clause"><h3><span class="num-mark">05</span>Probation Period</h3><p>You shall be on probation for a period of <strong>three (3) months</strong> from the date of joining. During this period, your services may be terminated by either party by giving <strong>seven (7) days' written notice</strong>, without assigning any reason. On satisfactory completion of probation, your appointment shall be confirmed in writing.</p></section>`,
   },
   {
     title: 'Leave Policy — Standard',
     category: 'LEAVE',
     sortOrder: 30,
-    htmlBody: `<h3><span class="num-mark">06</span>Leave Policy</h3><ul><li><strong>Earned Leave:</strong> 12 days per calendar year, accruing at 1 day per month worked. Encashment as per Company policy.</li><li><strong>Casual / Sick Leave:</strong> 7 days per calendar year. Sick leave beyond 2 consecutive days requires a medical certificate.</li><li><strong>Public Holidays:</strong> Per the Company's published list of 8 holidays for the calendar year.</li><li><strong>Overtime:</strong> Hours worked beyond the prescribed shift, on prior approval of the Branch Manager, shall be compensated at <strong>1.5× the per-hour rate</strong>.</li><li>Leave during the probation period is permitted only on prior written approval and is generally not encouraged.</li></ul>`,
+    htmlBody: `<section class="clause"><h3><span class="num-mark">06</span>Leave Policy</h3><ul><li><strong>Earned Leave:</strong> 12 days per calendar year, accruing at 1 day per month worked. Encashment as per Company policy.</li><li><strong>Casual / Sick Leave:</strong> 7 days per calendar year. Sick leave beyond 2 consecutive days requires a medical certificate.</li><li><strong>Public Holidays:</strong> Per the Company's published list of 8 holidays for the calendar year.</li><li><strong>Overtime:</strong> Hours worked beyond the prescribed shift, on prior approval of the Branch Manager, shall be compensated at <strong>1.5× the per-hour rate</strong>.</li><li>Leave during the probation period is permitted only on prior written approval and is generally not encouraged.</li></ul></section>`,
   },
   {
     title: 'Notice Period — 30 days',
     category: 'NOTICE',
     sortOrder: 40,
-    htmlBody: `<h3><span class="num-mark">07</span>Notice Period &amp; Termination</h3><p>Post confirmation, either party may terminate this employment by giving <strong>thirty (30) days' written notice</strong>, or one month's gross salary in lieu thereof. Notwithstanding the above, the Company reserves the right to terminate your services without notice in cases of misconduct, dishonesty, breach of confidentiality, unauthorised absence exceeding three consecutive working days, or conduct prejudicial to the interests of the Company.</p>`,
+    htmlBody: `<section class="clause"><h3><span class="num-mark">07</span>Notice Period &amp; Termination</h3><p>Post confirmation, either party may terminate this employment by giving <strong>thirty (30) days' written notice</strong>, or one month's gross salary in lieu thereof. Notwithstanding the above, the Company reserves the right to terminate your services without notice in cases of misconduct, dishonesty, breach of confidentiality, unauthorised absence exceeding three consecutive working days, or conduct prejudicial to the interests of the Company.</p></section>`,
   },
   {
     title: 'Documents Required at Joining',
     category: 'DOCUMENTS',
     sortOrder: 50,
-    htmlBody: `<h3><span class="num-mark">08</span>Documents Required at Joining</h3><ul><li>Self-attested copy of Aadhaar Card and PAN Card</li><li>Passport-size photographs (2 nos.)</li><li>Bank account details (cancelled cheque or passbook front page)</li><li>Proof of last drawn salary, if previously employed</li><li>Address proof (utility bill / rent agreement)</li></ul>`,
+    htmlBody: `<section class="clause"><h3><span class="num-mark">08</span>Documents Required at Joining</h3><ul><li>Self-attested copy of Aadhaar Card and PAN Card</li><li>Passport-size photographs (2 nos.)</li><li>Bank account details (cancelled cheque or passbook front page)</li><li>Proof of last drawn salary, if previously employed</li><li>Address proof (utility bill / rent agreement)</li></ul></section>`,
   },
 ]
 

--- a/src/app/(print)/job-offers/[id]/offer-letter.css
+++ b/src/app/(print)/job-offers/[id]/offer-letter.css
@@ -84,26 +84,26 @@
   .page {
     width: 210mm;
     margin: 24px auto;
-    background: var(--cream);
     padding: 18mm 18mm 16mm;
-    position: relative;
+    /* Cream sheet + thin gold left stripe encoded as a linear-gradient
+       background so it paints on EVERY physical printed sheet when
+       content paginates. (An absolute pseudo-element only renders
+       once, at the top of the logical .page rectangle.) */
+    background:
+      linear-gradient(
+        to right,
+        var(--cream) 0,
+        var(--cream) 8mm,
+        hsl(38 80% 55% / 0.55) 8mm,
+        hsl(38 80% 55% / 0.55) calc(8mm + 2px),
+        var(--cream) calc(8mm + 2px)
+      );
     box-shadow: 0 12px 40px rgba(0,0,0,0.10);
     page-break-after: always;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
   .page:last-of-type { page-break-after: auto; }
-
-  /* Subtle full-page edge: thin gold rule running down the left margin
-     — small brand cue without being a heavy band. */
-  .page::before {
-    content: "";
-    position: absolute;
-    left: 8mm; top: 18mm; bottom: 16mm;
-    width: 2px;
-    background: var(--gold);
-    opacity: 0.55;
-  }
 
   @media print {
     html, body { background: #fff; }

--- a/src/lib/services/__tests__/offer-letter.test.ts
+++ b/src/lib/services/__tests__/offer-letter.test.ts
@@ -7,17 +7,18 @@ import {
 } from '@/lib/services/offer-letter'
 
 describe('sanitizeOfferHtml', () => {
-  it('unwraps legacy <section class="clause"> / <div class="clause-head"> shells', () => {
-    // These wrappers were used by the very first version of the seeded
-    // snippets. They survive in some HR-pasted content. Keep the inner
-    // content; drop the wrappers (which use display: flex and break the
-    // print layout when they leak around the new <h3>-based snippets).
+  it('strips legacy <div class="clause-head"> shells but preserves <section class="clause">', () => {
+    // <div class="clause-head"> was display:flex in the old design and
+    // produced a broken 2-column layout when leftover wrappers leaked
+    // around the new <h3> snippets. We strip it. <section class="clause">
+    // is intentionally PRESERVED — it now wraps each h3+body group so
+    // CSS `break-inside: avoid` keeps the whole clause on one page.
     const html = '<section class="clause"><div class="clause-head">' +
       '<span class="num-mark">03</span>' +
       '<span class="title-en">Working Hours</span>' +
       '</div><p class="body">9 to 6.</p></section>'
     const out = sanitizeOfferHtml(html)
-    expect(out).not.toContain('<section')
+    expect(out).toContain('<section class="clause">')
     expect(out).not.toContain('class="clause-head"')
     expect(out).toContain('<span class="num-mark">')
     expect(out).toContain('Working Hours')

--- a/src/lib/services/offer-letter.ts
+++ b/src/lib/services/offer-letter.ts
@@ -1,7 +1,7 @@
 import DOMPurify from 'isomorphic-dompurify'
 
 const ALLOWED_TAGS = [
-  'div', 'span', 'p', 'br', 'hr',
+  'section', 'div', 'span', 'p', 'br', 'hr',
   'ul', 'ol', 'li',
   'strong', 'b', 'em', 'i', 'u',
   'h3', 'h4', 'h5',
@@ -16,22 +16,19 @@ const ALLOWED_ATTR = [
 const ALLOWED_URI_REGEXP = /^(?:https?:\/\/|mailto:|tel:|#)/i
 
 function unwrapLegacyClauseShells(html: string): string {
-  // Old snippet format wrapped each clause in <section class="clause"> with a
-  // <div class="clause-head"> for the title. New snippets use plain <h3>.
-  // When HR has pasted both formats over time, the new <h3> can end up nested
-  // inside a stale <div class="clause-head"> — and `.clause-head` is
-  // `display: flex`, producing a broken 2-column layout in the printed letter.
+  // Strip the legacy <div class="clause-head"> wrapper — the old snippet
+  // format used `display: flex` on it, which produced a broken 2-column
+  // layout when leftover wrappers leaked around the new <h3> snippets.
   //
-  // Strip the legacy wrappers via non-greedy regex. Repeat until stable so
-  // multiple stacked wrappers all unwrap. We do not touch any other <section>
-  // or <div> — only those carrying these specific class attributes.
+  // Note: <section class="clause"> is intentionally PRESERVED — it now
+  // wraps each h3+body group so CSS `break-inside: avoid` can keep the
+  // whole clause on one printed page. (Earlier we stripped this too,
+  // but that caused random heading-orphan-from-content breaks.)
   let prev: string
   let out = html
   do {
     prev = out
-    out = out
-      .replace(/<section class="clause">([\s\S]*?)<\/section>/gi, '$1')
-      .replace(/<div class="clause-head">([\s\S]*?)<\/div>/gi, '$1')
+    out = out.replace(/<div class="clause-head">([\s\S]*?)<\/div>/gi, '$1')
   } while (out !== prev)
   return out
 }


### PR DESCRIPTION
## Summary
Three real visual bugs in the printed offer letter:

1. **Gold left stripe missing on pages 2+** — \`.page::before\` was \`position: absolute\`, which only renders once at the top of the logical \`.page\` rectangle. When content auto-paginated, subsequent printed sheets had no stripe.
2. **Heading orphaned from its content** — \`<h3>\` and \`<ul>\`/\`<p>\` were siblings with no wrapping element. \`break-inside: avoid\` on the \`<ul>\` kept the list whole, but a heading could still land at the bottom of one page with its body bumped to the next.
3. **Cream background also dropped on pages 2+** — same root cause as the stripe.

## Fix
- Replace \`.page::before\` with a \`linear-gradient\` background on \`.page\` itself (cream sheet + 2px gold strip at 8mm). Backgrounds tile across physical pages during pagination, so the stripe now appears on every printed sheet.
- Wrap each seeded snippet's body in \`<section class="clause">\`. CSS already had \`.clause { break-inside: avoid }\` — wrapped clauses now stay together as a heading+body unit.
- Update the sanitiser: keep stripping legacy \`<div class="clause-head">\` (the \`display: flex\` shell from old snippets that broke the 2-column layout), but PRESERVE \`<section class="clause">\` since it's now load-bearing for break-inside.
- Add \`<section>\` back to DOMPurify ALLOWED_TAGS.
- Re-seed all 6 snippets and migrate one saved JobOffer's termsHtml to wrap its existing h3+content groups via a one-off regex script.

## Test plan
- [x] \`npm run build\` succeeds
- [x] 124 tests pass (sanitiser test updated to assert section.clause is preserved)
- [ ] Print preview an offer with many termsHtml clauses → confirm: gold stripe on every printed sheet, no clause split heading-from-body across page breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)