### PR TITLE
fix(offer-letter): @page margin 0 + .page padding (full-bleed cream)

### DIFF
--- a/src/app/(print)/job-offers/[id]/offer-letter.css
+++ b/src/app/(print)/job-offers/[id]/offer-letter.css
@@ -9,14 +9,15 @@
      Print-safe; @page set to A4 with the sheet owning padding.
      ============================================================ */
 
-  /* @page margins apply to EVERY physical sheet, including the continuation
-     sheets the browser produces when a single .page div auto-paginates.
-     This is the only way to get consistent top/bottom margins on every
-     sheet — .page's own padding only applies once at the start of the
-     logical element. */
+  /* @page margin is 0 so the cream sheet (and the gold stripe at 8mm
+     from .page edge) bleed all the way to the paper edge. .page's
+     own padding handles internal margins. The trade-off: continuation
+     sheets from auto-paginated content have no top padding — break-
+     inside: avoid on clauses keeps that from being a problem in
+     practice (content breaks at clause boundaries, not mid-paragraph). */
   @page {
     size: A4 portrait;
-    margin: 14mm 14mm 14mm 14mm;
+    margin: 0;
   }
 
   /* Floating "Download PDF" button on screen — hidden when printing so the
@@ -111,14 +112,21 @@
   .page:last-of-type { page-break-after: auto; }
 
   @media print {
-    html, body { background: #fff; }
+    /* Cream the body so the @page margin area (the strip outside the
+       printable area) also picks up the brand colour — otherwise the
+       printer leaves a white border around every printed sheet. */
+    html, body {
+      background: var(--cream);
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
     .page {
-      /* @page provides the per-sheet margins (incl. continuation sheets),
-         so .page itself sits flush within the printable area. Width is
-         auto so the gold-stripe gradient stretches the printable width. */
-      width: auto;
+      /* @page margin is 0 — .page itself provides internal padding so
+         the cream sheet bleeds to the paper edge and the gold stripe
+         at 8mm sits where it should. */
+      width: 210mm;
       margin: 0;
-      padding: 0;
+      padding: 18mm 18mm 16mm;
       box-shadow: none;
       /* Use break-before on subsequent .pages instead of break-after on
          every .page. The latter forced an extra blank physical sheet


### PR DESCRIPTION
## Summary
- User feedback: switch from \`@page { margin: 14mm }\` back to \`@page { margin: 0 }\` + \`.page { padding: 18mm 18mm 16mm }\`. The 14mm @page margin produced a white border around every printed sheet AND pushed the gold left stripe inward to 22mm from the paper edge (8mm gradient stop + 14mm @page margin) instead of the intended 8mm.
- Add \`body { background: var(--cream) }\` on print so any sheet area below a short-content \`.page\` (e.g. Annexure A's notes block ending mid-sheet) picks up the brand cream instead of showing white.

## Trade-off
Continuation sheets produced by auto-paginating a single \`.page\` div have no top padding — \`.page\` padding only applies once at the logical top. The earlier \`break-inside: avoid\` rules on \`.terms .clause\` etc. keep this from showing in practice because content breaks at clause boundaries rather than mid-paragraph.

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Print preview — confirm cream extends to paper edge, gold stripe sits 8mm in, no white area below short-content sheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)