### PR TITLE
fix(offer-letter): preserve gold stripe in saved PDF

### DIFF
--- a/src/app/(print)/job-offers/[id]/offer-letter.css
+++ b/src/app/(print)/job-offers/[id]/offer-letter.css
@@ -95,13 +95,17 @@
        background so it paints on EVERY physical printed sheet when
        content paginates. (An absolute pseudo-element only renders
        once, at the top of the logical .page rectangle.) */
+    /* The stripe colour is OPAQUE (no alpha) because Chrome can drop
+       alpha-channel gradients from saved PDFs even when the "Print
+       backgrounds" toggle is on. For a 2px stripe the saturated gold
+       reads almost identical to the previously-translucent version. */
     background:
       linear-gradient(
         to right,
         var(--cream) 0,
         var(--cream) 8mm,
-        hsl(38 80% 55% / 0.55) 8mm,
-        hsl(38 80% 55% / 0.55) calc(8mm + 2px),
+        var(--gold) 8mm,
+        var(--gold) calc(8mm + 2px),
         var(--cream) calc(8mm + 2px)
       );
     box-shadow: 0 12px 40px rgba(0,0,0,0.10);
@@ -118,13 +122,21 @@
   .page:last-of-type { page-break-after: auto; }
 
   @media print {
+    /* Force EVERY element to preserve its background/colour in the saved
+       PDF. Chrome drops backgrounds by default unless print-color-adjust
+       is set; even with the dialog's "Print backgrounds" toggle on, the
+       gold gradient stripe was being stripped from saved PDFs without
+       this rule. */
+    *, *::before, *::after {
+      -webkit-print-color-adjust: exact !important;
+      print-color-adjust: exact !important;
+      color-adjust: exact !important;
+    }
     /* Cream the body so the @page margin area (the strip outside the
        printable area) also picks up the brand colour — otherwise the
        printer leaves a white border around every printed sheet. */
     html, body {
       background: var(--cream);
-      -webkit-print-color-adjust: exact;
-      print-color-adjust: exact;
     }
     .page {
       /* @page margin is 0 — .page itself provides internal padding so


### PR DESCRIPTION
## Summary
User report: gold left stripe is visible in Chrome's print preview but disappears in the saved PDF.

## Fix
1. **Drop the alpha channel from the stripe gradient.** Chrome strips alpha-channel gradients from PDF export even when "Print backgrounds" is on. For a 2px-wide stripe the difference between \`hsl(38 80% 55% / 0.55)\` and opaque \`var(--gold)\` is negligible.
2. **Force \`print-color-adjust: exact\` on every element + pseudo-elements** in print mode, with \`!important\`. Without this blanket rule, descendant elements with backgrounds (comp table header, "featured" CTC tile, etc.) can also drop colour during PDF save depending on the user's settings.

## Test plan
- [x] \`npm run build\` succeeds
- [ ] Print preview → "Save as PDF" → confirm gold stripe is in the saved file

🤖 Generated with [Claude Code](https://claude.com/claude-code)