### PR TITLE
fix(salary): persist filters in URL + non-paid salary report

### DIFF
--- a/src/app/(auth)/salary/[id]/page.tsx
+++ b/src/app/(auth)/salary/[id]/page.tsx
@@ -48,14 +48,11 @@ async function getSalaryDetails(id: string) {
 
 export default async function SalaryDetailsPage({
   params,
-  searchParams
 }: {
   params: Promise<{ id: string }>
-  searchParams: Promise<{ month?: string; year?: string }>
 }) {
   const {id} = await params;
-  const {month, year} = await searchParams;
   const {salary, canEdit, activeWarningCount} = await getSalaryDetails(id);
 
-  return <SalaryDetails salary={salary} month={month} year={year} canEdit={canEdit} activeWarningCount={activeWarningCount} />
-} 
+  return <SalaryDetails salary={salary} canEdit={canEdit} activeWarningCount={activeWarningCount} />
+}

--- a/src/app/api/salary/generate-report/route.ts
+++ b/src/app/api/salary/generate-report/route.ts
@@ -22,11 +22,12 @@ export async function POST(req: Request) {
 
     // Get salaries for the given month and year. When nonPaidOnly is true, restrict to
     // PENDING and PROCESSING (the second payday on the 10th covers these).
+    // paidAt: null is belt-and-suspenders against any future drift between status and paidAt.
     const salaries = await prisma.salary.findMany({
       where: {
         month,
         year,
-        ...(nonPaidOnly ? { status: { in: ['PENDING', 'PROCESSING'] } } : {}),
+        ...(nonPaidOnly ? { status: { in: ['PENDING', 'PROCESSING'] }, paidAt: null } : {}),
       },
       include: {
         user: {

--- a/src/app/api/salary/generate-report/route.ts
+++ b/src/app/api/salary/generate-report/route.ts
@@ -14,17 +14,19 @@ export async function POST(req: Request) {
       return new NextResponse('Unauthorized', { status: 401 });
     }
 
-    const { year, month } = await req.json();
+    const { year, month, nonPaidOnly } = await req.json();
 
     if (!year || !month) {
       return NextResponse.json({ error: 'Year and month are required' }, { status: 400 });
     }
 
-    // Get all salaries for the given month and year (all statuses)
+    // Get salaries for the given month and year. When nonPaidOnly is true, restrict to
+    // PENDING and PROCESSING (the second payday on the 10th covers these).
     const salaries = await prisma.salary.findMany({
       where: {
         month,
         year,
+        ...(nonPaidOnly ? { status: { in: ['PENDING', 'PROCESSING'] } } : {}),
       },
       include: {
         user: {
@@ -43,7 +45,7 @@ export async function POST(req: Request) {
 
     if (salaries.length === 0) {
       return NextResponse.json(
-        { error: 'No salaries found for the given month' },
+        { error: nonPaidOnly ? 'No pending or processing salaries for the given month' : 'No salaries found for the given month' },
         { status: 404 }
       );
     }
@@ -225,7 +227,8 @@ export async function POST(req: Request) {
     // Create response with Excel file
     const response = new NextResponse(excelBuffer);
     response.headers.set('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    response.headers.set('Content-Disposition', `attachment; filename=salary-report-${month}-${year}.xlsx`);
+    const filenamePrefix = nonPaidOnly ? 'non-paid-salary-report' : 'salary-report';
+    response.headers.set('Content-Disposition', `attachment; filename=${filenamePrefix}-${month}-${year}.xlsx`);
 
     return response;
   } catch (error) {

--- a/src/components/salary/bulk-import-export.tsx
+++ b/src/components/salary/bulk-import-export.tsx
@@ -76,6 +76,7 @@ export function BulkImportExport({
   const [isExporting, setIsExporting] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [isDownloadingReport, setIsDownloadingReport] = useState(false)
+  const [isDownloadingNonPaidReport, setIsDownloadingNonPaidReport] = useState(false)
   const [hasSalaries, setHasSalaries] = useState(false)
   const [summary, setSummary] = useState<BulkImportSummary | null>(null)
   const [pendingFile, setPendingFile] = useState<File | null>(null)
@@ -125,36 +126,39 @@ export function BulkImportExport({
     }
   }
 
-  async function handleDownloadReport() {
+  async function handleDownloadReport(nonPaidOnly = false) {
+    const setBusy = nonPaidOnly ? setIsDownloadingNonPaidReport : setIsDownloadingReport
+    const reportLabel = nonPaidOnly ? 'non-paid salary report' : 'salary report'
+    const filenamePrefix = nonPaidOnly ? 'non-paid-salary-report' : 'salary-report'
     try {
-      setIsDownloadingReport(true)
+      setBusy(true)
       const response = await fetch('/api/salary/generate-report', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ year, month }),
+        body: JSON.stringify({ year, month, nonPaidOnly }),
       })
 
       if (!response.ok) {
         const error = await response.json()
-        throw new Error(error.error || 'Failed to generate salary report')
+        throw new Error(error.error || `Failed to generate ${reportLabel}`)
       }
 
       const blob = await response.blob()
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `salary-report-${month}-${year}.xlsx`
+      a.download = `${filenamePrefix}-${month}-${year}.xlsx`
       document.body.appendChild(a)
       a.click()
       window.URL.revokeObjectURL(url)
       a.remove()
 
-      toast.success('Salary report downloaded successfully')
+      toast.success(`${reportLabel.charAt(0).toUpperCase() + reportLabel.slice(1)} downloaded successfully`)
     } catch (error) {
-      console.error('Error downloading salary report:', error)
-      toast.error(error instanceof Error ? error.message : 'Failed to download salary report')
+      console.error(`Error downloading ${reportLabel}:`, error)
+      toast.error(error instanceof Error ? error.message : `Failed to download ${reportLabel}`)
     } finally {
-      setIsDownloadingReport(false)
+      setBusy(false)
     }
   }
 
@@ -224,11 +228,21 @@ export function BulkImportExport({
             disabled={!hasSalaries || isDownloadingReport}
             onSelect={(event) => {
               event.preventDefault()
-              void handleDownloadReport()
+              void handleDownloadReport(false)
             }}
           >
             <Download className="h-4 w-4" />
             {isDownloadingReport ? 'Downloading...' : 'Download Salary Report'}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            disabled={!hasSalaries || isDownloadingNonPaidReport}
+            onSelect={(event) => {
+              event.preventDefault()
+              void handleDownloadReport(true)
+            }}
+          >
+            <Download className="h-4 w-4" />
+            {isDownloadingNonPaidReport ? 'Downloading...' : 'Download Non-Paid Salary Report'}
           </DropdownMenuItem>
           <DropdownMenuItem
             disabled={isExporting}

--- a/src/components/salary/salary-details.tsx
+++ b/src/components/salary/salary-details.tsx
@@ -18,7 +18,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Badge } from '@/components/ui/badge'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { AlertCircle, CheckCircle, DollarSign, ArrowLeft, Download, Trash2 } from 'lucide-react'
 import { AdvancePaymentInstallment, Salary } from "@/models/models"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -39,6 +39,7 @@ interface SalaryDetailsProps {
 
 export function SalaryDetails({ salary, month, year, canEdit = false, activeWarningCount = 0 }: SalaryDetailsProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [isUpdating, setIsUpdating] = useState(false)
   const [, setAdvanceDeductions] = useState<Array<{
     advanceId: string;
@@ -157,11 +158,11 @@ export function SalaryDetails({ salary, month, year, canEdit = false, activeWarn
   }
 
   const handleBack = () => {
-    // Preserve the year and month when going back
-    const params = new URLSearchParams()
-    if (year) params.set('year', year)
-    if (month) params.set('month', month)
-    
+    // Preserve all filters (year, month, search, branch, role, status, etc.) when going back
+    const params = new URLSearchParams(searchParams.toString())
+    if (year && !params.has('year')) params.set('year', year)
+    if (month && !params.has('month')) params.set('month', month)
+
     const queryString = params.toString()
     router.push(`/salary${queryString ? `?${queryString}` : ''}`)
   }

--- a/src/components/salary/salary-details.tsx
+++ b/src/components/salary/salary-details.tsx
@@ -31,13 +31,11 @@ import Link from "next/link"
 
 interface SalaryDetailsProps {
   salary: Salary;
-  month?: string;
-  year?: string;
   canEdit?: boolean;
   activeWarningCount?: number;
 }
 
-export function SalaryDetails({ salary, month, year, canEdit = false, activeWarningCount = 0 }: SalaryDetailsProps) {
+export function SalaryDetails({ salary, canEdit = false, activeWarningCount = 0 }: SalaryDetailsProps) {
   const router = useRouter()
   const searchParams = useSearchParams()
   const [isUpdating, setIsUpdating] = useState(false)
@@ -159,11 +157,7 @@ export function SalaryDetails({ salary, month, year, canEdit = false, activeWarn
 
   const handleBack = () => {
     // Preserve all filters (year, month, search, branch, role, status, etc.) when going back
-    const params = new URLSearchParams(searchParams.toString())
-    if (year && !params.has('year')) params.set('year', year)
-    if (month && !params.has('month')) params.set('month', month)
-
-    const queryString = params.toString()
+    const queryString = searchParams.toString()
     router.push(`/salary${queryString ? `?${queryString}` : ''}`)
   }
 

--- a/src/components/salary/salary-list.tsx
+++ b/src/components/salary/salary-list.tsx
@@ -4,23 +4,8 @@ import {useCallback, useEffect, useState} from 'react'
 import {Branch, Salary, User} from "@/models/models"
 import {Button} from '@/components/ui/button'
 import {useRouter, useSearchParams} from 'next/navigation'
-
-const SEARCH_DEBOUNCE_MS = 300
-
-function readFilterParams(sp: URLSearchParams) {
-  return {
-    search: sp.get('search') || '',
-    branch: sp.get('branch') || 'all',
-    role: sp.get('role') || 'all',
-    deductions: sp.get('deductions') || 'all',
-    status: sp.get('status') || 'all',
-    userStatus: sp.get('userStatus') || 'all',
-    referralOnly: sp.get('referralOnly') === 'true',
-  }
-}
 import {Checkbox} from "@/components/ui/checkbox"
 import {toast} from "sonner"
-
 import {SearchIcon} from 'lucide-react'
 import {Input} from "@/components/ui/input"
 import {
@@ -42,6 +27,20 @@ import {CalendarDays, Clock, CalendarOff, CalendarCheck, Download} from 'lucide-
 import {Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter} from "@/components/ui/card"
 import {Badge} from "@/components/ui/badge"
 import {calculateNetSalaryFromObject} from '@/lib/services/salary-calculator'
+
+const SEARCH_DEBOUNCE_MS = 300
+
+function readFilterParams(sp: URLSearchParams) {
+  return {
+    search: sp.get('search') || '',
+    branch: sp.get('branch') || 'all',
+    role: sp.get('role') || 'all',
+    deductions: sp.get('deductions') || 'all',
+    status: sp.get('status') || 'all',
+    userStatus: sp.get('userStatus') || 'all',
+    referralOnly: sp.get('referralOnly') === 'true',
+  }
+}
 
 interface SalaryListProps {
   month: number
@@ -721,8 +720,8 @@ export function SalaryList({month, year}: SalaryListProps) {
               setStatus('all')
               setUserStatus('all')
               setReferralOnly(false)
+              // search clears via the debounce effect; clear the rest imperatively
               updateUrl({
-                search: undefined,
                 branch: undefined,
                 role: undefined,
                 deductions: undefined,

--- a/src/components/salary/salary-list.tsx
+++ b/src/components/salary/salary-list.tsx
@@ -4,6 +4,20 @@ import {useCallback, useEffect, useState} from 'react'
 import {Branch, Salary, User} from "@/models/models"
 import {Button} from '@/components/ui/button'
 import {useRouter, useSearchParams} from 'next/navigation'
+
+const SEARCH_DEBOUNCE_MS = 300
+
+function readFilterParams(sp: URLSearchParams) {
+  return {
+    search: sp.get('search') || '',
+    branch: sp.get('branch') || 'all',
+    role: sp.get('role') || 'all',
+    deductions: sp.get('deductions') || 'all',
+    status: sp.get('status') || 'all',
+    userStatus: sp.get('userStatus') || 'all',
+    referralOnly: sp.get('referralOnly') === 'true',
+  }
+}
 import {Checkbox} from "@/components/ui/checkbox"
 import {toast} from "sonner"
 
@@ -44,15 +58,58 @@ export function SalaryList({month, year}: SalaryListProps) {
   const searchParams = useSearchParams()
   const [selectedSalaries, setSelectedSalaries] = useState<string[]>([])
   const [isProcessing, setIsProcessing] = useState(false)
-  const [selectedFilters, setSelectedFilters] = useState({
-    deductions: 'all',
-    status: 'all',
-    search: '',
-    branch: 'all',
-    role: 'all',
-    referralOnly: false,
-    userStatus: 'all',
-  })
+
+  const [search, setSearch] = useState(() => readFilterParams(searchParams).search)
+  const [branch, setBranch] = useState(() => readFilterParams(searchParams).branch)
+  const [role, setRole] = useState(() => readFilterParams(searchParams).role)
+  const [deductions, setDeductions] = useState(() => readFilterParams(searchParams).deductions)
+  const [status, setStatus] = useState(() => readFilterParams(searchParams).status)
+  const [userStatus, setUserStatus] = useState(() => readFilterParams(searchParams).userStatus)
+  const [referralOnly, setReferralOnly] = useState(() => readFilterParams(searchParams).referralOnly)
+  const [initialized, setInitialized] = useState(false)
+
+  // Sync state from URL on subsequent navigations (e.g. browser back)
+  useEffect(() => {
+    if (!initialized) {
+      setInitialized(true)
+      return
+    }
+    const p = readFilterParams(searchParams)
+    setSearch(p.search)
+    setBranch(p.branch)
+    setRole(p.role)
+    setDeductions(p.deductions)
+    setStatus(p.status)
+    setUserStatus(p.userStatus)
+    setReferralOnly(p.referralOnly)
+  }, [searchParams, initialized])
+
+  const updateUrl = useCallback(
+    (updates: Record<string, string | boolean | undefined>) => {
+      const p = new URLSearchParams(searchParams.toString())
+      for (const [key, val] of Object.entries(updates)) {
+        if (val === undefined || val === '' || val === 'all' || val === false) {
+          p.delete(key)
+        } else if (val === true) {
+          p.set(key, 'true')
+        } else {
+          p.set(key, val)
+        }
+      }
+      router.replace(`/salary?${p.toString()}`, { scroll: false })
+    },
+    [router, searchParams]
+  )
+
+  // Debounce search -> URL
+  useEffect(() => {
+    if (!initialized) return
+    const t = setTimeout(() => {
+      updateUrl({ search: search || undefined })
+    }, SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(t)
+  }, [search, initialized, updateUrl])
+
   // Add state for users without salary
   const [usersWithoutSalary, setUsersWithoutSalary] = useState<User[]>([]);
 
@@ -63,14 +120,10 @@ export function SalaryList({month, year}: SalaryListProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
 
-  // Get current year and month from URL
-  const currentYear = searchParams.get('year')
-  const currentMonth = searchParams.get('month')
-
   const fetchSalaries = useCallback(async () => {
     try {
       setLoading(true)
-      const response = await fetch(`/api/salary?month=${month}&year=${year}${selectedFilters.referralOnly ? '&referralOnly=true' : ''}`)
+      const response = await fetch(`/api/salary?month=${month}&year=${year}${referralOnly ? '&referralOnly=true' : ''}`)
       if (response.ok) {
         const data = await response.json()
         setSalaries(data)
@@ -80,7 +133,7 @@ export function SalaryList({month, year}: SalaryListProps) {
     } finally {
       setLoading(false)
     }
-  }, [month, year, selectedFilters.referralOnly])
+  }, [month, year, referralOnly])
 
   useEffect(() => {
     if (month && year) {
@@ -92,13 +145,13 @@ export function SalaryList({month, year}: SalaryListProps) {
 
   // Fetch users without salary for selected month/year if filter is selected
   useEffect(() => {
-    if (selectedFilters.status === 'no-salary' && month && year) {
+    if (status === 'no-salary' && month && year) {
       fetchUsersWithoutSalary();
     } else {
       setUsersWithoutSalary([]); // Clear when not in 'no-salary' mode
     }
     // eslint-disable-next-line
-  }, [selectedFilters.status, month, year]);
+  }, [status, month, year]);
 
   const fetchBranches = async () => {
     try {
@@ -150,33 +203,33 @@ export function SalaryList({month, year}: SalaryListProps) {
   const getFilteredSalaries = () => {
     return salaries.filter(salary => {
       // Search filter
-      const matchesSearch = !selectedFilters.search ||
-        salary.user.name?.toLowerCase().includes(selectedFilters.search.toLowerCase()) ||
-        salary.user.email?.toLowerCase().includes(selectedFilters.search.toLowerCase()) ||
-        salary.user.numId?.toString().includes(selectedFilters.search)
+      const matchesSearch = !search ||
+        salary.user.name?.toLowerCase().includes(search.toLowerCase()) ||
+        salary.user.email?.toLowerCase().includes(search.toLowerCase()) ||
+        salary.user.numId?.toString().includes(search)
 
       // Branch filter
-      const matchesBranch = selectedFilters.branch === 'all' ||
-        salary.user.branchId === selectedFilters.branch
+      const matchesBranch = branch === 'all' ||
+        salary.user.branchId === branch
 
       // Role filter
-      const matchesRole = selectedFilters.role === 'all' ||
-        salary.user.role === selectedFilters.role
+      const matchesRole = role === 'all' ||
+        salary.user.role === role
 
       // Deductions filter
       const matchesDeductions =
-        selectedFilters.deductions === 'all' ? true :
-          selectedFilters.deductions === 'with-deductions' ? salary.installments.length > 0 :
-            selectedFilters.deductions === 'without-deductions' ? salary.installments.length === 0 :
+        deductions === 'all' ? true :
+          deductions === 'with-deductions' ? salary.installments.length > 0 :
+            deductions === 'without-deductions' ? salary.installments.length === 0 :
               true
 
       // Status filter
-      const matchesStatus = selectedFilters.status === 'all' ? true :
-        salary.status === selectedFilters.status
+      const matchesStatus = status === 'all' ? true :
+        salary.status === status
 
       // User status filter
-      const matchesUserStatus = selectedFilters.userStatus === 'all' ||
-        salary.user.status === selectedFilters.userStatus
+      const matchesUserStatus = userStatus === 'all' ||
+        salary.user.status === userStatus
 
       return matchesSearch && matchesBranch && matchesRole &&
         matchesDeductions && matchesStatus && matchesUserStatus
@@ -405,11 +458,8 @@ export function SalaryList({month, year}: SalaryListProps) {
   }
 
   const handleViewDetails = (salaryId: string) => {
-    const params = new URLSearchParams()
-    if (currentYear) params.set('year', currentYear)
-    if (currentMonth) params.set('month', currentMonth)
-
-    router.push(`/salary/${salaryId}?${params.toString()}`)
+    const qs = searchParams.toString()
+    router.push(`/salary/${salaryId}${qs ? `?${qs}` : ''}`)
   }
 
   const handleDownloadPayslip = (salaryId: string, userId: string) => {
@@ -543,11 +593,8 @@ export function SalaryList({month, year}: SalaryListProps) {
             <SearchIcon className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground"/>
             <Input
               placeholder="Search by name, email, or employee ID"
-              value={selectedFilters.search}
-              onChange={(e) => setSelectedFilters(prev => ({
-                ...prev,
-                search: e.target.value
-              }))}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
               className="pl-8"
             />
           </div>
@@ -555,11 +602,11 @@ export function SalaryList({month, year}: SalaryListProps) {
         <div className="w-[200px]">
           <label className="text-sm font-medium mb-2 block">Branch</label>
           <Select
-            value={selectedFilters.branch}
-            onValueChange={(value) => setSelectedFilters(prev => ({
-              ...prev,
-              branch: value
-            }))}
+            value={branch}
+            onValueChange={(value) => {
+              setBranch(value)
+              updateUrl({ branch: value })
+            }}
           >
             <SelectTrigger>
               <SelectValue placeholder="All Branches"/>
@@ -577,11 +624,11 @@ export function SalaryList({month, year}: SalaryListProps) {
         <div className="w-[200px]">
           <label className="text-sm font-medium mb-2 block">Role</label>
           <Select
-            value={selectedFilters.role}
-            onValueChange={(value) => setSelectedFilters(prev => ({
-              ...prev,
-              role: value
-            }))}
+            value={role}
+            onValueChange={(value) => {
+              setRole(value)
+              updateUrl({ role: value })
+            }}
           >
             <SelectTrigger>
               <SelectValue placeholder="All Roles"/>
@@ -599,11 +646,11 @@ export function SalaryList({month, year}: SalaryListProps) {
         <div className="w-[200px]">
           <label className="text-sm font-medium mb-2 block">Deductions</label>
           <Select
-            value={selectedFilters.deductions}
-            onValueChange={(value) => setSelectedFilters(prev => ({
-              ...prev,
-              deductions: value
-            }))}
+            value={deductions}
+            onValueChange={(value) => {
+              setDeductions(value)
+              updateUrl({ deductions: value })
+            }}
           >
             <SelectTrigger>
               <SelectValue placeholder="Filter by Deductions"/>
@@ -618,11 +665,11 @@ export function SalaryList({month, year}: SalaryListProps) {
         <div className="w-[200px]">
           <label className="text-sm font-medium mb-2 block">Status</label>
           <Select
-            value={selectedFilters.status}
-            onValueChange={(value) => setSelectedFilters(prev => ({
-              ...prev,
-              status: value
-            }))}
+            value={status}
+            onValueChange={(value) => {
+              setStatus(value)
+              updateUrl({ status: value })
+            }}
           >
             <SelectTrigger>
               <SelectValue placeholder="Filter by Status"/>
@@ -640,11 +687,11 @@ export function SalaryList({month, year}: SalaryListProps) {
         <div className="w-[200px]">
           <label className="text-sm font-medium mb-2 block">User Status</label>
           <Select
-            value={selectedFilters.userStatus}
-            onValueChange={(value) => setSelectedFilters(prev => ({
-              ...prev,
-              userStatus: value
-            }))}
+            value={userStatus}
+            onValueChange={(value) => {
+              setUserStatus(value)
+              updateUrl({ userStatus: value })
+            }}
           >
             <SelectTrigger>
               <SelectValue placeholder="Filter by User Status"/>
@@ -657,24 +704,33 @@ export function SalaryList({month, year}: SalaryListProps) {
             </SelectContent>
           </Select>
         </div>
-        {(selectedFilters.deductions !== 'all' ||
-          selectedFilters.status !== 'all' ||
-          selectedFilters.userStatus !== 'all' ||
-          selectedFilters.search ||
-          selectedFilters.branch ||
-          selectedFilters.role ||
-          selectedFilters.referralOnly) && (
+        {(deductions !== 'all' ||
+          status !== 'all' ||
+          userStatus !== 'all' ||
+          search ||
+          (branch !== 'all') ||
+          (role !== 'all') ||
+          referralOnly) && (
           <Button
             variant="outline"
-            onClick={() => setSelectedFilters({
-              deductions: 'all',
-              status: 'all',
-              search: '',
-              branch: 'all',
-              role: 'all',
-              referralOnly: false,
-              userStatus: 'all',
-            })}
+            onClick={() => {
+              setSearch('')
+              setBranch('all')
+              setRole('all')
+              setDeductions('all')
+              setStatus('all')
+              setUserStatus('all')
+              setReferralOnly(false)
+              updateUrl({
+                search: undefined,
+                branch: undefined,
+                role: undefined,
+                deductions: undefined,
+                status: undefined,
+                userStatus: undefined,
+                referralOnly: undefined,
+              })
+            }}
           >
             Clear Filters
           </Button>
@@ -683,11 +739,11 @@ export function SalaryList({month, year}: SalaryListProps) {
 
       <div className="flex items-center gap-2 -mt-2">
         <Checkbox
-          checked={selectedFilters.referralOnly}
+          checked={referralOnly}
           onCheckedChange={(checked) => {
-            setSelectedFilters(prev => ({ ...prev, referralOnly: !!checked }))
-            // refetch on toggle
-            setTimeout(() => fetchSalaries(), 0)
+            const next = !!checked
+            setReferralOnly(next)
+            updateUrl({ referralOnly: next })
           }}
         />
         <span className="text-sm">Show only salaries with referral bonuses</span>
@@ -772,7 +828,7 @@ export function SalaryList({month, year}: SalaryListProps) {
         )}
       </div>
 
-      {selectedFilters.status === 'no-salary' ? (
+      {status === 'no-salary' ? (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {usersWithoutSalary.length > 0 ? usersWithoutSalary.map((user) => (
             <Card key={user.id} className="hover:shadow-lg transition-shadow">

--- a/src/components/salary/salary-management.tsx
+++ b/src/components/salary/salary-management.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/select'
 import { SalaryList } from './salary-list'
 import { toast } from "sonner";
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { DownloadENETButton } from './download-enet-button'
 import { BulkImportExport } from './bulk-import-export'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -43,6 +43,7 @@ type ConflictWarning = {
 
 export function SalaryManagement({ initialYear, initialMonth }: SalaryManagementProps) {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [selectedYear, setSelectedYear] = useState(initialYear || new Date().getFullYear())
   const [selectedMonth, setSelectedMonth] = useState(initialMonth || new Date().getMonth() + 1)
   const [isGenerating, setIsGenerating] = useState(false)
@@ -68,13 +69,13 @@ export function SalaryManagement({ initialYear, initialMonth }: SalaryManagement
     { value: '12', label: 'December' },
   ]
 
-  // Update URL when selection changes
+  // Update URL when selection changes (preserve other filter params)
   const updateUrlParams = useCallback((year: number, month: number) => {
-    const params = new URLSearchParams()
+    const params = new URLSearchParams(searchParams.toString())
     params.set('year', year.toString())
     params.set('month', month.toString())
-    router.push(`/salary?${params.toString()}`, { scroll: false })
-  }, [router])
+    router.replace(`/salary?${params.toString()}`, { scroll: false })
+  }, [router, searchParams])
 
   // Handle year change
   const handleYearChange = (year: number) => {

--- a/src/components/salary/salary-management.tsx
+++ b/src/components/salary/salary-management.tsx
@@ -74,7 +74,7 @@ export function SalaryManagement({ initialYear, initialMonth }: SalaryManagement
     const params = new URLSearchParams(searchParams.toString())
     params.set('year', year.toString())
     params.set('month', month.toString())
-    router.replace(`/salary?${params.toString()}`, { scroll: false })
+    router.push(`/salary?${params.toString()}`, { scroll: false })
   }, [router, searchParams])
 
   // Handle year change


### PR DESCRIPTION
## Summary
- Salary management page filters (search, branch, role, deductions, status, user status, referral-only) now persist in the URL. Reload, View Details → View Attendance → Back, and changing month/year all preserve filters. Pattern matches `user-table.tsx` / `manage-attendance-filters.tsx`.
- New **Download Non-Paid Salary Report** action under More Actions, beneath the existing salary report. Filters to `PENDING` + `PROCESSING` salaries for use on the second payday (10th). Same XLSX layout as the regular report.

## Test plan
- [ ] On `/salary`, set filters (search, branch, role, status etc.) → reload → filters restored from URL
- [ ] On `/salary`, set filters → click View Details → click View Attendance → browser back twice (or the in-page Back button) → all filters intact
- [ ] Change month/year selectors → other filters survive (URL is updated, not replaced)
- [ ] Clear Filters resets every filter and prunes URL params
- [ ] Search input is debounced (~300ms), no jank while typing
- [ ] More Actions → Download Salary Report still produces the full report unchanged
- [ ] More Actions → Download Non-Paid Salary Report produces an XLSX named `non-paid-salary-report-{month}-{year}.xlsx` containing only PENDING + PROCESSING rows
- [ ] If no non-paid salaries exist for the month, a friendly toast is shown instead of a download

🤖 Generated with [Claude Code](https://claude.com/claude-code)