### PR TITLE
fix(salary): per-user generate writes recurringDeductions

### DIFF
--- a/src/app/api/salaries/[userId]/[month]/[year]/route.ts
+++ b/src/app/api/salaries/[userId]/[month]/[year]/route.ts
@@ -104,6 +104,7 @@ export async function POST(
           halfDays: salaryDetails.halfDays,
           leavesEarned: salaryDetails.leavesEarned,
           leaveSalary: salaryDetails.leaveSalary,
+          recurringDeductions: salaryDetails.recurringDeductions as unknown as object,
           status: 'PENDING'
         }
       });


### PR DESCRIPTION
## Summary
The bulk `POST /api/salary/generate` writes `recurringDeductions` correctly when creating new salary rows. The **per-user** `POST /api/salaries/{userId}/{month}/{year}` (called by the "Generate Salary" button on the salary actions panel — `salary-actions.tsx:33`) was missing the field in its `salary.create` payload.

Result: salaries generated via the per-user button had `recurring_deductions = NULL` even when the user had `optInPT = true`. On the subsequent PROCESSING transition, `sumRecurringDeductions(null) = 0`, so PT was silently skipped — the snapshot for the rest of the month was empty.

Hit in prod today on **7 employees** (April 2026): #6 Rajesh Prasad, #28 Saroj mandal, #29 Kailesh Kumar Mali, #30 Balram Shah, #102 Soman kumar, #187 Deepak Kumar, #217 Jatin Laxman Pathade. They will need a one-shot backfill (separate task) to write the PT snapshot and recompute net.

## Fix
One-line addition to the create payload at line 107:
```ts
recurringDeductions: salaryDetails.recurringDeductions as unknown as object,
```
`calculateSalary` already computes this from the user's current `optInPT/PF/ESI` flags, so no extra logic needed. Mirrors the bulk endpoint exactly.

## Test plan
- [ ] On a salary detail page, click **Generate Salary** for a user whose `optInPT = true` (and salary ≥ ₹7,500)
- [ ] Inspect the new row: `recurring_deductions` should be `[{"code":"PT","name":"Professional Tax","amount":200}]` (or 175 for slab 1, 300 for February)
- [ ] Move that salary to PROCESSING — net should reflect the PT deduction
- [ ] Repeat for a user with `optInPT = false` — `recurring_deductions` should be `[]` (still correct, just empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
