### PR TITLE
refactor(salary): extract shared buildSalaryCreateData helper

### DIFF
--- a/src/app/api/salaries/[userId]/[month]/[year]/route.ts
+++ b/src/app/api/salaries/[userId]/[month]/[year]/route.ts
@@ -2,6 +2,7 @@ import {NextResponse} from "next/server";
 import {auth} from "@/auth";
 import {prisma} from "@/lib/prisma";
 import {calculateSalary} from "@/lib/services/salary-calculator";
+import { buildSalaryCreateData } from "@/lib/services/salary-create";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { ActivityType } from "@prisma/client";
 import { format } from "date-fns";
@@ -89,24 +90,12 @@ export async function POST(
     const salary = await prisma.$transaction(async (tx) => {
       // Create the salary record
       const salary = await tx.salary.create({
-        data: {
+        data: buildSalaryCreateData({
           userId,
           month: monthNum,
           year: yearNum,
-          baseSalary: salaryDetails.baseSalary,
-          advanceDeduction: 0, // Will be updated when installments are approved
-          overtimeBonus: salaryDetails.overtimeAmount,
-          otherBonuses: salaryDetails.otherBonuses,
-          deductions: 0,
-          netSalary: salaryDetails.netSalary,
-          presentDays: salaryDetails.presentDays,
-          overtimeDays: salaryDetails.overtimeDays,
-          halfDays: salaryDetails.halfDays,
-          leavesEarned: salaryDetails.leavesEarned,
-          leaveSalary: salaryDetails.leaveSalary,
-          recurringDeductions: salaryDetails.recurringDeductions as unknown as object,
-          status: 'PENDING'
-        }
+          salaryDetails,
+        }),
       });
 
       // Create pending installments for each suggested deduction

--- a/src/app/api/salary/generate/route.ts
+++ b/src/app/api/salary/generate/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { calculateSalary } from '@/lib/services/salary-calculator'
+import { buildSalaryCreateData } from '@/lib/services/salary-create'
 import { auth } from "@/auth"
 import { AdvancePaymentInstallment } from "@/models/models";
 import { hasAttendanceConflicts } from "@/lib/services/attendance-conflicts";
@@ -146,24 +147,12 @@ export async function POST(request: Request) {
       return await prisma.$transaction(async (tx) => {
         // Create the salary record
         const salary = await tx.salary.create({
-          data: {
+          data: buildSalaryCreateData({
             userId: user.id,
             month,
             year,
-            baseSalary: salaryDetails.baseSalary,
-            advanceDeduction: 0, // Will be updated when installments are approved
-            overtimeBonus: salaryDetails.overtimeAmount,
-            otherBonuses: salaryDetails.otherBonuses,
-            deductions: 0,
-            netSalary: salaryDetails.netSalary,
-            presentDays: salaryDetails.presentDays,
-            overtimeDays: salaryDetails.overtimeDays,
-            halfDays: salaryDetails.halfDays,
-            leavesEarned: salaryDetails.leavesEarned,
-            leaveSalary: salaryDetails.leaveSalary,
-            recurringDeductions: salaryDetails.recurringDeductions as unknown as object,
-            status: 'PENDING'
-          }
+            salaryDetails,
+          }),
         })
 
         // Referral bonuses are processed explicitly via /api/salary/process-referrals.

--- a/src/lib/services/__tests__/salary-create.test.ts
+++ b/src/lib/services/__tests__/salary-create.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { buildSalaryCreateData } from '@/lib/services/salary-create'
+import type { calculateSalary } from '@/lib/services/salary-calculator'
+
+type SalaryDetails = Awaited<ReturnType<typeof calculateSalary>>
+
+/**
+ * Pin down the exact field set the helper emits. The bulk-generate and
+ * per-user generate routes both depend on this shape — adding/removing/
+ * renaming any field here is a behavior change and must be intentional.
+ */
+
+// Minimal salaryDetails fixture: only the fields the helper consumes.
+// `as unknown as SalaryDetails` because calculateSalary returns several
+// extra fields (attendance, suggestedAdvanceDeductions, etc.) we don't
+// need to populate for this contract test.
+function makeSalaryDetails(overrides: Partial<SalaryDetails> = {}): SalaryDetails {
+  return {
+    baseSalary: 25000,
+    overtimeAmount: 1500,
+    otherBonuses: 0,
+    netSalary: 22300,
+    presentDays: 28,
+    overtimeDays: 5,
+    halfDays: 0,
+    leavesEarned: 1,
+    leaveSalary: 833.33,
+    recurringDeductions: [
+      { code: 'PT', name: 'Professional Tax', amount: 200 },
+    ],
+    ...overrides,
+  } as unknown as SalaryDetails
+}
+
+describe('buildSalaryCreateData', () => {
+  it('emits the exact field set both generate routes expect', () => {
+    const data = buildSalaryCreateData({
+      userId: 'user-123',
+      month: 4,
+      year: 2026,
+      salaryDetails: makeSalaryDetails(),
+    })
+
+    // Snapshot-style assertion on every field. This protects against silent
+    // field omission (the bug class that caused the per-user route to skip
+    // recurringDeductions).
+    expect(data).toEqual({
+      userId: 'user-123',
+      month: 4,
+      year: 2026,
+      baseSalary: 25000,
+      advanceDeduction: 0,
+      overtimeBonus: 1500,
+      otherBonuses: 0,
+      deductions: 0,
+      netSalary: 22300,
+      presentDays: 28,
+      overtimeDays: 5,
+      halfDays: 0,
+      leavesEarned: 1,
+      leaveSalary: 833.33,
+      recurringDeductions: [
+        { code: 'PT', name: 'Professional Tax', amount: 200 },
+      ],
+      status: 'PENDING',
+    })
+  })
+
+  it('passes through PT-only recurring deductions verbatim', () => {
+    const data = buildSalaryCreateData({
+      userId: 'u1',
+      month: 6,
+      year: 2026,
+      salaryDetails: makeSalaryDetails({
+        recurringDeductions: [{ code: 'PT', name: 'Professional Tax', amount: 175 }],
+      }),
+    })
+    expect(data.recurringDeductions).toEqual([
+      { code: 'PT', name: 'Professional Tax', amount: 175 },
+    ])
+  })
+
+  it('passes through empty recurringDeductions as an empty array (not null)', () => {
+    const data = buildSalaryCreateData({
+      userId: 'u2',
+      month: 4,
+      year: 2026,
+      salaryDetails: makeSalaryDetails({ recurringDeductions: [] }),
+    })
+    // Critical: must be [] not undefined / null. NULL was what caused the
+    // original bug — sumRecurringDeductions(null) returns 0 and PT silently
+    // got dropped at the PROCESSING transition.
+    expect(data.recurringDeductions).toEqual([])
+    expect(data.recurringDeductions).not.toBeNull()
+    expect(data.recurringDeductions).not.toBeUndefined()
+  })
+
+  it('always creates with status PENDING', () => {
+    const data = buildSalaryCreateData({
+      userId: 'u3', month: 4, year: 2026, salaryDetails: makeSalaryDetails(),
+    })
+    expect(data.status).toBe('PENDING')
+  })
+
+  it('forces advanceDeduction and deductions to 0 regardless of salaryDetails', () => {
+    // salaryDetails has a `deductions` field (totalAdvanceDeduction) but the
+    // create payload intentionally writes 0 — installments are linked
+    // separately and advanceDeduction is recomputed at the PROCESSING
+    // transition.
+    const data = buildSalaryCreateData({
+      userId: 'u4', month: 4, year: 2026,
+      salaryDetails: makeSalaryDetails({
+        // @ts-expect-error — deductions exists on the calculator return
+        deductions: 5000,
+      }),
+    })
+    expect(data.advanceDeduction).toBe(0)
+    expect(data.deductions).toBe(0)
+  })
+
+  it('does not emit unexpected extra fields', () => {
+    // If something is added here without intent, this test forces an update
+    // and the reviewer has to acknowledge it.
+    const data = buildSalaryCreateData({
+      userId: 'u5', month: 4, year: 2026, salaryDetails: makeSalaryDetails(),
+    })
+    expect(Object.keys(data).sort()).toEqual([
+      'advanceDeduction',
+      'baseSalary',
+      'deductions',
+      'halfDays',
+      'leaveSalary',
+      'leavesEarned',
+      'month',
+      'netSalary',
+      'otherBonuses',
+      'overtimeBonus',
+      'overtimeDays',
+      'presentDays',
+      'recurringDeductions',
+      'status',
+      'userId',
+      'year',
+    ])
+  })
+})

--- a/src/lib/services/salary-create.ts
+++ b/src/lib/services/salary-create.ts
@@ -1,0 +1,50 @@
+import type { Prisma } from '@prisma/client'
+import type { calculateSalary } from '@/lib/services/salary-calculator'
+
+type SalaryDetails = Awaited<ReturnType<typeof calculateSalary>>
+
+export interface BuildSalaryCreateDataInput {
+  userId: string
+  month: number
+  year: number
+  salaryDetails: SalaryDetails
+}
+
+/**
+ * Build the data block for `prisma.salary.create()`.
+ *
+ * Used by both the bulk-generate route (`/api/salary/generate`) and the
+ * per-user generate route (`/api/salaries/[userId]/[month]/[year]`). The
+ * two paths used to duplicate this payload almost verbatim, and a previous
+ * field omission (recurringDeductions) on the per-user path silently
+ * skipped PT for any salary generated via the per-user "Generate Salary"
+ * button. Centralizing here ensures any future field addition lands on
+ * both paths automatically.
+ *
+ * Always creates the salary in `PENDING` status. Approved-installment
+ * advance deduction is intentionally 0 here — installments are linked
+ * separately and the value is recomputed at the PROCESSING transition.
+ */
+export function buildSalaryCreateData(
+  input: BuildSalaryCreateDataInput
+): Prisma.SalaryUncheckedCreateInput {
+  const { userId, month, year, salaryDetails } = input
+  return {
+    userId,
+    month,
+    year,
+    baseSalary: salaryDetails.baseSalary,
+    advanceDeduction: 0,
+    overtimeBonus: salaryDetails.overtimeAmount,
+    otherBonuses: salaryDetails.otherBonuses,
+    deductions: 0,
+    netSalary: salaryDetails.netSalary,
+    presentDays: salaryDetails.presentDays,
+    overtimeDays: salaryDetails.overtimeDays,
+    halfDays: salaryDetails.halfDays,
+    leavesEarned: salaryDetails.leavesEarned,
+    leaveSalary: salaryDetails.leaveSalary,
+    recurringDeductions: salaryDetails.recurringDeductions as unknown as Prisma.InputJsonValue,
+    status: 'PENDING',
+  }
+}


### PR DESCRIPTION
## Summary
The bulk-generate route (`POST /api/salary/generate`) and the per-user generate route (`POST /api/salaries/[userId]/[month]/[year]`) had nearly-identical `salary.create` payloads (~17 fields each). The two paths already diverged once: the per-user path was silently missing `recurringDeductions`, which caused PT to be skipped on every salary generated via the "Generate Salary" button (fixed in #39). To prevent that class of regression, hoist the payload into a single helper.

## Change
New helper `src/lib/services/salary-create.ts`:

```ts
export function buildSalaryCreateData(
  input: { userId: string; month: number; year: number; salaryDetails: ... }
): Prisma.SalaryUncheckedCreateInput
```

Both routes now construct the create data via:
```ts
const salary = await tx.salary.create({
  data: buildSalaryCreateData({ userId, month, year, salaryDetails }),
})
```

## What this does NOT change
- Field set, field values, ordering of operations, status (`PENDING`), advance-installment handling — all identical to before. This is a pure refactor.
- The `recurringDeductions` cast (`as unknown as Prisma.InputJsonValue`) is preserved.

## Why now
- Past divergence caused a real prod incident — 7 salaries created today without PT (#39 + manual backfill).
- Future fields added to one path would silently miss the other.
- Tightens the contract: there's one place to look for "what fields are written when a new salary is generated."

## Test plan
- [ ] On `/salary`, click **Generate Salaries** (bulk). All affected users get fresh salaries with the same fields as before — including `recurringDeductions`.
- [ ] On a salary detail page, click **Generate Salary** (per-user). The created row matches the bulk output exactly.
- [ ] Spot-check the DB: a salary created via either path has `recurring_deductions` reflecting the user's `optInPT/PF/ESI` flags.
- [ ] Existing PROCESSING transition logic (which reads back `recurringDeductions` and recomputes net) continues to work for new rows from both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
