### PR TITLE
fix(deduction-settings): include PARTIAL_INACTIVE users in export

### DIFF
--- a/src/app/api/users/deduction-settings/export/route.ts
+++ b/src/app/api/users/deduction-settings/export/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
   }
 
   const users = await prisma.user.findMany({
-    where: { status: 'ACTIVE' },
+    where: { status: { in: ['ACTIVE', 'PARTIAL_INACTIVE'] } },
     select: {
       id: true,
       numId: true,


### PR DESCRIPTION
## Summary
The deduction-settings export only listed `ACTIVE` users, but the salary bulk-export pays out both `ACTIVE` and `PARTIAL_INACTIVE` employees. This left HR unable to manage PT / PF / Insurance flags for partial-inactive employees still in their final cycle. Widened the filter to match.

The import route does not filter by status, so it already accepts updates for PARTIAL_INACTIVE users — no change needed there.

## Test plan
- [ ] Have at least one PARTIAL_INACTIVE user → click Export Deduction Settings on `/users/deduction-settings` → that user appears in the XLSX
- [ ] Edit their PT / PF / Insurance flags in the sheet, re-import → flags update successfully on the user
- [ ] ACTIVE users still appear as before; INACTIVE / PENDING / JOB_OFFER are still excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)
