### PR TITLE
fix(offer-letter): repeat padding on continuation sheets via box-decoration-break

### DIFF
--- a/src/app/(print)/job-offers/[id]/offer-letter.css
+++ b/src/app/(print)/job-offers/[id]/offer-letter.css
@@ -108,6 +108,12 @@
     page-break-after: always;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
+    /* When .page auto-paginates across multiple physical sheets, repeat
+       the padding + gradient background on EVERY fragment instead of
+       only on the first. Without this, continuation sheets had content
+       abutting the top of the paper with no padding. */
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
   }
   .page:last-of-type { page-break-after: auto; }
 


### PR DESCRIPTION
## Summary
User feedback: "just the top padding is missing" — when \`.page\` content auto-paginates across multiple physical sheets, continuation sheets had content abutting the top of the paper because \`.page\` padding only applies once at the logical top of the element.

## Fix
Add \`box-decoration-break: clone\` on \`.page\`. This tells the browser to repeat padding + background (including the cream + gold-stripe gradient) on every fragment when the element splits across pages. Each printed sheet now has the full 18mm/18mm/16mm padding regardless of where in \`.page\`'s content the page break falls.

Chrome supports this; \`-webkit-\` prefix added for safety.

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Print preview: confirm continuation sheets have top padding (clauses don't abut the paper edge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)