### PR TITLE
fix(offer-letter): per-sheet margins, no blank pages, drop page numbers

### DIFF
--- a/src/app/(print)/job-offers/[id]/offer-letter.css
+++ b/src/app/(print)/job-offers/[id]/offer-letter.css
@@ -9,9 +9,14 @@
      Print-safe; @page set to A4 with the sheet owning padding.
      ============================================================ */
 
+  /* @page margins apply to EVERY physical sheet, including the continuation
+     sheets the browser produces when a single .page div auto-paginates.
+     This is the only way to get consistent top/bottom margins on every
+     sheet — .page's own padding only applies once at the start of the
+     logical element. */
   @page {
     size: A4 portrait;
-    margin: 0;
+    margin: 14mm 14mm 14mm 14mm;
   }
 
   /* Floating "Download PDF" button on screen — hidden when printing so the
@@ -108,14 +113,23 @@
   @media print {
     html, body { background: #fff; }
     .page {
-      width: 210mm;
+      /* @page provides the per-sheet margins (incl. continuation sheets),
+         so .page itself sits flush within the printable area. Width is
+         auto so the gold-stripe gradient stretches the printable width. */
+      width: auto;
       margin: 0;
-      padding: 18mm 18mm 16mm;
+      padding: 0;
       box-shadow: none;
-      page-break-after: always;
-    }
-    .page:last-of-type {
+      /* Use break-before on subsequent .pages instead of break-after on
+         every .page. The latter forced an extra blank physical sheet
+         when a .page's content already filled (or auto-paginated to
+         fill) its sheet exactly. */
       page-break-after: auto;
+      break-after: auto;
+    }
+    .page + .page {
+      page-break-before: always;
+      break-before: page;
     }
     /* Keep clause heading stuck to its content; keep individual lists,
        paragraphs, signature block and Annexure tiles from splitting

--- a/src/app/(print)/job-offers/[id]/page.tsx
+++ b/src/app/(print)/job-offers/[id]/page.tsx
@@ -215,7 +215,6 @@ export default async function OfferLetterPrintPage({ params }: PageProps) {
 
         <div className="page-foot">
           <span>Offer Letter · {jobOffer.name} · Ref. {refNo}</span>
-          <span className="right">Page 1</span>
         </div>
       </div>
 
@@ -278,7 +277,6 @@ export default async function OfferLetterPrintPage({ params }: PageProps) {
 
         <div className="page-foot">
           <span>Offer Letter · {jobOffer.name} · Ref. {refNo}</span>
-          <span className="right">Page 2</span>
         </div>
       </div>
 
@@ -375,7 +373,6 @@ export default async function OfferLetterPrintPage({ params }: PageProps) {
 
         <div className="page-foot">
           <span>Annexure A · CTC Structure · {jobOffer.name}</span>
-          <span className="right">Page A1</span>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
Three concrete print bugs (screenshots in chat):

1. **Continuation sheets have no top margin** — \`.page\` padding only applies once at the top of the logical rectangle, not on each auto-paginated sheet. Move per-sheet margins to \`@page\` so they apply on every physical sheet.
2. **Blank sheet between sections** — \`.page { page-break-after: always }\` forced an extra physical sheet when a \`.page\` already filled its sheet exactly (or auto-paginated to). Switch to \`.page + .page { page-break-before: always }\`.
3. **Misleading page numbers** — hardcoded "PAGE 1 / PAGE 2 / PAGE A1" in the footer text was wrong once content auto-paginated. Drop them; footer now shows only candidate name + ref no.

## Test plan
- [x] \`npm run build\` succeeds
- [x] 124 tests pass
- [ ] Print preview — confirm consistent margins on continuation sheets, no blank sheets between sections, no misleading page labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)