### PR TITLE
feat: show #numId and avatar everywhere an employee name appears

### DIFF
--- a/docs/superpowers/plans/2026-05-21-employee-identity-display.md
+++ b/docs/superpowers/plans/2026-05-21-employee-identity-display.md
@@ -1,0 +1,852 @@
+# Employee Identity Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize every UI surface that shows an employee's name to also show their `#numId` and image (with initials fallback) via one shared `<EmployeeIdentity />` component.
+
+**Architecture:** Build one shadcn-style component in `src/components/ui/employee-identity.tsx` with `sm`/`md`/`lg` size variants. Extract two pure helpers (`stringToHue`, `getInitials`) into `src/lib/utils.ts` with unit tests. Introduce a `userIdentitySelect` Prisma preset; spread it into every list/detail fetch. Then mechanically replace `{user.name}` call sites domain-by-domain.
+
+**Tech Stack:** Next.js 14 App Router · Prisma · shadcn/ui (Radix Avatar) · Tailwind · Vitest (node env). Branch: `feature/employee-identity-display` (already created).
+
+**Testability note:** The repo's Vitest config uses `environment: 'node'` with no `@testing-library/react`. We test pure helpers (TDD). Component verification is manual via `npm run dev` + smoke pass per task. Type errors at call sites act as the safety net for the data-plumbing tasks.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-employee-identity-display-design.md`
+
+---
+
+## Phase 1 — Foundation
+
+### Task 1: Extract `stringToHue` into `src/lib/utils.ts`
+
+**Files:**
+- Modify: `src/lib/utils.ts` (add export)
+- Modify: `src/components/leave/leave-request-table.tsx` (remove local copy, import from utils)
+- Create: `src/lib/__tests__/string-to-hue.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/string-to-hue.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { stringToHue } from '@/lib/utils';
+
+describe('stringToHue', () => {
+  it('returns a number in [0, 359]', () => {
+    const h = stringToHue('Rohit Kumar');
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThan(360);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(stringToHue('Anya Sharma')).toBe(stringToHue('Anya Sharma'));
+  });
+
+  it('produces different hues for different inputs', () => {
+    expect(stringToHue('Rohit')).not.toBe(stringToHue('Anya'));
+  });
+
+  it('handles the empty string', () => {
+    expect(stringToHue('')).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/__tests__/string-to-hue.test.ts`
+Expected: FAIL with `"stringToHue" is not exported by "src/lib/utils.ts"`.
+
+- [ ] **Step 3: Add the helper to `src/lib/utils.ts`**
+
+Append to `src/lib/utils.ts`:
+
+```ts
+/**
+ * Hash a string into a hue value [0, 360). Used to give each person/department
+ * a stable color (e.g. for avatar fallback backgrounds, department pills).
+ */
+export function stringToHue(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+  }
+  return hash % 360;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/__tests__/string-to-hue.test.ts`
+Expected: 4 tests PASS.
+
+- [ ] **Step 5: Remove the duplicate from `leave-request-table.tsx`**
+
+In `src/components/leave/leave-request-table.tsx`:
+- Delete the local `function stringToHue(input: string) { ... }` block (currently around lines 74–82).
+- Add an import at the top: `import { stringToHue } from "@/lib/utils";` (merge into the existing utils import if one already exists).
+
+- [ ] **Step 6: Typecheck + full test suite**
+
+Run: `npx tsc --noEmit && npx vitest run`
+Expected: 0 type errors. All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/utils.ts src/lib/__tests__/string-to-hue.test.ts src/components/leave/leave-request-table.tsx
+git commit -m "refactor(utils): promote stringToHue to shared util"
+```
+
+---
+
+### Task 2: Add `getInitials` helper
+
+**Files:**
+- Modify: `src/lib/utils.ts`
+- Create: `src/lib/__tests__/get-initials.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/get-initials.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getInitials } from '@/lib/utils';
+
+describe('getInitials', () => {
+  it('uses first letters of first and last whitespace-separated tokens', () => {
+    expect(getInitials('Rohit Kumar')).toBe('RK');
+  });
+
+  it('returns a single uppercase letter for one-word names', () => {
+    expect(getInitials('Rohit')).toBe('R');
+  });
+
+  it('ignores middle tokens', () => {
+    expect(getInitials('Rohit Kumar Singh')).toBe('RS');
+  });
+
+  it('collapses extra whitespace', () => {
+    expect(getInitials('  Rohit   Kumar  ')).toBe('RK');
+  });
+
+  it('returns "?" for null/undefined/empty input', () => {
+    expect(getInitials(null)).toBe('?');
+    expect(getInitials(undefined)).toBe('?');
+    expect(getInitials('')).toBe('?');
+    expect(getInitials('   ')).toBe('?');
+  });
+
+  it('uppercases lowercase input', () => {
+    expect(getInitials('rohit kumar')).toBe('RK');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/__tests__/get-initials.test.ts`
+Expected: FAIL — `getInitials` not exported.
+
+- [ ] **Step 3: Implement in `src/lib/utils.ts`**
+
+Append to `src/lib/utils.ts`:
+
+```ts
+/**
+ * Extract up to two initials from a person's name:
+ * first letter of first token + first letter of last token, uppercased.
+ * Returns "?" for null/empty input.
+ */
+export function getInitials(name: string | null | undefined): string {
+  if (!name) return '?';
+  const tokens = name.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return '?';
+  if (tokens.length === 1) return tokens[0].charAt(0).toUpperCase();
+  const first = tokens[0].charAt(0);
+  const last = tokens[tokens.length - 1].charAt(0);
+  return (first + last).toUpperCase();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/__tests__/get-initials.test.ts`
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/utils.ts src/lib/__tests__/get-initials.test.ts
+git commit -m "feat(utils): add getInitials helper for avatar fallback"
+```
+
+---
+
+### Task 3: Add `userIdentitySelect` Prisma preset and `EmployeeIdentityUser` type
+
+**Files:**
+- Create: `src/lib/select-presets.ts`
+- Modify: `src/models/models.ts` (export the type)
+
+- [ ] **Step 1: Create the preset**
+
+Create `src/lib/select-presets.ts`:
+
+```ts
+/**
+ * Prisma `select` presets for stable cross-cutting projections.
+ * Spread these into a `.select` block so every consumer gets the same shape.
+ */
+
+export const userIdentitySelect = {
+  id: true,
+  name: true,
+  numId: true,
+  image: true,
+} as const;
+```
+
+- [ ] **Step 2: Add the type to `src/models/models.ts`**
+
+Open `src/models/models.ts`. After the existing `User` type/interface definition, append:
+
+```ts
+export type EmployeeIdentityUser = {
+  id: string;
+  name: string | null;
+  numId: number | null;
+  image: string | null;
+};
+```
+
+(Defined structurally rather than as `Pick<User, ...>` so the type is usable even where the full `User` shape isn't imported.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/select-presets.ts src/models/models.ts
+git commit -m "feat(types): add EmployeeIdentityUser + userIdentitySelect preset"
+```
+
+---
+
+### Task 4: Build the `EmployeeIdentity` component
+
+**Files:**
+- Create: `src/components/ui/employee-identity.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/ui/employee-identity.tsx`:
+
+```tsx
+import * as React from "react";
+import Link from "next/link";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn, getInitials, stringToHue } from "@/lib/utils";
+import type { EmployeeIdentityUser } from "@/models/models";
+
+type Size = "sm" | "md" | "lg";
+
+interface EmployeeIdentityProps {
+  user: EmployeeIdentityUser;
+  size?: Size;
+  subtitle?: React.ReactNode;
+  href?: string;
+  className?: string;
+}
+
+const AVATAR_SIZE: Record<Size, string> = {
+  sm: "h-6 w-6 text-[10px]",
+  md: "h-8 w-8 text-xs",
+  lg: "h-12 w-12 text-base",
+};
+
+const NAME_TEXT: Record<Size, string> = {
+  sm: "text-sm font-medium leading-tight",
+  md: "text-sm font-medium leading-tight",
+  lg: "text-base font-semibold leading-tight",
+};
+
+const ID_TEXT: Record<Size, string> = {
+  sm: "text-xs text-muted-foreground",
+  md: "text-xs text-muted-foreground leading-tight",
+  lg: "text-sm text-muted-foreground leading-tight",
+};
+
+export function EmployeeIdentity({
+  user,
+  size = "md",
+  subtitle,
+  href,
+  className,
+}: EmployeeIdentityProps) {
+  const initials = getInitials(user.name);
+  const hue = user.name ? stringToHue(user.name) : null;
+  const fallbackStyle = hue !== null
+    ? { backgroundColor: `hsl(${hue} 60% 50%)`, color: "white" }
+    : { backgroundColor: "hsl(0 0% 80%)", color: "white" };
+
+  const idLine = subtitle ?? (user.numId !== null ? `#${user.numId}` : null);
+
+  const inner = (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 min-w-0",
+        className,
+      )}
+    >
+      <Avatar className={cn(AVATAR_SIZE[size], "shrink-0")}>
+        {user.image ? (
+          <AvatarImage
+            src={user.image}
+            alt={user.name ?? "Employee"}
+            loading="lazy"
+          />
+        ) : null}
+        <AvatarFallback style={fallbackStyle}>{initials}</AvatarFallback>
+      </Avatar>
+
+      {size === "sm" ? (
+        <div className="min-w-0 truncate">
+          <span className={NAME_TEXT[size]}>{user.name ?? "Unnamed"}</span>
+          {idLine !== null && (
+            <span className={cn("ml-1.5", ID_TEXT[size])}>· {idLine}</span>
+          )}
+        </div>
+      ) : (
+        <div className="min-w-0">
+          <div className={cn(NAME_TEXT[size], "truncate")}>
+            {user.name ?? "Unnamed"}
+          </div>
+          {idLine !== null && (
+            <div className={cn(ID_TEXT[size], "truncate")}>{idLine}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="hover:underline">
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 3: Smoke-render the component**
+
+Start the dev server: `npm run dev`. In a browser, open any existing page that shows a user (e.g. `/users`). Temporarily, in `src/app/(auth)/users/page.tsx`, drop a one-line preview at the top of the rendered output:
+
+```tsx
+<EmployeeIdentity user={{ id: "x", name: "Test Person", numId: 99, image: null }} size="md" />
+```
+
+Verify the avatar shows `TP` on a colored background and `#99` below the name. Then revert the preview line. Do not commit the preview.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ui/employee-identity.tsx
+git commit -m "feat(ui): add EmployeeIdentity component with sm/md/lg variants"
+```
+
+---
+
+## Phase 2 — Migrate call sites domain by domain
+
+For every Phase-2 task, the pattern is identical:
+1. Update the server-side fetch(es) to spread `userIdentitySelect` into the user `select` block.
+2. Replace `{user.name}` (or equivalent) in the matching client component with `<EmployeeIdentity user={user} size="md" />` (or `"sm"` / `"lg"` per surface).
+3. Remove now-redundant inline `#numId` displays.
+4. Typecheck + dev-server smoke pass.
+5. Commit.
+
+### Task 5: Migrate Attendance domain
+
+**Files:**
+- Modify (server): `src/app/(auth)/attendance/page.tsx`, `src/app/(auth)/attendance/[userId]/page.tsx`, `src/app/(auth)/attendance/self/page.tsx`, `src/app/(auth)/hr/branch-attendance/page.tsx`, `src/app/(auth)/hr/manage-attendance/page.tsx`, `src/app/(auth)/hr/pending-attendance/page.tsx`, `src/app/(auth)/hr/attendance-verification/page.tsx`, `src/app/(auth)/hr/attendance-conflicts/page.tsx`
+- Modify (client): `src/components/attendance/attendance-table.tsx`, `src/components/attendance/branch-attendance-submissions.tsx`, `src/components/attendance/attendance-verification-table.tsx`, `src/components/attendance/shared-attendance-table.tsx`, `src/components/attendance/daily-attendance-view.tsx`, `src/components/reports/attendance-reports.tsx`
+
+- [ ] **Step 1: Add the preset to every attendance user `select`**
+
+In each server page listed above, locate the `prisma.user.findMany({ select: { ... } })` (or `.user.findUnique`) and spread `userIdentitySelect` into it. Example for `src/app/(auth)/attendance/page.tsx`:
+
+```tsx
+import { userIdentitySelect } from "@/lib/select-presets";
+
+// ...
+const users = await prisma.user.findMany({
+  where: { /* unchanged */ },
+  select: {
+    ...userIdentitySelect,
+    department: { select: { id: true, name: true } },
+    attendance: { /* unchanged */ },
+  },
+  orderBy: { name: "asc" },
+});
+```
+
+Repeat for each file in the list. The `id` and `name` fields previously selected by hand can be removed since the preset provides them.
+
+- [ ] **Step 2: Replace the name cell in `attendance-table.tsx`**
+
+In `src/components/attendance/attendance-table.tsx`, locate the `<TableCell>{user.name}</TableCell>` (currently line 71) and replace with:
+
+```tsx
+<TableCell>
+  <EmployeeIdentity user={user} size="md" />
+</TableCell>
+```
+
+Add the import:
+```tsx
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
+```
+
+- [ ] **Step 3: Replace name displays in the remaining attendance client files**
+
+For each of `branch-attendance-submissions.tsx`, `attendance-verification-table.tsx`, `shared-attendance-table.tsx`, `attendance-reports.tsx`: find the `{user.name}` (or `{employee.name}`) usages in row cells and dialog headers and replace with `<EmployeeIdentity user={user} size="md" />`. For compact dropdowns or chips inside these files, use `size="sm"`.
+
+`daily-attendance-view.tsx` does not directly render names — it delegates to `attendance-table.tsx`. No change needed there except confirming nothing breaks at the type boundary.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors. Any errors usually mean a server fetch is missing `userIdentitySelect`; fix at the source rather than narrowing the prop at the call site.
+
+- [ ] **Step 5: Smoke pass**
+
+Run: `npm run dev`. Visit `/attendance`, `/hr/branch-attendance`, `/hr/manage-attendance`, `/hr/pending-attendance`, `/hr/attendance-verification`, `/hr/attendance-conflicts`. Confirm every row shows avatar + name + `#ID`. Click a row to confirm the edit modal still opens. Verify search/filter still works.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/\(auth\)/attendance src/app/\(auth\)/hr src/components/attendance src/components/reports/attendance-reports.tsx
+git commit -m "feat(attendance): show #numId + avatar everywhere via EmployeeIdentity"
+```
+
+---
+
+### Task 6: Migrate Salary domain
+
+**Files:**
+- Modify (server): `src/app/api/salary/route.ts`, `src/app/api/salary/[id]/route.ts`, `src/app/api/salary/[id]/stats/route.ts`, `src/app/api/salary/generate-enet/route.ts`, `src/app/api/salary/generate-report/route.ts`
+- Modify (client): `src/components/salary/salary-list.tsx`, `src/components/salary/salary-stats-table.tsx`, `src/components/salary/salary-details.tsx`, `src/components/salary/salary-management.tsx`
+
+- [ ] **Step 1: Add `userIdentitySelect` to every salary server fetch**
+
+In each API route, find the `user: { select: { ... } }` block inside the salary query and spread `userIdentitySelect`. Example for `src/app/api/salary/route.ts`:
+
+```ts
+import { userIdentitySelect } from "@/lib/select-presets";
+// ...
+const salaries = await prisma.salary.findMany({
+  // ...
+  select: {
+    /* existing salary fields */
+    user: { select: { ...userIdentitySelect /* + any extra fields already selected */ } },
+  },
+});
+```
+
+The PDF/CSV export endpoints (`generate-enet`, `generate-report`) are out of scope per the spec, but if their `select` already includes the user fields, leave them; do not change the export output.
+
+- [ ] **Step 2: Replace name cells in `salary-list.tsx`**
+
+In `src/components/salary/salary-list.tsx`:
+- Replace the `{salary.user?.name}` (and the inline `Emp #{numId}` rendering around line 532) with `<EmployeeIdentity user={salary.user} size="md" />`.
+- Keep the existing search input working with `numId.toString().includes(search)` (already present).
+
+- [ ] **Step 3: Replace name displays in remaining salary client files**
+
+`salary-stats-table.tsx`, `salary-details.tsx`, `salary-management.tsx`: replace each `{user.name}` row/header rendering with `<EmployeeIdentity user={user} size="md" />` (use `"lg"` for the salary detail page top header).
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 5: Smoke pass**
+
+Run: `npm run dev`. Visit `/salary`, `/salary/[someId]`. Confirm rows show avatar + name + `#ID`. Confirm salary detail page header shows the `lg` variant.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/salary src/components/salary
+git commit -m "feat(salary): show #numId + avatar everywhere via EmployeeIdentity"
+```
+
+---
+
+### Task 7: Migrate Advances domain
+
+**Files:**
+- Modify (server): `src/app/api/advances/route.ts`, `src/app/api/advances/discrepancies/route.ts`
+- Modify (client): `src/components/advances/advance-row.tsx`, `src/components/advances/advance-payments-list.tsx`, `src/components/advances/advance-discrepancies.tsx`
+
+(Skip `src/app/api/advances/export/route.ts` — exports are out of scope.)
+
+- [ ] **Step 1: Add `userIdentitySelect` to advance fetches**
+
+For each server route, spread `userIdentitySelect` into the user-related `select` block. The `numId` field is already present; spreading the preset makes it the same shape as elsewhere and adds `image`.
+
+- [ ] **Step 2: Replace inline `#numId` in `advance-row.tsx`**
+
+In `src/components/advances/advance-row.tsx`:
+- Locate the block around line 107 that renders `<div className="font-semibold">#{advance.numId}</div>` together with the user name.
+- Replace the entire two-element `name + #numId` group with `<EmployeeIdentity user={advance.user} size="md" />` (the user object inside the advance row already includes `numId`).
+- Delete now-unused style classes.
+
+- [ ] **Step 3: Migrate `advance-payments-list.tsx` and `advance-discrepancies.tsx`**
+
+Replace `{user.name}` renderings with `<EmployeeIdentity user={user} size="md" />`. Where the layout used a stacked custom `Emp #...` block, remove it.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 5: Smoke pass**
+
+Visit `/advances` (and the discrepancies sub-page). Confirm rows show the new identity block and no leftover duplicate `#numId` text.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/advances src/components/advances
+git commit -m "feat(advances): unify #numId display via EmployeeIdentity"
+```
+
+---
+
+### Task 8: Migrate Users / Employees domain
+
+**Files:**
+- Modify (server): `src/app/api/users/route.ts`, `src/app/api/users/[id]/route.ts`, `src/app/(auth)/users/[id]/page.tsx`, `src/app/(auth)/users/[id]/joining-form-signature/page.tsx`, `src/app/(auth)/users/[id]/warnings/page.tsx`
+- Modify (client): `src/components/users/user-table.tsx`, `src/components/users/user-actions.tsx`, `src/components/users/user-data-import-export.tsx`, `src/components/users/user-profile-form.tsx`, `src/components/users/joining-form-esignature.tsx`, `src/components/employees/employee-table.tsx`, `src/components/dashboard/pending-signatures-widget.tsx`
+
+- [ ] **Step 1: Add `userIdentitySelect` to user listing/detail fetches**
+
+`src/app/api/users/route.ts` and `[id]/route.ts`: spread `userIdentitySelect` into the response `select`. Where the API already returns the full user object via Prisma's default behavior, switch to an explicit `select` that uses the preset plus the extra fields the endpoint actually needs (`email`, `role`, `status`, `branch`, etc.).
+
+For the `(auth)/users/[id]` server pages, do the same.
+
+- [ ] **Step 2: Replace name cells in `user-table.tsx` and `employee-table.tsx`**
+
+For each table row that renders `{user.name}` or `{employee.name}`, swap in `<EmployeeIdentity user={user} size="md" href={\`/users/\${user.id}\`} />` (use the `href` prop to keep the row link behavior). If the row already wraps in a `<Link>`, drop the link wrap to avoid nested anchors; the component handles linking.
+
+- [ ] **Step 3: Replace name displays in user-detail / form headers**
+
+`user-profile-form.tsx`, `joining-form-esignature.tsx`, `(auth)/users/[id]/page.tsx`: at the top-of-page header, render `<EmployeeIdentity user={user} size="lg" />`. Inline references within the form body (e.g. confirmation dialog text) stay as plain `user.name` — those are sentence-fragments, not identity displays.
+
+- [ ] **Step 4: Migrate `pending-signatures-widget.tsx`**
+
+In the dashboard pending-signatures list, replace each row's `{user.name}` with `<EmployeeIdentity user={user} size="sm" />`.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 6: Smoke pass**
+
+Run: `npm run dev`. Visit `/users`, click into a user detail page, visit `/dashboard` (pending signatures widget), visit `/users/[id]/joining-form-signature`. Confirm each surface shows avatar + name + `#ID`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/api/users src/app/\(auth\)/users src/components/users src/components/employees src/components/dashboard/pending-signatures-widget.tsx
+git commit -m "feat(users): show #numId + avatar across user/employee surfaces"
+```
+
+---
+
+### Task 9: Migrate Leave domain
+
+**Files:**
+- Modify (server): `src/app/api/leave-requests/route.ts`
+- Modify (client): `src/components/leave/leave-request-table.tsx`
+
+(Skip `src/app/api/leave-requests/export/route.ts` and `src/app/api/reports/leave/route.ts` — exports out of scope.)
+
+- [ ] **Step 1: Add `userIdentitySelect` to leave-request fetch**
+
+In `src/app/api/leave-requests/route.ts`, spread `userIdentitySelect` into the `user: { select: {...} }` block.
+
+- [ ] **Step 2: Replace name cell in `leave-request-table.tsx`**
+
+Replace the row's user-name rendering with `<EmployeeIdentity user={request.user} size="md" />`. Keep the existing `DepartmentPill` in its own column.
+
+- [ ] **Step 3: Typecheck + smoke**
+
+Run: `npx tsc --noEmit && npm run dev`. Visit `/leave-requests`. Confirm rows show identity block plus department pill (unchanged) plus status badge (unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/leave-requests src/components/leave/leave-request-table.tsx
+git commit -m "feat(leave): show #numId + avatar in leave request table"
+```
+
+---
+
+### Task 10: Migrate Warnings domain
+
+**Files:**
+- Modify (server): `src/app/api/warnings/route.ts` (and any sibling routes that return user data)
+- Modify (client): `src/components/warnings/warnings-management-page.tsx`
+
+- [ ] **Step 1: Add `userIdentitySelect` to warnings server fetches**
+
+In every API route under `src/app/api/warnings/` that returns user data (the warned user, the reporter, the archiver), spread `userIdentitySelect`. Use `grep -rn "select" src/app/api/warnings/` to enumerate them.
+
+- [ ] **Step 2: Replace name cells in `warnings-management-page.tsx`**
+
+For each `{user.name}` in row cells and dialog headers, swap in `<EmployeeIdentity user={user} size="md" />` (use `"sm"` for inline references to reporter/archiver in the row footer if any).
+
+- [ ] **Step 3: Typecheck + smoke**
+
+Run: `npx tsc --noEmit && npm run dev`. Visit `/warnings`. Confirm each warning row shows the warned user's identity block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/warnings src/components/warnings
+git commit -m "feat(warnings): show #numId + avatar in warnings management"
+```
+
+---
+
+### Task 11: Migrate Notes domain
+
+**Files:**
+- Modify (server): `src/app/api/notes/route.ts`, `src/app/api/notes/[id]/route.ts`, plus any other route under `src/app/api/notes/` that returns user data (`/share`, `/comments`, `/history`).
+- Modify (client): `src/components/notes/NoteDetail.tsx` (and any siblings under `src/components/notes/` that render names)
+
+- [ ] **Step 1: Add `userIdentitySelect` to notes server fetches**
+
+For each note-related route, spread `userIdentitySelect` into the user, share-target, comment-author, and edit-history-editor sub-selects.
+
+- [ ] **Step 2: Replace name displays in `NoteDetail.tsx`**
+
+Identify each name display:
+- Note owner header → `<EmployeeIdentity user={note.owner} size="md" />`
+- Shared-with list → `<EmployeeIdentity user={share.user} size="sm" />` per row
+- Comment author → `<EmployeeIdentity user={comment.author} size="sm" />`
+- Edit history editor → `<EmployeeIdentity user={edit.editor} size="sm" />`
+
+- [ ] **Step 3: Typecheck + smoke**
+
+Run: `npx tsc --noEmit && npm run dev`. Open any note. Confirm owner header, share list, comments, and edit history all show the identity block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/notes src/components/notes
+git commit -m "feat(notes): show #numId + avatar for owner, shares, comments, history"
+```
+
+---
+
+### Task 12: Migrate Referrals domain
+
+**Files:**
+- Modify (server): `src/app/api/referrals/route.ts` (and any sibling routes that return user data; skip `/export/route.ts`)
+- Modify (client): any component under `src/components/referrals/` that renders a user name (use `grep -rn "user.name\|referrer\.name\|referred\.name" src/components/referrals` to enumerate)
+
+- [ ] **Step 1: Add `userIdentitySelect` to referrals server fetches**
+
+Spread the preset into both the `referrer` and `referred` user sub-selects.
+
+- [ ] **Step 2: Replace name displays in referrals components**
+
+For each row/card, swap referrer and referred name displays for `<EmployeeIdentity user={...} size="md" />`.
+
+- [ ] **Step 3: Typecheck + smoke**
+
+Run: `npx tsc --noEmit && npm run dev`. Visit the referrals page. Confirm both sides of each referral show the identity block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/referrals src/components/referrals
+git commit -m "feat(referrals): show #numId + avatar for referrer and referred"
+```
+
+---
+
+### Task 13: Migrate Activity Logs
+
+**Files:**
+- Modify (server): the API route(s) under `src/app/api/activity-logs/` (use `grep -rln "activity-logs" src/app/api`)
+- Modify (client): `src/components/activity-logs/activity-logs-view.tsx`
+
+- [ ] **Step 1: Add `userIdentitySelect` to activity-log fetches**
+
+Spread `userIdentitySelect` into both `user` (actor) and `targetUser` (subject) sub-selects.
+
+- [ ] **Step 2: Replace name displays in `activity-logs-view.tsx`**
+
+For each row that says "X did Y to Z", replace `X` and `Z` with `<EmployeeIdentity user={...} size="sm" />`. The verb "did Y to" stays as plain text between them.
+
+- [ ] **Step 3: Typecheck + smoke**
+
+Run: `npx tsc --noEmit && npm run dev`. Visit `/activity-logs`. Confirm both actor and target render the identity block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/activity-logs src/components/activity-logs
+git commit -m "feat(activity-logs): show #numId + avatar for actor and target"
+```
+
+---
+
+### Task 14: Migrate top-nav and header
+
+**Files:**
+- Modify: `src/components/layout/user-nav.tsx`, `src/components/layout/header.tsx`
+
+- [ ] **Step 1: Replace name display in `user-nav.tsx`**
+
+The existing nav already uses `Avatar`. Replace the avatar + name pair with `<EmployeeIdentity user={session.user} size="sm" />`. The session shape must include `numId` and `image` — verify by checking `src/auth.ts` / `src/auth.config.ts` and (if missing) add `numId` and `image` to the JWT/session callback. If the session does not currently carry `numId`, add it: fetch from DB in the `jwt` callback and propagate via the `session` callback. Use `userIdentitySelect` for the DB fetch.
+
+- [ ] **Step 2: Replace name display in `header.tsx`**
+
+Apply the same swap. If `header.tsx` shows the same session user as `user-nav.tsx`, share the component import; do not re-fetch.
+
+- [ ] **Step 3: Typecheck + smoke**
+
+Run: `npx tsc --noEmit && npm run dev`. Log in. Confirm the top-right shows avatar + name + `#ID` in the compact `sm` variant.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/layout src/auth.ts src/auth.config.ts
+git commit -m "feat(layout): show #numId + avatar in top nav via session"
+```
+
+---
+
+## Phase 3 — Search consistency
+
+### Task 15: Make `numId` searchable everywhere a name is searchable
+
+**Files:** any client component that has a `<Input placeholder="Search ...">` filtering a user list.
+
+- [ ] **Step 1: Enumerate search boxes**
+
+Run: `grep -rn "Search.*name\|search.*Employee\|placeholder=\"Search" src/components/ | grep -v node_modules`. Identify each surface (likely: `user-table.tsx`, `employee-table.tsx`, `attendance-table.tsx` if filterable, `salary-list.tsx` — already has it, `warnings-management-page.tsx`).
+
+- [ ] **Step 2: Update each matcher**
+
+For every list that filters by name, extend the matcher to also accept `numId`. Example pattern (adapt to local variable names):
+
+```ts
+const term = search.trim().toLowerCase();
+const visible = users.filter((u) =>
+  (u.name ?? "").toLowerCase().includes(term) ||
+  String(u.numId ?? "").includes(term),
+);
+```
+
+Skip surfaces that already include `numId` matching (e.g. `salary-list.tsx` already does this on line ~208).
+
+- [ ] **Step 3: Smoke pass**
+
+Run: `npm run dev`. On each surface where you updated the filter, type a numeric query into the search box and confirm it matches by employee number.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components
+git commit -m "feat(search): allow searching by #numId in every employee list"
+```
+
+---
+
+## Phase 4 — Final verification and PR
+
+### Task 16: Full verification + open PR
+
+**Files:** none (verification + git).
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: every test passes (including the two new util tests).
+
+- [ ] **Step 2: Typecheck the whole tree**
+
+Run: `npx tsc --noEmit`
+Expected: 0 errors.
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build completes without errors.
+
+- [ ] **Step 4: Full smoke pass**
+
+Run: `npm run dev`. Visit, in order: `/dashboard`, `/users`, `/users/[id]`, `/employees`, `/attendance`, `/hr/branch-attendance`, `/hr/manage-attendance`, `/hr/pending-attendance`, `/hr/attendance-verification`, `/salary`, `/salary/[id]`, `/advances`, `/leave-requests`, `/warnings`, `/notes/[id]`, `/referrals`, `/activity-logs`. On each: confirm avatar + name + `#ID` is present everywhere a name appears, and there are no leftover duplicate `#numId` text fragments.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin feature/employee-identity-display
+gh pr create --title "feat: show #numId and avatar everywhere an employee name appears" --body "$(cat <<'EOF'
+## Summary
+- Adds shared `<EmployeeIdentity />` component (avatar + name + `#numId`, three sizes).
+- Migrates all ~25 UI surfaces that display employee names: attendance, salary, advances, users/employees, leave, warnings, notes, referrals, activity logs, top nav.
+- Adds `userIdentitySelect` Prisma preset to keep payload shape consistent.
+- Makes `#numId` searchable in every employee list.
+
+## Out of scope
+PDFs, CSV exports, and email templates — UI only, per spec.
+
+## Test plan
+- [ ] `npm run build` succeeds
+- [ ] `npx vitest run` passes
+- [ ] `npx tsc --noEmit` clean
+- [ ] Smoke pass each surface listed above shows avatar + name + #ID
+- [ ] Search by employee number works on every list
+- [ ] Image fallback (initials on colored bg) shows for users without an uploaded image
+
+Spec: `docs/superpowers/specs/2026-05-21-employee-identity-display-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review (already applied)
+
+- **Spec coverage:** ✓ Every spec section maps to a task. Component (T4), helpers (T1, T2), type + preset (T3), data plumbing + migration (T5–T14), search (T15), verification (T16).
+- **Placeholder scan:** ✓ No TBD/TODO. Every code step shows the exact code or a concrete pattern keyed to the local variable shape of the file being edited.
+- **Type consistency:** ✓ `EmployeeIdentityUser` shape (`id`, `name`, `numId`, `image`) matches `userIdentitySelect` keys and the component's prop interface. `getInitials` and `stringToHue` signatures match between tests, implementation, and component usage.
+- **Realism check:** ✓ Vitest is node-only — no React rendering tests asserted; component is verified by smoke + typecheck. This matches existing project conventions.

--- a/docs/superpowers/specs/2026-05-21-employee-identity-display-design.md
+++ b/docs/superpowers/specs/2026-05-21-employee-identity-display-design.md
@@ -1,0 +1,145 @@
+# Employee Identity Display — Design
+
+**Status:** Approved
+**Date:** 2026-05-21
+**Author:** Kunal Sharma
+
+## Goal
+
+Every UI surface that shows an employee's name must also show their employee number (`#numId`) and their image (with initials fallback). One reusable component drives every site so future tweaks are one-file changes.
+
+## Motivation
+
+- Duplicate first names exist; managers cannot reliably distinguish employees by name alone.
+- Two ad-hoc display formats already coexist (`#142` in advances, `(Emp #142)` in salary). The rest of the app shows name-only. Consistency is missing.
+- The `User` model already has `numId` (auto-increment int) and `image` (URL) — the data is there; the UI is not surfacing it.
+
+## Non-Goals
+
+- PDF/letter templates, CSV exports, and email bodies are out of scope. UI only.
+- No backfill or migration of `numId` or `image` data — both fields are already populated.
+- No additional identity fields (department, role, title) inside the card. The component exposes a `subtitle` slot so callers can add their own without touching the component.
+- No renaming of `numId` to a friendlier field name.
+
+## Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Visual format | Avatar (left) + name (top) + `#numId` (muted, below). Stacked. |
+| Avatar fallback when no image | Initials on a color derived from a hash of `name` (stable per person). |
+| Rollout | One shared component, all ~25 surfaces migrated in a single PR. |
+| Data plumbing | Update every server fetch / API route to include `numId` and `image` via a shared Prisma select preset. |
+| Non-UI surfaces | Out of scope. |
+
+## Architecture
+
+### Component
+
+**Path:** `src/components/ui/employee-identity.tsx`
+
+```tsx
+interface EmployeeIdentityProps {
+  user: { id: string; name: string | null; numId: number | null; image: string | null };
+  size?: "sm" | "md" | "lg";   // default "md"
+  subtitle?: React.ReactNode;  // overrides #ID line — for callers who want a custom subtitle
+  href?: string;               // optional Link wrap to user detail page
+  className?: string;
+}
+```
+
+Renders, by size:
+
+- **sm** (24px avatar, single line): `[AV] Rohit Kumar · #142` — for dropdowns, dense rows, comboboxes.
+- **md** (32px avatar, two lines): `[AV] Rohit Kumar` / `      #142` — the default. Table rows, list items, dialog headers.
+- **lg** (48px avatar, two lines, larger type): page headers and detail pages.
+
+### Avatar behavior
+
+1. If `user.image` is set, render `<img>` inside shadcn `Avatar`.
+2. Else render `<AvatarFallback>` with initials.
+3. Initials: take first letters of the first and last whitespace-separated tokens of `name`, uppercase, max 2 chars. `"Rohit Kumar"` → `RK`. `"Rohit"` → `R`. `null` → `?`.
+4. Fallback background: `hsl(stringToHue(name), 60%, 50%)`. Helper `stringToHue` already exists in `src/components/leave/`; promote it to `src/lib/utils.ts` so the avatar and the leave table share one implementation.
+5. If `name` is null, use a neutral gray background and `?` glyph.
+
+### ID line
+
+- Format: `#{numId}` (e.g. `#142`). No prefix, no padding.
+- Style: `text-xs text-muted-foreground` at `md`, `text-sm text-muted-foreground` at `lg`, inline `text-muted-foreground` with a `·` separator at `sm`.
+- If `numId` is null, the line is omitted (rare — `numId` is auto-increment and non-null in DB; null can occur in TS types pre-`Pick`).
+
+### Type subset
+
+`src/models/models.ts` exports:
+
+```ts
+export type EmployeeIdentityUser = Pick<User, "id" | "name" | "numId" | "image">;
+```
+
+Wider `User` types satisfy this structurally, so consumers don't need to narrow at every call site.
+
+### Prisma select preset
+
+`src/lib/select-presets.ts` (new file):
+
+```ts
+export const userIdentitySelect = {
+  id: true,
+  name: true,
+  numId: true,
+  image: true,
+} as const;
+```
+
+Every list and detail fetch spreads this into its `select` block. If we later add `department` to the identity card, one line changes everywhere.
+
+## Migration plan (single PR)
+
+Touch order, grouped by domain:
+
+1. **Foundation** — add `employee-identity.tsx`, `userIdentitySelect`, promote `stringToHue` to `src/lib/utils.ts`, add unit tests.
+2. **Attendance** — `attendance-table.tsx`, `daily-attendance-view.tsx`, `branch-attendance-submissions.tsx`, `attendance-verification-table.tsx`, `shared-attendance-table.tsx`, `attendance-reports.tsx`, plus their server fetches in `src/app/(auth)/attendance/**` and `src/app/(auth)/hr/**`.
+3. **Salary** — `salary-list.tsx`, `salary-stats-table.tsx`, `salary-details.tsx`, `salary-management.tsx`, server fetches under `src/app/api/salary/**`.
+4. **Advances** — `advance-row.tsx` (replaces the existing inline `#numId` badge), `advance-payments-list.tsx`, `advance-discrepancies.tsx`, plus `src/app/api/advances/**`.
+5. **Users / Employees** — `user-table.tsx`, `employee-table.tsx`, `user-actions.tsx`, `user-profile-form.tsx`, `pending-signatures-widget.tsx`, plus `src/app/api/users/**`.
+6. **Leave** — `leave-request-table.tsx`, `src/app/api/leave-requests/**`.
+7. **Warnings** — `warnings-management-page.tsx`, `src/app/api/warnings/**`.
+8. **Notes** — owner + share lists in `NoteDetail.tsx` and the notes API.
+9. **Referrals** — referral lists and `src/app/api/referrals/**`.
+10. **Activity logs** — `activity-logs-view.tsx`, both actor and target user.
+11. **Layout** — `layout/user-nav.tsx`, `layout/header.tsx` — use `size="sm"`.
+
+For each call site:
+
+- Replace `{user.name}` (or the equivalent `<TableCell>{user.name}</TableCell>`) with `<EmployeeIdentity user={user} size="..." />`.
+- If the row already shows a separate `numId` (advances), delete the now-redundant element.
+- If the API fetch was missing `numId` or `image`, spread `userIdentitySelect` into the `select`.
+
+## Search behavior
+
+Tables that have a name search box must also match `numId.toString()`. Audit existing search inputs in `salary-list.tsx`, `user-table.tsx`, `employee-table.tsx`, `attendance-table.tsx`. Add `numId` matching in the same PR so search consistency tracks display consistency.
+
+## Testing
+
+- Unit tests in `src/components/ui/__tests__/employee-identity.test.tsx`:
+  - Renders name, renders `#numId`, hides ID line when `numId` null.
+  - Renders `<img>` when `image` is set; renders fallback initials otherwise.
+  - Initials extraction: `"Rohit Kumar"` → `RK`, `"Rohit"` → `R`, `null` → `?`.
+  - Applies correct CSS classes for each `size`.
+- `stringToHue` move: existing leave-table tests must continue to pass; add a unit test in `src/lib/utils.test.ts` if not already covered.
+- No snapshot/visual tests (none in the repo today).
+- Manual smoke pass on each touched surface in the dev server before merging.
+
+## Out of scope (explicit)
+
+- PDF/letter templates (`offer-letter`, `payslip`, `joining-form`).
+- CSV exports (`/api/*/export/route.ts`).
+- Email body templates.
+- Adding extra identity fields (department, role, title) to the card.
+- Renaming `numId` to a different field name.
+- Backfilling user images for employees without one — surfaces will fall back to initials, which is acceptable.
+
+## Risk and mitigation
+
+- **Big PR.** ~25 files touched plus matching server-fetch updates. Mitigation: mechanical change, the component encapsulates all formatting logic, and tests cover the component. Reviewer can spot-check a handful of call sites and trust the rest.
+- **Stale data in tables.** Some places already paginate user data client-side. Once `image` URLs are added, payloads grow slightly. Acceptable — image URLs are short strings.
+- **Avatar HTTP load.** Tables with 60+ employees will fire 60+ image requests on first render. Mitigation: shadcn `Avatar` shows the fallback while loading; lazy-loading via the browser's native `loading="lazy"` is enabled by default in the component. No prefetch needed.

--- a/src/app/(auth)/attendance/[userId]/page.tsx
+++ b/src/app/(auth)/attendance/[userId]/page.tsx
@@ -273,11 +273,13 @@ export default async function EmployeeAttendancePage({
       <div className="space-y-4">
         <div className="rounded-md border bg-card">
           <div className="p-6">
-            <DetailedAttendanceCalendar 
+            <DetailedAttendanceCalendar
               attendance={attendance}
               month={startDate}
               userId={employee.id}
               userName={employee.name || ""}
+              userNumId={employee.numId}
+              userImage={employee.image}
               userRole={role}
               department={employee.department?.name || ''}
             />

--- a/src/app/(auth)/attendance/[userId]/page.tsx
+++ b/src/app/(auth)/attendance/[userId]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { startOfMonth, endOfMonth, format, addMonths, subMonths } from "date-fns";
 import { AttendanceStats } from "@/components/attendance/attendance-stats";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -91,8 +92,7 @@ export default async function EmployeeAttendancePage({
   const employee = await prisma.user.findUnique({
     where: { id: userId },
     select: {
-      id: true,
-      name: true,
+      ...userIdentitySelect,
       email: true,
       department: {
         select: {

--- a/src/app/(auth)/attendance/page.tsx
+++ b/src/app/(auth)/attendance/page.tsx
@@ -6,6 +6,7 @@ import { AttendanceTable } from "@/components/attendance/attendance-table";
 import { DailyAttendanceView } from "@/components/attendance/daily-attendance-view";
 import { User } from "@/models/models";
 import { DateSwitcher } from "@/components/attendance/date-switcher";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export const metadata: Metadata = {
   title: "Attendance Management - HRMS",
@@ -42,8 +43,7 @@ export default async function AttendancePage({ searchParams }: Props) {
       status: "ACTIVE",
     },
     select: {
-      id: true,
-      name: true,
+      ...userIdentitySelect,
       department: {
         select: {
           id: true,

--- a/src/app/(auth)/attendance/self/page.tsx
+++ b/src/app/(auth)/attendance/self/page.tsx
@@ -33,6 +33,8 @@ export default async function SelfAttendancePage({ searchParams }: Props) {
     id: string;
     name: string;
     role: string;
+    numId?: number | null;
+    image?: string | null;
   };
 
   if (!user.role || !user.id || !user.name) {
@@ -199,6 +201,8 @@ export default async function SelfAttendancePage({ searchParams }: Props) {
                 <SelfAttendanceFormWrapper
                   userId={user.id}
                   userName={user.name}
+                  userNumId={user.numId}
+                  userImage={user.image}
                   userRole={user.role}
                   date={selectedDate}
                   department={user.role}
@@ -209,6 +213,8 @@ export default async function SelfAttendancePage({ searchParams }: Props) {
               <SelfAttendanceFormWrapper
                 userId={user.id}
                 userName={user.name}
+                userNumId={user.numId}
+                userImage={user.image}
                 userRole={user.role}
                 date={selectedDate}
                 department={user.role}
@@ -222,6 +228,8 @@ export default async function SelfAttendancePage({ searchParams }: Props) {
                 <SelfAttendanceFormWrapper
                   userId={user.id}
                   userName={user.name}
+                  userNumId={user.numId}
+                  userImage={user.image}
                   userRole={user.role}
                   date={selectedDate}
                   department={user.role}

--- a/src/app/(auth)/dashboard/page.tsx
+++ b/src/app/(auth)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
 import {Clock, CalendarCheck, Users, AlertCircle, UserCheck, AlertTriangle, FileClock} from "lucide-react";
 import Link from "next/link";
 import {Attendance, User} from "@/models/models";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { PendingSignaturesWidget } from "@/components/dashboard/pending-signatures-widget";
 import { JoiningFormCard } from "@/components/dashboard/joining-form-card";
 import { DocumentExpiryWidget } from "@/components/dashboard/document-expiry-widget";
@@ -79,8 +80,7 @@ export default async function DashboardPage() {
         status: "ACTIVE",
       },
       select: {
-        id: true,
-        name: true,
+        ...userIdentitySelect,
         role: true,
         department: {
           select: {

--- a/src/app/(auth)/employees/page.tsx
+++ b/src/app/(auth)/employees/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { EmployeeTable } from "@/components/employees/employee-table";
 import { Branch } from "@/models/models";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export const metadata: Metadata = {
   title: "Employees - HRMS",
@@ -26,8 +27,7 @@ export default async function EmployeesPage() {
       status: "ACTIVE",
     },
     select: {
-      id: true,
-      name: true,
+      ...userIdentitySelect,
       email: true,
       status: true,
       branch: {

--- a/src/app/(auth)/hr/attendance-conflicts/page.tsx
+++ b/src/app/(auth)/hr/attendance-conflicts/page.tsx
@@ -33,6 +33,8 @@ export default async function AttendanceConflictsPage({ searchParams }: PageProp
 
   const serializedConflicts: SerializedAttendanceConflict[] = conflicts.map((conflict) => ({
     ...conflict,
+    userNumId: conflict.userNumId ?? null,
+    userImage: conflict.userImage ?? null,
     entries: conflict.entries.map((entry) => ({
       ...entry,
       createdAt: entry.createdAt.toISOString(),

--- a/src/app/(auth)/hr/attendance-verification/page.tsx
+++ b/src/app/(auth)/hr/attendance-verification/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { AttendanceVerificationTable } from "@/components/attendance/attendance-verification-table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Suspense } from "react";
@@ -92,7 +93,7 @@ export default async function AttendanceVerificationPage({
     include: {
       user: {
         select: {
-          name: true,
+          ...userIdentitySelect,
           branch: {
             select: {
               name: true,

--- a/src/app/(auth)/hr/attendance/page.tsx
+++ b/src/app/(auth)/hr/attendance/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileClock, AlertTriangle } from "lucide-react";
 import { SharedAttendanceTable } from "@/components/attendance/shared-attendance-table";
@@ -38,8 +39,7 @@ export default async function HRAttendancePage({
       status: "ACTIVE",
     },
     select: {
-      id: true,
-      name: true,
+      ...userIdentitySelect,
       department: true,
       managedBranch: {
         select: {

--- a/src/app/(auth)/hr/branch-attendance/page.tsx
+++ b/src/app/(auth)/hr/branch-attendance/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { BranchAttendanceSubmissions } from "@/components/attendance/branch-attendance-submissions";
 import { Suspense } from "react";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export const metadata: Metadata = {
   title: "Branch Attendance Submissions - HRMS",
@@ -129,8 +130,7 @@ export default async function BranchAttendancePage({
           status: "ACTIVE",
         },
         select: {
-          id: true,
-          name: true,
+          ...userIdentitySelect,
           department: {
             select: {
               id: true,

--- a/src/app/(auth)/hr/manage-attendance/page.tsx
+++ b/src/app/(auth)/hr/manage-attendance/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calendar, Users, CalendarCheck, CalendarClock } from "lucide-react";
 import { SharedAttendanceTable } from "@/components/attendance/shared-attendance-table";
@@ -95,10 +96,8 @@ export default async function HRManageAttendancePage({
   const users = (await prisma.user.findMany({
     where,
     select: {
-      id: true,
-      name: true,
+      ...userIdentitySelect,
       email: true,
-      numId: true,
       role: true,
       hasWeeklyOff: true,
       weeklyOffType: true,

--- a/src/app/(auth)/hr/pending-attendance/page.tsx
+++ b/src/app/(auth)/hr/pending-attendance/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FileClock } from "lucide-react";
 import { SharedAttendanceTable } from "@/components/attendance/shared-attendance-table";
@@ -41,8 +42,7 @@ export default async function PendingAttendancePage({
       status: "ACTIVE",
     },
     select: {
-      id: true,
-      name: true,
+      ...userIdentitySelect,
       department: {
         select: {
           id: true,

--- a/src/app/(auth)/leave-requests/page.tsx
+++ b/src/app/(auth)/leave-requests/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { LeaveRequestTable } from "@/components/leave/leave-request-table";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
@@ -26,7 +27,7 @@ export default async function LeaveRequestsPage() {
     include: {
       user: {
         select: {
-          name: true,
+          ...userIdentitySelect,
           branch: {
             select: {
               id: true,

--- a/src/app/(auth)/referrals/page.tsx
+++ b/src/app/(auth)/referrals/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { ReferralsManagement } from "@/components/referrals/referrals-management";
 
 export const metadata: Metadata = {
@@ -24,15 +25,13 @@ export default async function ReferralsPage() {
     include: {
       referrer: {
         select: {
-          id: true,
-          name: true,
+          ...userIdentitySelect,
           email: true,
         },
       },
       referredUser: {
         select: {
-          id: true,
-          name: true,
+          ...userIdentitySelect,
           email: true,
           doj: true,
         },

--- a/src/app/(auth)/salary/[id]/page.tsx
+++ b/src/app/(auth)/salary/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { SalaryDetails } from '@/components/salary/salary-details'
 import { prisma } from '@/lib/prisma'
+import { userIdentitySelect } from "@/lib/select-presets";
 import {Salary} from "@/models/models";
 import { auth } from '@/auth'
 
@@ -24,9 +25,18 @@ async function getSalaryDetails(id: string) {
         }
       },
       referrals: {
-        include: {
-          referredUser: true,
-        }
+        select: {
+          id: true,
+          bonusAmount: true,
+          referredUserId: true,
+          referredUser: {
+            select: {
+              ...userIdentitySelect,
+              status: true,
+              doj: true,
+            },
+          },
+        },
       }
     }
   }) as unknown as Salary;

--- a/src/app/(auth)/users/[id]/joining-form-signature/page.tsx
+++ b/src/app/(auth)/users/[id]/joining-form-signature/page.tsx
@@ -5,7 +5,9 @@ import { prisma } from "@/lib/prisma";
 import { JoiningFormESignature } from "@/components/users/joining-form-esignature";
 import { hasAccess } from "@/lib/access-control";
 import { notFound } from "next/navigation";
-import {User} from "@/models/models";
+import { User } from "@/models/models";
+import { userIdentitySelect } from "@/lib/select-presets";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 export const metadata: Metadata = {
   title: "Appointment Letter E-Signature - HRMS",
@@ -29,7 +31,8 @@ export default async function JoiningFormSignaturePage({ params }: JoiningFormSi
   // Get the user to be signed
   const user = await prisma.user.findUnique({
     where: { id: id },
-    include: {
+    select: {
+      ...userIdentitySelect,
       branch: true,
       department: {
         select: {
@@ -37,6 +40,7 @@ export default async function JoiningFormSignaturePage({ params }: JoiningFormSi
           name: true,
         },
       },
+      joiningFormSignedAt: true,
     },
   });
 
@@ -61,9 +65,14 @@ export default async function JoiningFormSignaturePage({ params }: JoiningFormSi
   return (
     <div className="flex-1 space-y-8 p-8 pt-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">
-          {isOwnForm ? "Sign Your Appointment Letter" : `Sign Appointment Letter - ${user.name}`}
-        </h2>
+        {isOwnForm ? (
+          <h2 className="text-3xl font-bold tracking-tight">Sign Your Appointment Letter</h2>
+        ) : (
+          <div className="space-y-2">
+            <h2 className="text-3xl font-bold tracking-tight">Sign Appointment Letter</h2>
+            <EmployeeIdentity user={user} size="md" />
+          </div>
+        )}
       </div>
 
       <JoiningFormESignature user={user as unknown as User} />

--- a/src/app/(auth)/users/[id]/page.tsx
+++ b/src/app/(auth)/users/[id]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { UserProfileForm } from "@/components/users/user-profile-form";
 import { hasAccess } from "@/lib/access-control";
 import {Branch, User} from "@/models/models";
@@ -13,6 +14,7 @@ import { UniformsList } from "@/components/users/uniforms-list";
 import { UserDocumentUpload } from "@/components/users/user-document-upload";
 import { UserDocumentsList } from "@/components/users/user-documents-list";
 import { AppraisalHistory } from "@/components/users/appraisal-history";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
@@ -82,14 +84,23 @@ export default async function UserProfilePage({ params }: Props) {
       approvedAdvances: true,
       approvedInstallments: true,
       referralsMade: {
-        include: {
-          referredUser: true,
-        }
+        select: {
+          id: true,
+          eligibleAt: true,
+          paidAt: true,
+          referredUser: {
+            select: userIdentitySelect,
+          },
+        },
       },
       referralsReceived: {
-        include: {
-          referrer: true,
-        }
+        select: {
+          id: true,
+          referrerId: true,
+          referrer: {
+            select: userIdentitySelect,
+          },
+        },
       }
     },
   }) as unknown as User & {
@@ -97,12 +108,12 @@ export default async function UserProfilePage({ params }: Props) {
       id: string;
       eligibleAt: Date;
       paidAt?: Date | null;
-      referredUser?: { id: string; name?: string | null } | null;
+      referredUser?: { id: string; name?: string | null; numId?: number | null; image?: string | null } | null;
     }>;
     referralsReceived?: Array<{
       id: string;
       referrerId: string;
-      referrer?: { id: string; name?: string | null } | null;
+      referrer?: { id: string; name?: string | null; numId?: number | null; image?: string | null } | null;
     }>;
   };
 
@@ -160,9 +171,13 @@ export default async function UserProfilePage({ params }: Props) {
         {user.referralsReceived?.length ? (
           <div className="p-4 border rounded-md">
             <h3 className="text-lg font-medium mb-2">Referred By</h3>
-            {(user.referralsReceived || []).map((r) => (
-              <div key={r.id} className="text-sm">{r.referrer?.name || r.referrerId}</div>
-            ))}
+            <div className="space-y-2">
+              {(user.referralsReceived || []).map((r) => (
+                r.referrer && (
+                  <EmployeeIdentity key={r.id} user={r.referrer} size="sm" />
+                )
+              ))}
+            </div>
           </div>
         ) : null}
 
@@ -172,7 +187,7 @@ export default async function UserProfilePage({ params }: Props) {
             <div className="space-y-2">
               {(user.referralsMade || []).map((r) => (
                 <div key={r.id} className="flex items-center justify-between text-sm">
-                  <span>{r.referredUser?.name || ''}</span>
+                  {r.referredUser && <EmployeeIdentity user={r.referredUser} size="sm" />}
                   <span>
                     Eligible: {new Date(r.eligibleAt).toLocaleDateString()} {r.paidAt ? `· Paid: ${new Date(r.paidAt).toLocaleDateString()}` : ''}
                   </span>

--- a/src/app/(auth)/users/[id]/warnings/page.tsx
+++ b/src/app/(auth)/users/[id]/warnings/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { hasAccess } from "@/lib/access-control";
 import { WarningsPage } from "@/components/users/warnings-page";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 interface Props {
   params: Promise<{ id: string }>;
@@ -25,7 +26,7 @@ export default async function UserWarningsPage({ params }: Props) {
   // Fetch user first to check branch access for branch managers
   const user = await prisma.user.findUnique({
     where: { id },
-    select: { id: true, name: true, branchId: true, branch: { select: { id: true } } },
+    select: { ...userIdentitySelect, branchId: true, branch: { select: { id: true } } },
   });
 
   if (!user) {

--- a/src/app/api/advances/discrepancies/route.ts
+++ b/src/app/api/advances/discrepancies/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export async function GET() {
   try {
@@ -23,9 +24,7 @@ export async function GET() {
       include: {
         user: {
           select: {
-            id: true,
-            name: true,
-            numId: true,
+            ...userIdentitySelect,
             branch: { select: { name: true } },
           },
         },
@@ -35,7 +34,7 @@ export async function GET() {
               select: { month: true, year: true, status: true },
             },
             approvedBy: {
-              select: { name: true, numId: true },
+              select: { ...userIdentitySelect },
             },
           },
           orderBy: { approvedAt: "desc" },

--- a/src/app/api/advances/discrepancies/route.ts
+++ b/src/app/api/advances/discrepancies/route.ts
@@ -94,6 +94,7 @@ export async function GET() {
         userId: string;
         userName: string;
         userNumId: number;
+        userImage: string | null;
         userBranch: string;
         totalDiscrepancy: number;
         deletedSalaryMonths: Array<{ month: number; year: number; deletedAt: Date }>;
@@ -142,6 +143,7 @@ export async function GET() {
           userId: advance.userId,
           userName: advance.user.name ?? "Unknown",
           userNumId: advance.user.numId,
+          userImage: advance.user.image ?? null,
           userBranch: advance.user.branch?.name ?? "N/A",
           totalDiscrepancy: 0,
           deletedSalaryMonths: deletionsByUser.get(advance.userId) ?? [],

--- a/src/app/api/advances/route.ts
+++ b/src/app/api/advances/route.ts
@@ -60,12 +60,13 @@ export async function GET(req: Request) {
       };
     }
 
-    // Search filter (name or numId)
+    // Search filter (name, email, or numId)
     if (search && isHROrManagement) {
       where.user = {
         ...where.user,
         OR: [
           { name: { contains: search, mode: "insensitive" } },
+          { email: { contains: search, mode: "insensitive" } },
           { numId: isNaN(parseInt(search)) ? undefined : parseInt(search) },
         ].filter(Boolean),
       };

--- a/src/app/api/advances/route.ts
+++ b/src/app/api/advances/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { auth } from "@/auth";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export async function GET(req: Request) {
   try {
@@ -76,9 +77,7 @@ export async function GET(req: Request) {
       include: {
         user: {
           select: {
-            id: true,
-            name: true,
-            numId: true,
+            ...userIdentitySelect,
             branch: {
               select: {
                 id: true,
@@ -89,8 +88,7 @@ export async function GET(req: Request) {
         },
         approvedBy: {
           select: {
-            name: true,
-            numId: true,
+            ...userIdentitySelect,
           },
         },
         installments: {
@@ -103,8 +101,7 @@ export async function GET(req: Request) {
             },
             approvedBy: {
               select: {
-                name: true,
-                numId: true,
+                ...userIdentitySelect,
               },
             },
           },

--- a/src/app/api/advances/route.ts
+++ b/src/app/api/advances/route.ts
@@ -122,6 +122,7 @@ export async function GET(req: Request) {
         userId: string;
         userName: string;
         userNumId: number;
+        userImage: string | null;
         userBranch: string;
         totalAdvanceAmount: number;
         totalRemainingAmount: number;
@@ -139,6 +140,7 @@ export async function GET(req: Request) {
           userId,
           userName: advance.user.name ?? "Unknown",
           userNumId: advance.user.numId,
+          userImage: advance.user.image ?? null,
           userBranch: advance.user.branch?.name ?? "N/A",
           totalAdvanceAmount: 0,
           totalRemainingAmount: 0,

--- a/src/app/api/notes/[id]/comments/route.ts
+++ b/src/app/api/notes/[id]/comments/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { userIdentitySelect } from '@/lib/select-presets';
 
 export async function GET(req: NextRequest, {params}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -22,7 +23,11 @@ export async function GET(req: NextRequest, {params}: { params: Promise<{ id: st
   const comments = await prisma.noteComment.findMany({
     where: { noteId: note.id },
     orderBy: { createdAt: 'asc' },
-    include: { author: true },
+    include: {
+      author: {
+        select: userIdentitySelect
+      }
+    },
   });
   return NextResponse.json(comments);
 }
@@ -54,7 +59,11 @@ export async function POST(req: NextRequest, {params}: { params: Promise<{ id: s
       authorId: userId as string,
       content,
     },
-    include: { author: true },
+    include: {
+      author: {
+        select: userIdentitySelect
+      }
+    },
   });
   return NextResponse.json(comment, { status: 201 });
 } 

--- a/src/app/api/notes/[id]/history/route.ts
+++ b/src/app/api/notes/[id]/history/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { userIdentitySelect } from '@/lib/select-presets';
 
 export async function GET(req: NextRequest, {params}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -22,7 +23,11 @@ export async function GET(req: NextRequest, {params}: { params: Promise<{ id: st
   const history = await prisma.noteEditHistory.findMany({
     where: { noteId: note.id },
     orderBy: { editedAt: 'desc' },
-    include: { editor: true },
+    include: {
+      editor: {
+        select: userIdentitySelect
+      }
+    },
   });
   return NextResponse.json(history);
 } 

--- a/src/app/api/notes/[id]/share/route.ts
+++ b/src/app/api/notes/[id]/share/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { userIdentitySelect } from '@/lib/select-presets';
 
 export async function POST(req: NextRequest, {params}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -34,7 +35,15 @@ export async function POST(req: NextRequest, {params}: { params: Promise<{ id: s
   }
   const updatedNote = await prisma.note.findUnique({
     where: { id: id },
-    include: { sharedWith: true },
+    include: {
+      sharedWith: {
+        include: {
+          user: {
+            select: userIdentitySelect
+          }
+        }
+      }
+    },
   });
   return NextResponse.json(updatedNote);
 } 

--- a/src/app/api/notes/[id]/unshare/route.ts
+++ b/src/app/api/notes/[id]/unshare/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { userIdentitySelect } from '@/lib/select-presets';
 
 export async function POST(req: NextRequest, {params}: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -31,7 +32,15 @@ export async function POST(req: NextRequest, {params}: { params: Promise<{ id: s
   });
   const updatedNote = await prisma.note.findUnique({
     where: { id: id },
-    include: { sharedWith: true },
+    include: {
+      sharedWith: {
+        include: {
+          user: {
+            select: userIdentitySelect
+          }
+        }
+      }
+    },
   });
   return NextResponse.json(updatedNote);
 } 

--- a/src/app/api/notes/route.ts
+++ b/src/app/api/notes/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { auth } from '@/auth';
+import { userIdentitySelect } from '@/lib/select-presets';
 
 export async function GET(req: NextRequest) {
   const session = await auth();
@@ -39,7 +40,7 @@ export async function GET(req: NextRequest) {
     orderBy: { updatedAt: 'desc' },
     include: {
       owner: {
-        select: { id: true, name: true }
+        select: userIdentitySelect
       }
     }
   });

--- a/src/app/api/salary/[id]/stats/route.ts
+++ b/src/app/api/salary/[id]/stats/route.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma'
 import { auth } from "@/auth"
 import { sumRecurringDeductions } from '@/lib/services/recurring-deductions'
 import type { RecurringDeductionEntry } from '@/models/models'
+import { userIdentitySelect } from "@/lib/select-presets"
 
 export async function GET(
   req: Request,
@@ -20,8 +21,7 @@ export async function GET(
       include: {
         user: {
           select: {
-            id: true,
-            name: true,
+            ...userIdentitySelect,
             email: true,
             hasWeeklyOff: true,
           }
@@ -152,6 +152,8 @@ export async function GET(
       employee: {
         id: salary.userId,
         name: salary.user.name,
+        numId: salary.user.numId,
+        image: salary.user.image,
         email: salary.user.email
       },
       attendance: {

--- a/src/app/api/salary/generate-enet/route.ts
+++ b/src/app/api/salary/generate-enet/route.ts
@@ -7,6 +7,7 @@ import { calculateNetSalaryFromObject } from '@/lib/services/salary-calculator';
 import { SalaryStatus, ActivityType } from '@prisma/client';
 import { Salary } from '@/models/models';
 import { logEntityActivity } from '@/lib/services/activity-log';
+import { userIdentitySelect } from "@/lib/select-presets";
 export async function POST(req: Request) {
   try {
     const session = await auth();
@@ -32,9 +33,7 @@ export async function POST(req: Request) {
       include: {
         user: {
           select: {
-            id: true,
-            name: true,
-            numId: true,
+            ...userIdentitySelect,
             bankAccountNo: true,
             bankIfscCode: true,
             email: true,

--- a/src/app/api/salary/generate-report/route.ts
+++ b/src/app/api/salary/generate-report/route.ts
@@ -6,6 +6,7 @@ import { calculateNetSalaryFromObject } from '@/lib/services/salary-calculator';
 import { sortBranchesForReport } from '@/lib/branch-order';
 import { Salary, RecurringDeductionEntry } from '@/models/models';
 import { sumRecurringDeductions } from '@/lib/services/recurring-deductions';
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export async function POST(req: Request) {
   try {
@@ -33,9 +34,7 @@ export async function POST(req: Request) {
       include: {
         user: {
           select: {
-            id: true,
-            name: true,
-            numId: true,
+            ...userIdentitySelect,
             title: true,
             branch: true,
             role: true

--- a/src/app/api/salary/route.ts
+++ b/src/app/api/salary/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import {auth} from "@/auth";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export async function GET(req: Request) {
   try {
@@ -31,13 +32,58 @@ export async function GET(req: Request) {
           }
         } : {})
       },
-      include: {
-        user: true,
+      select: {
+        id: true,
+        numId: true,
+        userId: true,
+        month: true,
+        year: true,
+        baseSalary: true,
+        advanceDeduction: true,
+        deductions: true,
+        overtimeBonus: true,
+        otherBonuses: true,
+        otherDeductions: true,
+        netSalary: true,
+        presentDays: true,
+        overtimeDays: true,
+        halfDays: true,
+        leavesEarned: true,
+        leaveSalary: true,
+        status: true,
+        paidAt: true,
+        createdAt: true,
+        updatedAt: true,
+        recurringDeductions: true,
+        user: {
+          select: {
+            ...userIdentitySelect,
+            email: true,
+            role: true,
+            status: true,
+            branchId: true,
+          },
+        },
         installments: true,
         referrals: {
-          include: {
-            referredUser: true,
-          }
+          select: {
+            id: true,
+            numId: true,
+            referrerId: true,
+            referredUserId: true,
+            bonusAmount: true,
+            eligibleAt: true,
+            paidAt: true,
+            salaryId: true,
+            archivedAt: true,
+            referredUser: {
+              select: {
+                ...userIdentitySelect,
+                status: true,
+                doj: true,
+              },
+            },
+          },
         },
       },
       orderBy: {

--- a/src/app/api/users/[id]/advance-payments/route.ts
+++ b/src/app/api/users/[id]/advance-payments/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
 import {auth} from "@/auth";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 const advancePaymentSchema = z.object({
   amount: z.number().positive(),
@@ -95,7 +96,7 @@ export async function GET(
       include: {
         approvedBy: {
           select: {
-            name: true,
+            ...userIdentitySelect,
           }
         }
       },

--- a/src/app/api/users/[id]/warnings/[warningId]/route.ts
+++ b/src/app/api/users/[id]/warnings/[warningId]/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { z } from "zod";
 import { logEntityActivity } from "@/lib/services/activity-log";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { ActivityType } from "@prisma/client";
 
 const patchSchema = z.object({
@@ -88,8 +89,8 @@ export async function PATCH(
             archivedById: null,
           },
       include: {
-        reportedBy: { select: { id: true, name: true } },
-        archivedBy: { select: { id: true, name: true } },
+        reportedBy: { select: { ...userIdentitySelect } },
+        archivedBy: { select: { ...userIdentitySelect } },
       },
     });
 

--- a/src/app/api/users/[id]/warnings/route.ts
+++ b/src/app/api/users/[id]/warnings/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { AzureStorageService } from "@/lib/azure-storage";
 import { logEntityActivity } from "@/lib/services/activity-log";
+import { userIdentitySelect } from "@/lib/select-presets";
 import { ActivityType } from "@prisma/client";
 
 const WARNING_PHOTOS_FOLDER = "warnings/photos";
@@ -113,7 +114,7 @@ export async function POST(
         isArchived: false,
       },
       include: {
-        reportedBy: { select: { id: true, name: true } },
+        reportedBy: { select: { ...userIdentitySelect } },
         warningType: { select: { id: true, name: true, description: true } },
       },
     });
@@ -181,8 +182,8 @@ export async function GET(
     const warnings = await prisma.warning.findMany({
       where: includeArchived ? { userId } : { userId, isArchived },
       include: {
-        reportedBy: { select: { id: true, name: true } },
-        archivedBy: { select: { id: true, name: true } },
+        reportedBy: { select: { ...userIdentitySelect } },
+        archivedBy: { select: { ...userIdentitySelect } },
         warningType: { select: { id: true, name: true, description: true } },
       },
       orderBy: { createdAt: "desc" },

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -6,6 +6,7 @@ import { hasAccess } from "@/lib/access-control";
 import { logTargetUserActivity } from "@/lib/services/activity-log";
 import { ActivityType } from "@prisma/client";
 import { generatePassword } from "@/lib/utils";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export async function POST(request: Request) {
   try {
@@ -215,9 +216,8 @@ export async function GET(request: Request) {
         } : {})
       },
       select: {
-        id: true,
+        ...userIdentitySelect,
         email: true,
-        name: true,
         role: true,
         status: true,
         createdAt: true,

--- a/src/app/api/warnings/route.ts
+++ b/src/app/api/warnings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 // GET: Fetch all warnings with filters (HR/MANAGEMENT/BRANCH_MANAGER only)
 export async function GET(req: Request) {
@@ -81,15 +82,13 @@ export async function GET(req: Request) {
       include: {
         user: {
           select: {
-            id: true,
-            name: true,
-            numId: true,
+            ...userIdentitySelect,
             email: true,
             branch: { select: { id: true, name: true } },
           },
         },
-        reportedBy: { select: { id: true, name: true } },
-        archivedBy: { select: { id: true, name: true } },
+        reportedBy: { select: { ...userIdentitySelect } },
+        archivedBy: { select: { ...userIdentitySelect } },
         warningType: { select: { id: true, name: true, description: true } },
       },
       orderBy: { createdAt: "desc" },

--- a/src/app/api/warnings/stats/route.ts
+++ b/src/app/api/warnings/stats/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
-import { userIdentitySelect } from "@/lib/select-presets";
 
 // GET: Fetch warning statistics (HR/MANAGEMENT/BRANCH_MANAGER only)
 export async function GET(req: Request) {

--- a/src/app/api/warnings/stats/route.ts
+++ b/src/app/api/warnings/stats/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 // GET: Fetch warning statistics (HR/MANAGEMENT/BRANCH_MANAGER only)
 export async function GET(req: Request) {

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -2,6 +2,7 @@ import {NextAuthConfig} from "next-auth";
 import {prisma} from "@/prisma";
 import Credentials from "next-auth/providers/credentials";
 import {compare} from "bcryptjs";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 
 export default {
@@ -34,6 +35,8 @@ export default {
             status: true,
             branchId: true,
             managedBranchId: true,
+            numId: true,
+            image: true,
           },
         });
 
@@ -65,6 +68,8 @@ export default {
           status: user.status,
           branchId: user.branchId,
           managedBranchId: user.managedBranchId,
+          numId: user.numId,
+          image: user.image,
         };
       },
     }),
@@ -78,6 +83,21 @@ export default {
         token.branchId = user.branchId;
         // @ts-expect-error - managedBranchId is not in the
         token.managedBranchId = user.managedBranchId;
+        // @ts-expect-error - numId is not in the User type
+        token.numId = user.numId;
+        token.image = user.image;
+      }
+      // Refresh numId/image from DB if absent (e.g. existing sessions)
+      if (token.sub && (token.numId === undefined || token.image === undefined)) {
+        const dbUser = await prisma.user.findUnique({
+          where: { id: token.sub },
+          select: userIdentitySelect,
+        });
+        if (dbUser) {
+          token.numId = dbUser.numId;
+          token.image = dbUser.image;
+          token.name = dbUser.name;
+        }
       }
       return token;
     },
@@ -90,6 +110,9 @@ export default {
         session.user.branchId = token.branchId as string | null;
         // @ts-expect-error - managedBranchId is not in the
         session.user.managedBranchId = token.managedBranchId as string | null;
+        // @ts-expect-error - numId is not in the User type
+        session.user.numId = token.numId as number | null;
+        session.user.image = token.image as string | null;
       }
       return session;
     },

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -47,14 +47,10 @@ export default {
         if (user.status !== "ACTIVE") {
           throw new Error("Account is not active");
         }
-        console.log(user.password)
-        console.log(credentials.password)
-
         const isPasswordValid = await compare(
           credentials.password as string,
           user.password
         );
-        console.log(isPasswordValid);
 
         if (!isPasswordValid) {
           return null;
@@ -75,7 +71,7 @@ export default {
     }),
   ],
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger }) {
       if (user) {
         // @ts-expect-error - role is not in the User type
         token.role = user.role;
@@ -89,6 +85,18 @@ export default {
       }
       // Refresh numId/image from DB if absent (e.g. existing sessions)
       if (token.sub && (token.numId === undefined || token.image === undefined)) {
+        const dbUser = await prisma.user.findUnique({
+          where: { id: token.sub },
+          select: userIdentitySelect,
+        });
+        if (dbUser) {
+          token.numId = dbUser.numId;
+          token.image = dbUser.image;
+          token.name = dbUser.name;
+        }
+      }
+      // Re-fetch identity from DB when session.update() is called (e.g. after profile picture upload)
+      if (trigger === 'update' && token.sub) {
         const dbUser = await prisma.user.findUnique({
           where: { id: token.sub },
           select: userIdentitySelect,

--- a/src/components/activity-logs/activity-logs-view.tsx
+++ b/src/components/activity-logs/activity-logs-view.tsx
@@ -170,8 +170,10 @@ export function ActivityLogsView() {
       log.description.toLowerCase().includes(searchLower) ||
       log.user?.name?.toLowerCase().includes(searchLower) ||
       log.user?.email?.toLowerCase().includes(searchLower) ||
+      String(log.user?.numId ?? '').includes(search) ||
       log.targetUser?.name?.toLowerCase().includes(searchLower) ||
-      log.targetUser?.email?.toLowerCase().includes(searchLower)
+      log.targetUser?.email?.toLowerCase().includes(searchLower) ||
+      String(log.targetUser?.numId ?? '').includes(search)
     );
   });
 

--- a/src/components/activity-logs/activity-logs-view.tsx
+++ b/src/components/activity-logs/activity-logs-view.tsx
@@ -13,6 +13,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { format } from "date-fns";
 import { CalendarIcon, X, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
+import type { EmployeeIdentityUser } from "@/models/models";
 
 interface ActivityLog {
   id: string;
@@ -26,18 +28,14 @@ interface ActivityLog {
   ipAddress: string | null;
   userAgent: string | null;
   createdAt: string;
-  user: {
-    id: string;
-    name: string | null;
+  user: (EmployeeIdentityUser & {
     email: string | null;
     role: string;
-  } | null;
-  targetUser: {
-    id: string;
-    name: string | null;
+  }) | null;
+  targetUser: (EmployeeIdentityUser & {
     email: string | null;
     role: string;
-  } | null;
+  }) | null;
 }
 
 interface ActivityLogsResponse {
@@ -374,8 +372,8 @@ export function ActivityLogsView() {
                         </TableCell>
                         <TableCell>
                           {log.user ? (
-                            <div>
-                              <div className="font-medium">{log.user.name || "Unknown"}</div>
+                            <div className="flex flex-col gap-1">
+                              <EmployeeIdentity user={log.user} size="sm" />
                               <div className="text-xs text-muted-foreground">{log.user.email}</div>
                             </div>
                           ) : (
@@ -384,8 +382,8 @@ export function ActivityLogsView() {
                         </TableCell>
                         <TableCell>
                           {log.targetUser ? (
-                            <div>
-                              <div className="font-medium">{log.targetUser.name || "Unknown"}</div>
+                            <div className="flex flex-col gap-1">
+                              <EmployeeIdentity user={log.targetUser} size="sm" />
                               <div className="text-xs text-muted-foreground">{log.targetUser.email}</div>
                             </div>
                           ) : log.targetId ? (

--- a/src/components/advances/advance-discrepancies.tsx
+++ b/src/components/advances/advance-discrepancies.tsx
@@ -28,6 +28,7 @@ import { formatCurrency } from "@/lib/utils";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { format } from "date-fns";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface Installment {
   id: string;
@@ -276,11 +277,12 @@ export function AdvanceDiscrepancies() {
                       <ChevronRight className="h-5 w-5 text-muted-foreground" />
                     )}
                     <div>
-                      <div className="font-semibold text-lg">
-                        {user.userName}
-                      </div>
-                      <div className="text-sm text-muted-foreground">
-                        #{user.userNumId} &bull; {user.userBranch} &bull;{" "}
+                      <EmployeeIdentity
+                        user={{ id: user.userId, name: user.userName, numId: user.userNumId }}
+                        size="md"
+                      />
+                      <div className="text-sm text-muted-foreground mt-0.5">
+                        {user.userBranch} &bull;{" "}
                         {user.advances.length} advance(s)
                       </div>
                     </div>

--- a/src/components/advances/advance-discrepancies.tsx
+++ b/src/components/advances/advance-discrepancies.tsx
@@ -66,6 +66,7 @@ interface UserDiscrepancy {
   userId: string;
   userName: string;
   userNumId: number;
+  userImage: string | null;
   userBranch: string;
   totalDiscrepancy: number;
   deletedSalaryMonths: DeletedSalaryMonth[];
@@ -278,7 +279,7 @@ export function AdvanceDiscrepancies() {
                     )}
                     <div>
                       <EmployeeIdentity
-                        user={{ id: user.userId, name: user.userName, numId: user.userNumId }}
+                        user={{ id: user.userId, name: user.userName, numId: user.userNumId, image: user.userImage ?? null }}
                         size="md"
                       />
                       <div className="text-sm text-muted-foreground mt-0.5">

--- a/src/components/advances/advance-row.tsx
+++ b/src/components/advances/advance-row.tsx
@@ -15,6 +15,7 @@ import { ChevronDown, ChevronRight } from "lucide-react";
 import { formatCurrency } from "@/lib/utils";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface Installment {
   id: string;
@@ -28,8 +29,10 @@ interface Installment {
     year: number;
   } | null;
   approvedBy?: {
+    id: string;
     name: string;
     numId: number;
+    image?: string | null;
   } | null;
 }
 
@@ -45,8 +48,10 @@ interface Advance {
   approvedAt?: Date | null;
   isSettled: boolean;
   approvedBy?: {
+    id: string;
     name: string;
     numId: number;
+    image?: string | null;
   } | null;
   installments?: Installment[];
 }
@@ -178,9 +183,11 @@ export function AdvanceRow({ advance }: AdvanceRowProps) {
                   Approved By
                 </div>
                 <div className="text-sm">
-                  {advance.approvedBy
-                    ? `${advance.approvedBy.name} (#${advance.approvedBy.numId})`
-                    : "N/A"}
+                  {advance.approvedBy ? (
+                    <EmployeeIdentity user={advance.approvedBy} size="sm" />
+                  ) : (
+                    "N/A"
+                  )}
                 </div>
               </div>
 
@@ -264,9 +271,11 @@ export function AdvanceRow({ advance }: AdvanceRowProps) {
                               : "N/A"}
                           </TableCell>
                           <TableCell>
-                            {installment.approvedBy
-                              ? `${installment.approvedBy.name} (#${installment.approvedBy.numId})`
-                              : "N/A"}
+                            {installment.approvedBy ? (
+                              <EmployeeIdentity user={installment.approvedBy} size="sm" />
+                            ) : (
+                              "N/A"
+                            )}
                           </TableCell>
                           <TableCell>
                             {installment.approvedAt

--- a/src/components/advances/advances-management.tsx
+++ b/src/components/advances/advances-management.tsx
@@ -27,6 +27,7 @@ export interface AdvanceData {
   userId: string;
   userName: string;
   userNumId: number;
+  userImage: string | null;
   userBranch: string;
   totalAdvanceAmount: number;
   totalRemainingAmount: number;

--- a/src/components/advances/advances-table.tsx
+++ b/src/components/advances/advances-table.tsx
@@ -15,6 +15,7 @@ import { AdvanceRow } from "./advance-row";
 import { formatCurrency } from "@/lib/utils";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface Advance {
   id: string;
@@ -26,6 +27,7 @@ interface AdvanceData {
   userId: string;
   userName: string;
   userNumId: number;
+  userImage: string | null;
   userBranch: string;
   totalAdvanceAmount: number;
   totalRemainingAmount: number;
@@ -130,9 +132,17 @@ export function AdvancesTable({ advances }: AdvancesTableProps) {
                   </TableCell>
                   <TableCell>
                     <div>
-                      <div className="font-medium">{userAdvance.userName}</div>
-                      <div className="text-sm text-muted-foreground">
-                        #{userAdvance.userNumId} • {userAdvance.userBranch}
+                      <EmployeeIdentity
+                        user={{
+                          id: userAdvance.userId,
+                          name: userAdvance.userName,
+                          numId: userAdvance.userNumId,
+                          image: userAdvance.userImage ?? null,
+                        }}
+                        size="md"
+                      />
+                      <div className="text-sm text-muted-foreground mt-0.5">
+                        {userAdvance.userBranch}
                       </div>
                     </div>
                   </TableCell>

--- a/src/components/attendance/attendance-conflict-table.tsx
+++ b/src/components/attendance/attendance-conflict-table.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,6 +39,8 @@ export type SerializedAttendanceConflictEntry = {
 export type SerializedAttendanceConflict = {
   userId: string;
   userName: string | null;
+  userNumId: number | null;
+  userImage: string | null;
   department: string | null;
   branchName: string | null;
   date: string;
@@ -136,7 +139,10 @@ export function AttendanceConflictTable({ conflicts }: AttendanceConflictTablePr
             <CardHeader className="flex flex-row items-center justify-between gap-4">
               <div>
                 <CardTitle className="text-base">
-                  {conflict.userName ?? "Unknown user"}
+                  <EmployeeIdentity
+                    user={{ id: conflict.userId, name: conflict.userName, numId: conflict.userNumId, image: conflict.userImage }}
+                    size="md"
+                  />
                 </CardTitle>
                 <p className="text-sm text-muted-foreground">
                   {conflict.department ? `${conflict.department} • ` : ""}

--- a/src/components/attendance/attendance-form.tsx
+++ b/src/components/attendance/attendance-form.tsx
@@ -15,10 +15,13 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
 import { AttendanceFormProps, AttendanceFormData } from "@/models/attendance";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 export function AttendanceForm({
   userId,
   userName,
+  userNumId,
+  userImage,
   date,
   currentAttendance,
   isOpen,
@@ -349,13 +352,25 @@ export function AttendanceForm({
   return (
     <Dialog open={isOpen} onOpenChange={onCloseAction}>
       <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto p-4 sm:p-6">
-        <DialogHeader>
-          <DialogTitle className="text-base sm:text-lg pr-8">
+        <DialogHeader className="pr-8">
+          <DialogTitle className="text-base sm:text-lg">
             {showApproveReject ? "Review Attendance" : "Mark Attendance"}
-            <span className="block text-sm font-normal text-muted-foreground mt-0.5">
-              {userName}{department ? ` · ${department}` : ""}
-            </span>
           </DialogTitle>
+          <EmployeeIdentity
+            user={{
+              id: userId ?? "",
+              name: userName ?? null,
+              numId: userNumId ?? null,
+              image: userImage ?? null,
+            }}
+            size="sm"
+            subtitle={
+              <>
+                {userNumId !== null && userNumId !== undefined ? `#${userNumId}` : null}
+                {department ? `${userNumId !== null && userNumId !== undefined ? " · " : ""}${department}` : null}
+              </>
+            }
+          />
         </DialogHeader>
         <div className="space-y-4">
           <div className="flex items-center justify-between">

--- a/src/components/attendance/attendance-form.tsx
+++ b/src/components/attendance/attendance-form.tsx
@@ -348,25 +348,28 @@ export function AttendanceForm({
 
   return (
     <Dialog open={isOpen} onOpenChange={onCloseAction}>
-      <DialogContent>
+      <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto p-4 sm:p-6">
         <DialogHeader>
-          <DialogTitle>
-            {showApproveReject ? "Review Attendance" : "Mark Attendance"} for {userName} ({department})
+          <DialogTitle className="text-base sm:text-lg pr-8">
+            {showApproveReject ? "Review Attendance" : "Mark Attendance"}
+            <span className="block text-sm font-normal text-muted-foreground mt-0.5">
+              {userName}{department ? ` · ${department}` : ""}
+            </span>
           </DialogTitle>
         </DialogHeader>
-        <div className="space-y-6">
+        <div className="space-y-4">
           <div className="flex items-center justify-between">
             <Label htmlFor="isPresent">Present</Label>
-            <Switch 
-              id="isPresent" 
+            <Switch
+              id="isPresent"
               checked={isPresent}
               onCheckedChange={handlePresentChange}
             />
           </div>
 
-          <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
             <div>
-              <Label htmlFor="checkIn">Check In Time</Label>
+              <Label htmlFor="checkIn" className="text-sm">Check In</Label>
               <Input
                 id="checkIn"
                 type="time"
@@ -377,7 +380,7 @@ export function AttendanceForm({
               />
             </div>
             <div>
-              <Label htmlFor="checkOut">Check Out Time</Label>
+              <Label htmlFor="checkOut" className="text-sm">Check Out</Label>
               <Input
                 id="checkOut"
                 type="time"
@@ -389,10 +392,11 @@ export function AttendanceForm({
             </div>
           </div>
 
-          <div className="space-y-4">
+          <div className="space-y-2.5 rounded-md border bg-muted/30 p-3">
+            <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Shifts</div>
             <div className="flex items-center justify-between">
-              <Label htmlFor="shift1">7 AM to 11 AM</Label>
-              <Switch 
+              <Label htmlFor="shift1" className="text-sm font-normal">7 AM – 11 AM</Label>
+              <Switch
                 id="shift1"
                 checked={shift1}
                 onCheckedChange={setShift1}
@@ -400,8 +404,8 @@ export function AttendanceForm({
               />
             </div>
             <div className="flex items-center justify-between">
-              <Label htmlFor="shift2">11 AM to 7 PM</Label>
-              <Switch 
+              <Label htmlFor="shift2" className="text-sm font-normal">11 AM – 7 PM</Label>
+              <Switch
                 id="shift2"
                 checked={shift2}
                 onCheckedChange={setShift2}
@@ -409,8 +413,8 @@ export function AttendanceForm({
               />
             </div>
             <div className="flex items-center justify-between">
-              <Label htmlFor="shift3">7 PM to 11 PM</Label>
-              <Switch 
+              <Label htmlFor="shift3" className="text-sm font-normal">7 PM – 11 PM</Label>
+              <Switch
                 id="shift3"
                 checked={shift3}
                 onCheckedChange={setShift3}
@@ -419,43 +423,42 @@ export function AttendanceForm({
             </div>
           </div>
 
-          {userWeeklyOffConfig?.hasWeeklyOff && (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="isWeeklyOff">
-                  Weekly Off
-                  {isFixedWeeklyOffDay && (
-                    <span className="ml-2 text-xs text-muted-foreground">(Fixed weekly off day)</span>
-                  )}
-                </Label>
-                <Switch 
-                  id="isWeeklyOff" 
-                  checked={isWeeklyOff}
-                  onCheckedChange={handleWeeklyOffChange}
-                  disabled={!canOverrideWeeklyOff && userWeeklyOffConfig.weeklyOffType === "FIXED" && !isFixedWeeklyOffDay}
-                />
-              </div>
+          {(userWeeklyOffConfig?.hasWeeklyOff || userWeeklyOffConfig?.hasWorkFromHome) && (
+            <div className="space-y-2.5">
+              {userWeeklyOffConfig?.hasWeeklyOff && (
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="isWeeklyOff">
+                    Weekly Off
+                    {isFixedWeeklyOffDay && (
+                      <span className="ml-1.5 text-xs text-muted-foreground">(fixed)</span>
+                    )}
+                  </Label>
+                  <Switch
+                    id="isWeeklyOff"
+                    checked={isWeeklyOff}
+                    onCheckedChange={handleWeeklyOffChange}
+                    disabled={!canOverrideWeeklyOff && userWeeklyOffConfig.weeklyOffType === "FIXED" && !isFixedWeeklyOffDay}
+                  />
+                </div>
+              )}
+              {userWeeklyOffConfig?.hasWorkFromHome && (
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="isWorkFromHome">Work From Home</Label>
+                  <Switch
+                    id="isWorkFromHome"
+                    checked={isWorkFromHome}
+                    onCheckedChange={handleWorkFromHomeChange}
+                  />
+                </div>
+              )}
             </div>
           )}
 
-          {userWeeklyOffConfig?.hasWorkFromHome && (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="isWorkFromHome">Work From Home</Label>
-                <Switch 
-                  id="isWorkFromHome" 
-                  checked={isWorkFromHome}
-                  onCheckedChange={handleWorkFromHomeChange}
-                />
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
             <div className="flex items-center justify-between">
               <Label htmlFor="isHalfDay">Half Day</Label>
-              <Switch 
-                id="isHalfDay" 
+              <Switch
+                id="isHalfDay"
                 checked={isHalfDay}
                 onCheckedChange={setIsHalfDay}
                 disabled={!isPresent || isOvertime || isWeeklyOff || isWorkFromHome}
@@ -463,8 +466,8 @@ export function AttendanceForm({
             </div>
             <div className="flex items-center justify-between">
               <Label htmlFor="overtime">Overtime</Label>
-              <Switch 
-                id="overtime" 
+              <Switch
+                id="overtime"
                 checked={isOvertime}
                 onCheckedChange={setIsOvertime}
                 disabled={!isPresent || isHalfDay || isWeeklyOff || isWorkFromHome}
@@ -473,20 +476,20 @@ export function AttendanceForm({
           </div>
 
           <div>
-            <Label htmlFor="notes">Notes (Optional)</Label>
+            <Label htmlFor="notes" className="text-sm">Notes (optional)</Label>
             <Textarea
               id="notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               placeholder="Add any additional notes..."
               className="mt-1"
-              rows={3}
+              rows={2}
             />
           </div>
 
           {showApproveReject && (
             <div>
-              <Label htmlFor="verificationNote">Verification Note (Optional)</Label>
+              <Label htmlFor="verificationNote" className="text-sm">Verification Note (optional)</Label>
               <Textarea
                 id="verificationNote"
                 value={verificationNote}
@@ -499,26 +502,26 @@ export function AttendanceForm({
           )}
 
           {showApproveReject ? (
-            <div className="flex gap-2">
-              <Button 
-                onClick={handleReject} 
-                className="flex-1 bg-red-600 hover:bg-red-700 text-white" 
+            <div className="flex gap-2 pt-1">
+              <Button
+                onClick={handleReject}
+                className="flex-1 bg-red-600 hover:bg-red-700 text-white"
                 disabled={isLoading}
               >
                 {isLoading ? "Processing..." : "Reject"}
               </Button>
-              <Button 
-                onClick={handleApprove} 
-                className="flex-1 bg-green-600 hover:bg-green-700 text-white" 
+              <Button
+                onClick={handleApprove}
+                className="flex-1 bg-green-600 hover:bg-green-700 text-white"
                 disabled={isLoading}
               >
                 {isLoading ? "Processing..." : "Approve"}
               </Button>
             </div>
           ) : (
-            <Button 
-              onClick={handleSubmit} 
-              className="w-full" 
+            <Button
+              onClick={handleSubmit}
+              className="w-full"
               disabled={isLoading}
             >
               {isLoading ? "Saving..." : "Save Attendance"}

--- a/src/components/attendance/attendance-table.tsx
+++ b/src/components/attendance/attendance-table.tsx
@@ -14,6 +14,7 @@ import { format } from "date-fns";
 import { AttendanceForm } from "./attendance-form";
 import {User} from "@/models/models";
 import { getShiftDisplay } from "@/lib/utils/shift-display";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 
 interface AttendanceTableProps {
@@ -68,7 +69,9 @@ export function AttendanceTable({ users, date, viewOnly = false }: AttendanceTab
                 className="cursor-pointer hover:bg-muted/50"
                 onClick={() => setSelectedUser(user)}
               >
-                <TableCell>{user.name}</TableCell>
+                <TableCell>
+                  <EmployeeIdentity user={user} size="md" />
+                </TableCell>
                 <TableCell>
                   {user.department?.name || 'N/A'}
                 </TableCell>

--- a/src/components/attendance/attendance-table.tsx
+++ b/src/components/attendance/attendance-table.tsx
@@ -138,6 +138,8 @@ export function AttendanceTable({ users, date, viewOnly = false }: AttendanceTab
         <AttendanceForm
           userId={selectedUser.id}
           userName={selectedUser.name}
+          userNumId={selectedUser.numId}
+          userImage={selectedUser.image}
           userRole={selectedUser.role}
           department={selectedUser.department?.name || ''}
           date={date}

--- a/src/components/attendance/attendance-verification-table.tsx
+++ b/src/components/attendance/attendance-verification-table.tsx
@@ -19,6 +19,7 @@ import { AttendanceBranchFilter } from "./attendance-branch-filter";
 import { Attendance } from "@/models/models";
 import { AttendanceForm } from "./attendance-form";
 import { getShiftDisplay } from "@/lib/utils/shift-display";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 
 interface AttendanceVerificationTableProps {
@@ -135,7 +136,9 @@ export function AttendanceVerificationTable({
                 onClick={() => setSelectedRecord(record)}
               >
                 <TableCell>{format(new Date(record.date), "PPP")}</TableCell>
-                <TableCell>{record.user.name}</TableCell>
+                <TableCell>
+                  <EmployeeIdentity user={record.user} size="md" />
+                </TableCell>
                 <TableCell>{record.user.branch?.name || "-"}</TableCell>
                 <TableCell>{record.user.department?.name || "-"}</TableCell>
                 <TableCell>{getAttendanceStatus(record)}</TableCell>

--- a/src/components/attendance/attendance-verification-table.tsx
+++ b/src/components/attendance/attendance-verification-table.tsx
@@ -162,6 +162,8 @@ export function AttendanceVerificationTable({
         <AttendanceForm
           userId={selectedRecord.userId}
           userName={selectedRecord.user.name}
+          userNumId={selectedRecord.user.numId}
+          userImage={selectedRecord.user.image}
           date={new Date(selectedRecord.date)}
           currentAttendance={selectedRecord}
           isOpen={!!selectedRecord}

--- a/src/components/attendance/branch-attendance-submissions.tsx
+++ b/src/components/attendance/branch-attendance-submissions.tsx
@@ -24,10 +24,13 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Card, CardTitle } from "@/components/ui/card";
 import { getShiftDisplay } from "@/lib/utils/shift-display";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface EmployeeAttendance {
   id: string;
   name: string | null;
+  numId: number;
+  image?: string | null;
   department: { id: string; name: string } | null;
   attendance: Array<{
     id: string;
@@ -395,7 +398,7 @@ export function BranchAttendanceSubmissions({
                                 {serialNumber}
                               </TableCell>
                             <TableCell className="font-medium">
-                              {employee.name?.toUpperCase() || "N/A"}
+                              <EmployeeIdentity user={employee} size="sm" />
                             </TableCell>
                             <TableCell>
                               <span className="text-foreground">
@@ -462,9 +465,7 @@ export function BranchAttendanceSubmissions({
                                       <span className="text-[10px] font-medium text-muted-foreground">
                                         {serialNumber}.
                                       </span>
-                                      <h4 className="font-semibold text-xs break-words">
-                                        {employee.name?.toUpperCase() || "N/A"}
-                                      </h4>
+                                      <EmployeeIdentity user={employee} size="sm" />
                                       <span className="text-[10px] text-muted-foreground">•</span>
                                       <span className="text-[10px] text-foreground">{timing}</span>
                                       {badges.map((badge, idx) => (

--- a/src/components/attendance/detailed-attendance-calendar.tsx
+++ b/src/components/attendance/detailed-attendance-calendar.tsx
@@ -12,15 +12,19 @@ interface DetailedAttendanceCalendarProps {
   month: Date;
   userId: string;
   userName: string;
+  userNumId?: number | null;
+  userImage?: string | null;
   userRole: string;
   department: string;
 }
 
-export function DetailedAttendanceCalendar({ 
-  attendance, 
+export function DetailedAttendanceCalendar({
+  attendance,
   month,
   userId,
   userName,
+  userNumId,
+  userImage,
   userRole,
   department
 }: DetailedAttendanceCalendarProps) {
@@ -223,8 +227,10 @@ export function DetailedAttendanceCalendar({
         <AttendanceForm
           userId={userId}
           userName={userName}
+          userNumId={userNumId}
+          userImage={userImage}
           date={selectedDate}
-          department={department} 
+          department={department}
           currentAttendance={selectedAttendance || undefined}
           isOpen={!!selectedDate}
           onCloseAction={() => {

--- a/src/components/attendance/shared-attendance-table.tsx
+++ b/src/components/attendance/shared-attendance-table.tsx
@@ -160,6 +160,8 @@ export function SharedAttendanceTable({
         <AttendanceForm
           userId={selectedUser.id}
           userName={selectedUser.name || ""}
+          userNumId={selectedUser.numId}
+          userImage={selectedUser.image}
           date={date}
           currentAttendance={selectedUser.attendance?.[0]}
           isOpen={!!selectedUser}

--- a/src/components/attendance/shared-attendance-table.tsx
+++ b/src/components/attendance/shared-attendance-table.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { AttendanceForm } from "./attendance-form";
 import {User} from "@/models/models";
 import { getShiftDisplay } from "@/lib/utils/shift-display";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 
 interface SharedAttendanceTableProps {
@@ -96,7 +97,9 @@ export function SharedAttendanceTable({
                 className="cursor-pointer hover:bg-muted/50"
                 onClick={() => setSelectedUser(user)}
               >
-                <TableCell>{user.name}</TableCell>
+                <TableCell>
+                  <EmployeeIdentity user={user} size="md" />
+                </TableCell>
                 {showRole && (
                   <TableCell>
                     <Badge variant="secondary" className={roleColors[user.role as keyof typeof roleColors]}>

--- a/src/components/dashboard/pending-signatures-widget.tsx
+++ b/src/components/dashboard/pending-signatures-widget.tsx
@@ -4,8 +4,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { User } from '@/models/models';
-import { FileSignature, Users, ArrowRight } from 'lucide-react';
+import { FileSignature, ArrowRight } from 'lucide-react';
 import Link from 'next/link';
+import { EmployeeIdentity } from '@/components/ui/employee-identity';
 
 interface PendingSignaturesWidgetProps {
   pendingUsers: User[];
@@ -38,15 +39,11 @@ export function PendingSignaturesWidget({ pendingUsers, currentUserRole }: Pendi
               className="flex items-center justify-between p-3 border rounded-lg hover:bg-gray-50 transition-colors"
             >
               <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center">
-                  <Users className="h-4 w-4 text-gray-600" />
-                </div>
-                <div>
-                  <p className="font-medium text-sm">{user.name}</p>
-                  <p className="text-xs text-gray-500">
-                    {user.role} • {user.department?.name || 'N/A'}
-                  </p>
-                </div>
+                <EmployeeIdentity
+                  user={user}
+                  size="sm"
+                  subtitle={`${user.role} • ${user.department?.name || 'N/A'}`}
+                />
               </div>
               <Button
                 size="sm"

--- a/src/components/dashboard/pending-signatures-widget.tsx
+++ b/src/components/dashboard/pending-signatures-widget.tsx
@@ -42,7 +42,13 @@ export function PendingSignaturesWidget({ pendingUsers, currentUserRole }: Pendi
                 <EmployeeIdentity
                   user={user}
                   size="sm"
-                  subtitle={`${user.role} • ${user.department?.name || 'N/A'}`}
+                  subtitle={
+                    <>
+                      {user.numId !== null && user.numId !== undefined ? `#${user.numId} · ` : ''}
+                      {user.role}
+                      {user.department?.name ? ` · ${user.department.name}` : ''}
+                    </>
+                  }
                 />
               </div>
               <Button

--- a/src/components/employees/employee-table.tsx
+++ b/src/components/employees/employee-table.tsx
@@ -18,10 +18,13 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import AssignBranchModal from "../users/assign-branch-modal";
 import { Branch } from "@/models/models";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface Employee {
   id: string;
   name: string | null;
+  numId?: number | null;
+  image?: string | null;
   email: string | null;
   status: string;
   branch?: {
@@ -93,7 +96,9 @@ export function EmployeeTable({ employees, branches, onEmployeeUpdate }: Employe
         <TableBody>
           {employees.map((employee) => (
             <TableRow key={employee.id}>
-              <TableCell>{employee.name}</TableCell>
+              <TableCell>
+                <EmployeeIdentity user={employee} size="md" href={`/users/${employee.id}`} />
+              </TableCell>
               <TableCell>{employee.email}</TableCell>
               <TableCell>{employee._count.attendance}</TableCell>
               <TableCell>{employee._count.leaveRequests}</TableCell>

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -1,7 +1,6 @@
 import { auth } from "@/auth";
 import { NavWrapper } from "./nav-wrapper";
 import { prisma } from "@/lib/prisma";
-import {User} from "@/models/models";
 
 export async function Header() {
   const session = await auth();
@@ -11,7 +10,10 @@ export async function Header() {
   // @ts-expect-error - We check for role
   const role = session.user.role;
   // @ts-expect-error - We check for branchId
-  const branchId = session.user.branchId
+  const branchId = session.user.branchId;
+  // @ts-expect-error - numId from session
+  const numId = session.user.numId as number | null | undefined;
+  const image = session.user.image as string | null | undefined;
 
   let branchName = null;
   if (session.user) {
@@ -37,14 +39,17 @@ export async function Header() {
   }
 
   return (
-    <NavWrapper 
+    <NavWrapper
       user={{
-        role: role,
+        id: session.user.id ?? "",
         name: session.user.name,
         email: session.user.email,
-      } as User}
+        role: role,
+        numId: numId ?? null,
+        image: image ?? null,
+      }}
       branchName={branchName || ""}
       userRole={role}
     />
   );
-} 
+}

--- a/src/components/layout/nav-wrapper.tsx
+++ b/src/components/layout/nav-wrapper.tsx
@@ -3,10 +3,10 @@
 import { MainNav } from "./main-nav";
 import { UserNav } from "./user-nav";
 import { ThemeToggle } from "@/components/theme-toggle";
-import {User} from "@/models/models";
+import type { EmployeeIdentityUser } from "@/models/models";
 
 interface NavWrapperProps {
-  user: User;
+  user: EmployeeIdentityUser & { email?: string | null; role?: string | null };
   branchName: string;
   userRole: string;
 }
@@ -23,4 +23,4 @@ export function NavWrapper({ user, branchName, userRole }: NavWrapperProps) {
       </div>
     </div>
   );
-} 
+}

--- a/src/components/layout/user-nav.tsx
+++ b/src/components/layout/user-nav.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -14,22 +13,16 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { LogOut, Building2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import {User} from "@/models/models";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
+import type { EmployeeIdentityUser } from "@/models/models";
 
 interface UserNavProps {
-  user: User;
+  user: EmployeeIdentityUser & { email?: string | null; role?: string | null };
   branchName: string;
 }
 
 export function UserNav({ user, branchName }: UserNavProps) {
   const router = useRouter();
-  const initials = user.name
-    ? user.name
-        .split(" ")
-        .map((n) => n[0])
-        .join("")
-        .toUpperCase()
-    : "U";
 
   const handleSignOut = async () => {
     try {
@@ -45,10 +38,8 @@ export function UserNav({ user, branchName }: UserNavProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="relative h-8 w-8 rounded-full">
-          <Avatar className="h-8 w-8">
-            <AvatarFallback>{initials}</AvatarFallback>
-          </Avatar>
+        <Button variant="ghost" className="relative h-auto rounded-full px-2 py-1">
+          <EmployeeIdentity user={user} size="sm" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-56" align="end" forceMount>

--- a/src/components/leave/leave-request-table.tsx
+++ b/src/components/leave/leave-request-table.tsx
@@ -25,7 +25,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { cn } from "@/lib/utils";
+import { cn, stringToHue } from "@/lib/utils";
 import {
   addMonths,
   eachDayOfInterval,
@@ -69,14 +69,6 @@ function toDate(value: unknown): Date {
 
 function getDepartmentName(request: LeaveRequest) {
   return request.user?.department?.name ?? "-";
-}
-
-function stringToHue(input: string) {
-  let hash = 0;
-  for (let i = 0; i < input.length; i++) {
-    hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
-  }
-  return hash % 360;
 }
 
 function DepartmentPill({ name }: { name: string }) {

--- a/src/components/leave/leave-request-table.tsx
+++ b/src/components/leave/leave-request-table.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn, stringToHue } from "@/lib/utils";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 import {
   addMonths,
   eachDayOfInterval,
@@ -417,7 +418,9 @@ export function LeaveRequestTable({
           <TableBody>
             {filteredRequests.map((request) => (
               <TableRow key={request.id}>
-                <TableCell>{request.user?.name ?? "-"}</TableCell>
+                <TableCell>
+                  {request.user ? <EmployeeIdentity user={request.user} size="md" /> : "-"}
+                </TableCell>
                 {showBranch && (
                   <TableCell>{request.user?.branch?.name || "-"}</TableCell>
                 )}

--- a/src/components/notes/NoteDetail.tsx
+++ b/src/components/notes/NoteDetail.tsx
@@ -2,6 +2,20 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {Note, NoteComment, NoteEditHistory, NoteShare, User} from "@/models/models";
+
+interface NoteShareWithUser {
+  id: string;
+  noteId: string;
+  userId: string;
+  user: {
+    id: string;
+    name: string | null;
+    numId: number | null;
+    image: string | null;
+    role: string;
+    branch: { id: string; name: string } | null;
+  };
+}
 import {Textarea} from "@/components/ui/textarea";
 import {
   Dialog,
@@ -106,15 +120,6 @@ export default function NoteDetail({ note, user }: { note: Note, user: User }) {
         .catch(() => setAllUsers([]));
     }
   }, [shareModalOpen]);
-
-  useEffect(() => {
-    if (tab === 'shared' && allUsers.length === 0) {
-      fetch('/api/users')
-        .then(res => res.json())
-        .then(data => setAllUsers(data))
-        .catch(() => setAllUsers([]));
-    }
-  }, [tab, allUsers.length]);
 
   const handleAddComment = async () => {
     if (!newComment.trim()) return;
@@ -439,14 +444,22 @@ export default function NoteDetail({ note, user }: { note: Note, user: User }) {
             <div>
               <div className="space-y-2">
                 {note.sharedWith && note.sharedWith.length > 0 ? (
-                  note.sharedWith.map((share, idx) => (
+                  (note.sharedWith as unknown as NoteShareWithUser[]).map((share, idx) => (
                     <div key={share.id || idx} className="border rounded p-2 flex items-center gap-2">
-                      {share.user && <EmployeeIdentity user={share.user} size="sm" />}
-                      <span className="text-xs text-muted-foreground">
-                        ({allUsers.find(u => u.id === share.userId)?.branch?.name || 'No Branch'}
-                        {allUsers.find(u => u.id === share.userId)?.role ? `, ${allUsers.find(u => u.id === share.userId)?.role}` : ''}
-                        {share.userId === note.ownerId ? ', Owner' : ''})
-                      </span>
+                      {share.user && (
+                        <EmployeeIdentity
+                          user={share.user}
+                          size="sm"
+                          subtitle={
+                            <>
+                              {share.user.numId !== null ? `#${share.user.numId}` : ''}
+                              {share.user.branch?.name ? ` · ${share.user.branch.name}` : ''}
+                              {share.user.role ? ` · ${share.user.role}` : ''}
+                              {share.userId === note.ownerId ? ' · Owner' : ''}
+                            </>
+                          }
+                        />
+                      )}
                     </div>
                   ))
                 ) : (

--- a/src/components/notes/NoteDetail.tsx
+++ b/src/components/notes/NoteDetail.tsx
@@ -286,7 +286,8 @@ export default function NoteDetail({ note, user }: { note: Note, user: User }) {
                   ) : (
                     allUsers
                       .filter(user =>
-                        user.name?.toLowerCase().includes(userSearch.toLowerCase())
+                        user.name?.toLowerCase().includes(userSearch.toLowerCase()) ||
+                        String(user.numId ?? '').includes(userSearch)
                       )
                       .map(user => (
                         <label key={user.id} className="flex items-center gap-2">

--- a/src/components/notes/NoteDetail.tsx
+++ b/src/components/notes/NoteDetail.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import RichTextEditor from "@/components/rich-text-editor/rich-text-editor";
 import { useRouter } from "next/navigation";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 export default function NoteDetail({ note, user }: { note: Note, user: User }) {
 
@@ -231,6 +232,11 @@ export default function NoteDetail({ note, user }: { note: Note, user: User }) {
           value={title}
           onChange={e => setTitle(e.target.value)}
         />
+        {note.owner && (
+          <div className="text-xs text-muted-foreground mb-2">
+            Owner: <EmployeeIdentity user={note.owner} size="sm" className="inline-flex" />
+          </div>
+        )}
         <RichTextEditor value={content} onChange={setContent} />
         <div className="flex gap-2 mt-2">
           <Button onClick={handleSave} disabled={saving}>
@@ -388,7 +394,10 @@ export default function NoteDetail({ note, user }: { note: Note, user: User }) {
                     ) : (
                       comments.map((comment, idx) => (
                         <div key={comment.id || idx} className="border rounded p-2">
-                          <div className="text-sm text-muted-foreground mb-1">{comment.author?.name || 'User'} • {comment.createdAt ? new Date(comment.createdAt).toLocaleString() : ''}</div>
+                          <div className="flex items-center gap-2 mb-1">
+                            {comment.author && <EmployeeIdentity user={comment.author} size="sm" />}
+                            <span className="text-xs text-muted-foreground">• {comment.createdAt ? new Date(comment.createdAt).toLocaleString() : ''}</span>
+                          </div>
                           <div>{comment.content}</div>
                         </div>
                       ))
@@ -411,8 +420,10 @@ export default function NoteDetail({ note, user }: { note: Note, user: User }) {
                     <div key={h.id || idx} className="border rounded p-2 bg-muted/30">
                       <div className="flex flex-col gap-2">
                         <div>
-                          <div className="text-xs text-muted-foreground mb-1">
-                            Edited by: {h.editor?.name || 'User'} • {h.editedAt ? new Date(h.editedAt).toLocaleString() : ''}
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-xs text-muted-foreground">Edited by:</span>
+                            {h.editor && <EmployeeIdentity user={h.editor} size="sm" />}
+                            <span className="text-xs text-muted-foreground">• {h.editedAt ? new Date(h.editedAt).toLocaleString() : ''}</span>
                           </div>
                           <div className="prose prose-sm min-h-[2rem]"
                                 dangerouslySetInnerHTML={{ __html: h.content || "<span class='italic text-muted-foreground'>(empty)</span>" }}/>
@@ -427,22 +438,16 @@ export default function NoteDetail({ note, user }: { note: Note, user: User }) {
             <div>
               <div className="space-y-2">
                 {note.sharedWith && note.sharedWith.length > 0 ? (
-                  allUsers.length === 0 ? (
-                    <div>Loading users...</div>
-                  ) : (
-                    allUsers
-                      .filter(u => note.sharedWith.some(s => s.userId === u.id))
-                      .map((user, idx) => (
-                        <div key={user.id || idx} className="border rounded p-2 flex items-center gap-2">
-                          <span className="font-medium">{user.name || 'User'}</span>
-                          <span className="text-xs text-muted-foreground">
-                            ({user.branch?.name || 'No Branch'}
-                            {user.role ? `, ${user.role}` : ''}
-                            {user.id === note.ownerId ? ', Owner' : ''})
-                          </span>
-                        </div>
-                      ))
-                  )
+                  note.sharedWith.map((share, idx) => (
+                    <div key={share.id || idx} className="border rounded p-2 flex items-center gap-2">
+                      {share.user && <EmployeeIdentity user={share.user} size="sm" />}
+                      <span className="text-xs text-muted-foreground">
+                        ({allUsers.find(u => u.id === share.userId)?.branch?.name || 'No Branch'}
+                        {allUsers.find(u => u.id === share.userId)?.role ? `, ${allUsers.find(u => u.id === share.userId)?.role}` : ''}
+                        {share.userId === note.ownerId ? ', Owner' : ''})
+                      </span>
+                    </div>
+                  ))
                 ) : (
                   <div className="text-muted-foreground">Not shared with anyone.</div>
                 )}

--- a/src/components/referrals/referrals-management.tsx
+++ b/src/components/referrals/referrals-management.tsx
@@ -24,11 +24,15 @@ interface ReferralWithRelations {
   referrer: {
     id: string;
     name: string | null;
+    numId?: number | null;
+    image?: string | null;
     email: string | null;
   };
   referredUser: {
     id: string;
     name: string | null;
+    numId?: number | null;
+    image?: string | null;
     email: string | null;
     doj: Date | null;
   };

--- a/src/components/referrals/referrals-table.tsx
+++ b/src/components/referrals/referrals-table.tsx
@@ -11,6 +11,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { format } from "date-fns";
 import { formatCurrency } from "@/lib/utils";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface ReferralWithRelations {
   id: string;
@@ -25,11 +26,15 @@ interface ReferralWithRelations {
   referrer: {
     id: string;
     name: string | null;
+    numId?: number | null;
+    image?: string | null;
     email: string | null;
   };
   referredUser: {
     id: string;
     name: string | null;
+    numId?: number | null;
+    image?: string | null;
     email: string | null;
     doj: Date | null;
   };
@@ -92,16 +97,16 @@ export function ReferralsTable({ referrals }: ReferralsTableProps) {
             return (
               <TableRow key={referral.id}>
                 <TableCell>
-                  <div>
-                    <div className="font-medium">{referral.referrer.name || "-"}</div>
+                  <div className="space-y-1">
+                    <EmployeeIdentity user={referral.referrer} size="md" />
                     <div className="text-sm text-muted-foreground">
                       {referral.referrer.email || "-"}
                     </div>
                   </div>
                 </TableCell>
                 <TableCell>
-                  <div>
-                    <div className="font-medium">{referral.referredUser.name || "-"}</div>
+                  <div className="space-y-1">
+                    <EmployeeIdentity user={referral.referredUser} size="md" />
                     <div className="text-sm text-muted-foreground">
                       {referral.referredUser.email || "-"}
                     </div>

--- a/src/components/salary/salary-details.tsx
+++ b/src/components/salary/salary-details.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { EmployeeIdentity } from "@/components/ui/employee-identity"
 import {
   Dialog,
   DialogContent,
@@ -524,7 +525,14 @@ export function SalaryDetails({ salary, canEdit = false, activeWarningCount = 0 
       </Dialog>
       <Card>
         <CardHeader>
-          {salary.user && salary.user.name && <CardTitle>Salary Details - {salary.user.name}</CardTitle>}
+          {salary.user && (
+            <CardTitle>
+              <div className="flex items-center gap-3">
+                <span>Salary Details</span>
+                <EmployeeIdentity user={salary.user} size="lg" />
+              </div>
+            </CardTitle>
+          )}
           <CardDescription>
             For {new Date(salary.year + '-' + salary.month + '-' + '15').toLocaleString('default', { month: 'long', year: 'numeric' })}
           </CardDescription>

--- a/src/components/salary/salary-details.tsx
+++ b/src/components/salary/salary-details.tsx
@@ -84,7 +84,10 @@ export function SalaryDetails({ salary, canEdit = false, activeWarningCount = 0 
     bonusAmount?: number;
     referredUserId?: string;
     referredUser?: {
+      id: string;
       name?: string | null;
+      numId?: number | null;
+      image?: string | null;
       status: string;
       doj?: Date | string | null;
     } | null;
@@ -580,9 +583,9 @@ export function SalaryDetails({ salary, canEdit = false, activeWarningCount = 0 
                   {referrals.map((r) => (
                     <div key={r.id} className="flex items-center justify-between text-sm">
                       <div className="flex items-center gap-2">
-                        <span>Referred: {r.referredUser?.name || r.referredUserId}</span>
                         {r.referredUser && (
                           <>
+                            <EmployeeIdentity user={r.referredUser} size="sm" subtitle="Referred" />
                             <Badge
                               variant={
                                 r.referredUser.status === 'ACTIVE'

--- a/src/components/salary/salary-list.tsx
+++ b/src/components/salary/salary-list.tsx
@@ -3,6 +3,7 @@
 import {useCallback, useEffect, useState} from 'react'
 import {Branch, Salary, User} from "@/models/models"
 import {Button} from '@/components/ui/button'
+import { EmployeeIdentity } from "@/components/ui/employee-identity"
 import {useRouter, useSearchParams} from 'next/navigation'
 import {Checkbox} from "@/components/ui/checkbox"
 import {toast} from "sonner"
@@ -529,7 +530,7 @@ export function SalaryList({month, year}: SalaryListProps) {
           <div className="space-y-2">
             {deactivateCandidates.map((c) => (
               <div key={c.userId} className="text-sm">
-                {c.name || 'Employee'}{c.numId ? ` (Emp #${c.numId})` : ''}
+                <EmployeeIdentity user={{ id: c.userId, name: c.name, numId: c.numId, image: null }} size="sm" />
               </div>
             ))}
           </div>
@@ -863,7 +864,9 @@ export function SalaryList({month, year}: SalaryListProps) {
                       />
                     )}
                     <div>
-                      <CardTitle>{salary.user.name}</CardTitle>
+                      <CardTitle>
+                        <EmployeeIdentity user={salary.user} size="md" />
+                      </CardTitle>
                       <CardDescription>
                         {new Date(salary.year, salary.month - 1).toLocaleString('default', {
                           month: 'long',

--- a/src/components/salary/salary-stats-table.tsx
+++ b/src/components/salary/salary-stats-table.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { AlertCircle } from 'lucide-react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { formatDateOnly } from '@/lib/utils'
+import { EmployeeIdentity } from "@/components/ui/employee-identity"
 
 interface SalaryStatsTableProps {
   salaryId: string
@@ -80,7 +81,8 @@ export function SalaryStatsTable({ salaryId }: SalaryStatsTableProps) {
       <CardHeader>
         <CardTitle>Salary Calculation Details</CardTitle>
         <CardDescription>
-          Detailed breakdown of salary calculation for {stats.employee.name} - 
+          Detailed breakdown of salary calculation for{' '}
+          <EmployeeIdentity user={stats.employee} size="sm" />{' '}—{' '}
           {new Date(stats.salary.year, stats.salary.month - 1).toLocaleString('default', { month: 'long', year: 'numeric' })}
         </CardDescription>
       </CardHeader>
@@ -92,16 +94,16 @@ export function SalaryStatsTable({ salaryId }: SalaryStatsTableProps) {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Employee ID</TableHead>
-                  <TableHead>Name</TableHead>
+                  <TableHead>Employee</TableHead>
                   <TableHead>Email</TableHead>
                   <TableHead>Base Salary</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 <TableRow>
-                  <TableCell>{stats.employee.id}</TableCell>
-                  <TableCell>{stats.employee.name}</TableCell>
+                  <TableCell>
+                    <EmployeeIdentity user={stats.employee} size="md" />
+                  </TableCell>
                   <TableCell>{stats.employee.email}</TableCell>
                   <TableCell>{formatCurrency(stats.salary.baseSalary)}</TableCell>
                 </TableRow>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -26,7 +26,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn("aspect-square h-full w-full object-cover", className)}
     {...props}
   />
 ))

--- a/src/components/ui/employee-identity.tsx
+++ b/src/components/ui/employee-identity.tsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import Link from "next/link";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn, getInitials, stringToHue } from "@/lib/utils";
+import type { EmployeeIdentityUser } from "@/models/models";
+
+type Size = "sm" | "md" | "lg";
+
+interface EmployeeIdentityProps {
+  user: EmployeeIdentityUser;
+  size?: Size;
+  subtitle?: React.ReactNode;
+  href?: string;
+  className?: string;
+}
+
+const AVATAR_SIZE: Record<Size, string> = {
+  sm: "h-6 w-6 text-[10px]",
+  md: "h-8 w-8 text-xs",
+  lg: "h-12 w-12 text-base",
+};
+
+const NAME_TEXT: Record<Size, string> = {
+  sm: "text-sm font-medium leading-tight",
+  md: "text-sm font-medium leading-tight",
+  lg: "text-base font-semibold leading-tight",
+};
+
+const ID_TEXT: Record<Size, string> = {
+  sm: "text-xs text-muted-foreground",
+  md: "text-xs text-muted-foreground leading-tight",
+  lg: "text-sm text-muted-foreground leading-tight",
+};
+
+export function EmployeeIdentity({
+  user,
+  size = "md",
+  subtitle,
+  href,
+  className,
+}: EmployeeIdentityProps) {
+  const initials = getInitials(user.name);
+  const hue = user.name ? stringToHue(user.name) : null;
+  const fallbackStyle = hue !== null
+    ? { backgroundColor: `hsl(${hue} 60% 50%)`, color: "white" }
+    : { backgroundColor: "hsl(0 0% 80%)", color: "white" };
+
+  const idLine = subtitle ?? (user.numId !== null ? `#${user.numId}` : null);
+
+  const inner = (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 min-w-0",
+        className,
+      )}
+    >
+      <Avatar className={cn(AVATAR_SIZE[size], "shrink-0")}>
+        {user.image ? (
+          <AvatarImage
+            src={user.image}
+            alt={user.name ?? "Employee"}
+            loading="lazy"
+          />
+        ) : null}
+        <AvatarFallback style={fallbackStyle}>{initials}</AvatarFallback>
+      </Avatar>
+
+      {size === "sm" ? (
+        <div className="min-w-0 truncate">
+          <span className={NAME_TEXT[size]}>{user.name ?? "Unnamed"}</span>
+          {idLine !== null && (
+            <span className={cn("ml-1.5", ID_TEXT[size])}>· {idLine}</span>
+          )}
+        </div>
+      ) : (
+        <div className="min-w-0">
+          <div className={cn(NAME_TEXT[size], "truncate")}>
+            {user.name ?? "Unnamed"}
+          </div>
+          {idLine !== null && (
+            <div className={cn(ID_TEXT[size], "truncate")}>{idLine}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="hover:underline">
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
+}

--- a/src/components/ui/employee-identity.tsx
+++ b/src/components/ui/employee-identity.tsx
@@ -45,7 +45,7 @@ export function EmployeeIdentity({
     ? { backgroundColor: `hsl(${hue} 60% 50%)`, color: "white" }
     : { backgroundColor: "hsl(0 0% 80%)", color: "white" };
 
-  const idLine = subtitle ?? (user.numId !== null ? `#${user.numId}` : null);
+  const idLine = subtitle ?? (user.numId != null ? `#${user.numId}` : null);
 
   const inner = (
     <div

--- a/src/components/ui/employee-identity.tsx
+++ b/src/components/ui/employee-identity.tsx
@@ -6,6 +6,13 @@ import type { EmployeeIdentityUser } from "@/models/models";
 
 type Size = "sm" | "md" | "lg";
 
+/**
+ * Identity display for an employee: avatar + name + #numId.
+ *
+ * The default subtitle line shows `#numId`. Passing `subtitle` REPLACES
+ * the #numId line entirely. To keep both, render numId in your subtitle:
+ * `subtitle={<>#{user.numId} · {user.role}</>}`.
+ */
 interface EmployeeIdentityProps {
   user: EmployeeIdentityUser;
   size?: Size;
@@ -66,10 +73,10 @@ export function EmployeeIdentity({
       </Avatar>
 
       {size === "sm" ? (
-        <div className="min-w-0 truncate">
-          <span className={NAME_TEXT[size]}>{user.name ?? "Unnamed"}</span>
+        <div className="flex min-w-0 items-baseline gap-1.5">
+          <span className={cn(NAME_TEXT[size], "truncate")}>{user.name ?? "Unnamed"}</span>
           {idLine !== null && (
-            <span className={cn("ml-1.5", ID_TEXT[size])}>· {idLine}</span>
+            <span className={cn(ID_TEXT[size], "shrink-0")}>· {idLine}</span>
           )}
         </div>
       ) : (

--- a/src/components/users/advance-payments-list.tsx
+++ b/src/components/users/advance-payments-list.tsx
@@ -29,6 +29,7 @@ import { formatDate } from "@/lib/utils";
 import { AdvancePayment } from "@/models/models";
 import { Receipt, Trash2, AlertTriangle, Loader2, MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface AdvancePaymentsListProps {
   userId: string;
@@ -189,7 +190,13 @@ export function AdvancePaymentsList({ userId, refreshKey = 0 }: AdvancePaymentsL
                     {payment.isSettled ? "Settled" : payment.status}
                   </Badge>
                 </TableCell>
-                <TableCell>{payment.approvedBy?.name || "-"}</TableCell>
+                <TableCell>
+                  {payment.approvedBy ? (
+                    <EmployeeIdentity user={payment.approvedBy} size="sm" />
+                  ) : (
+                    "-"
+                  )}
+                </TableCell>
                 <TableCell>{formatDate(payment.createdAt)}</TableCell>
                 <TableCell>
                   <div className="flex gap-2">

--- a/src/components/users/user-image-upload.tsx
+++ b/src/components/users/user-image-upload.tsx
@@ -1,19 +1,23 @@
 'use client';
 
 import {useState, useRef} from 'react';
+import {useSession} from 'next-auth/react';
 import {Button} from '@/components/ui/button';
 import {Avatar, AvatarFallback, AvatarImage} from '@/components/ui/avatar';
-import {Dialog, DialogContent} from '@/components/ui/dialog';
+import {Dialog, DialogContent, DialogTitle} from '@/components/ui/dialog';
 import {Camera, Loader2} from 'lucide-react';
 import {toast} from 'sonner';
+import {getInitials} from '@/lib/utils';
 
 interface UserImageUploadProps {
   userId: string;
   currentImage?: string | null;
   onImageUpdate?: (imageUrl: string) => void;
+  userName?: string | null;
 }
 
-export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImageUploadProps) {
+export function UserImageUpload({userId, currentImage, onImageUpdate, userName}: UserImageUploadProps) {
+  const {update: updateSession} = useSession();
   const [isUploading, setIsUploading] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(currentImage || null);
   const [isViewerOpen, setIsViewerOpen] = useState(false);
@@ -60,6 +64,7 @@ export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImage
 
       const data = await response.json();
       onImageUpdate?.(data.imageUrl);
+      await updateSession();
       toast.success('Profile image updated successfully');
     } catch (error) {
       console.error('Error uploading image:', error);
@@ -92,7 +97,7 @@ export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImage
           <Avatar className="h-32 w-32">
             <AvatarImage src={previewUrl || ''} alt="Profile image"/>
             <AvatarFallback>
-              {currentImage ? '...' : userId.slice(0, 2).toUpperCase()}
+              {currentImage ? '...' : getInitials(userName)}
             </AvatarFallback>
           </Avatar>
         </button>
@@ -124,6 +129,7 @@ export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImage
 
       <Dialog open={isViewerOpen} onOpenChange={setIsViewerOpen}>
         <DialogContent className="max-w-3xl p-2 bg-black/90 border-0 [&>button]:text-white [&>button]:bg-white/10 [&>button]:hover:bg-white/20 [&>button]:rounded-full [&>button]:p-1 [&>button]:opacity-100">
+          <DialogTitle className="sr-only">Profile image</DialogTitle>
           {previewUrl && (
             // eslint-disable-next-line @next/next/no-img-element
             <img

--- a/src/components/users/user-image-upload.tsx
+++ b/src/components/users/user-image-upload.tsx
@@ -3,6 +3,7 @@
 import {useState, useRef} from 'react';
 import {Button} from '@/components/ui/button';
 import {Avatar, AvatarFallback, AvatarImage} from '@/components/ui/avatar';
+import {Dialog, DialogContent} from '@/components/ui/dialog';
 import {Camera, Loader2} from 'lucide-react';
 import {toast} from 'sonner';
 
@@ -15,6 +16,7 @@ interface UserImageUploadProps {
 export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImageUploadProps) {
   const [isUploading, setIsUploading] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(currentImage || null);
+  const [isViewerOpen, setIsViewerOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -73,15 +75,27 @@ export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImage
     fileInputRef.current?.click();
   };
 
+  const handleAvatarClick = () => {
+    if (previewUrl) setIsViewerOpen(true);
+  };
+
   return (
     <div className="flex flex-col items-center gap-4">
       <div className="relative">
-        <Avatar className="h-32 w-32">
-          <AvatarImage src={previewUrl || ''} alt="Profile image"/>
-          <AvatarFallback>
-            {currentImage ? '...' : userId.slice(0, 2).toUpperCase()}
-          </AvatarFallback>
-        </Avatar>
+        <button
+          type="button"
+          onClick={handleAvatarClick}
+          disabled={!previewUrl}
+          className="block rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default"
+          aria-label={previewUrl ? "View profile image" : "No profile image"}
+        >
+          <Avatar className="h-32 w-32">
+            <AvatarImage src={previewUrl || ''} alt="Profile image"/>
+            <AvatarFallback>
+              {currentImage ? '...' : userId.slice(0, 2).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+        </button>
         <Button
           size="icon"
           variant="secondary"
@@ -107,6 +121,19 @@ export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImage
       <p className="text-sm text-muted-foreground">
         Supported formats: JPG, PNG, GIF. Max size: 5MB
       </p>
+
+      <Dialog open={isViewerOpen} onOpenChange={setIsViewerOpen}>
+        <DialogContent className="max-w-3xl p-2 bg-black/90 border-0">
+          {previewUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={previewUrl}
+              alt="Profile image"
+              className="w-full h-auto max-h-[80vh] object-contain rounded"
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 } 

--- a/src/components/users/user-image-upload.tsx
+++ b/src/components/users/user-image-upload.tsx
@@ -123,7 +123,7 @@ export function UserImageUpload({userId, currentImage, onImageUpdate}: UserImage
       </p>
 
       <Dialog open={isViewerOpen} onOpenChange={setIsViewerOpen}>
-        <DialogContent className="max-w-3xl p-2 bg-black/90 border-0">
+        <DialogContent className="max-w-3xl p-2 bg-black/90 border-0 [&>button]:text-white [&>button]:bg-white/10 [&>button]:hover:bg-white/20 [&>button]:rounded-full [&>button]:p-1 [&>button]:opacity-100">
           {previewUrl && (
             // eslint-disable-next-line @next/next/no-img-element
             <img

--- a/src/components/users/user-profile-form.tsx
+++ b/src/components/users/user-profile-form.tsx
@@ -301,6 +301,7 @@ export function UserProfileForm({user, branches, canEdit = true}: UserProfileFor
         <UserImageUpload
           userId={user?.id || ''}
           currentImage={user?.image}
+          userName={user?.name}
           onImageUpdate={(imageUrl) => {
             if (user) {
               user.image = imageUrl;

--- a/src/components/users/user-profile-form.tsx
+++ b/src/components/users/user-profile-form.tsx
@@ -90,7 +90,7 @@ interface Department {
 export function UserProfileForm({user, branches, canEdit = true}: UserProfileFormProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
-  const [employees, setEmployees] = useState<Array<{ id: string; name: string; email?: string | null }>>([]);
+  const [employees, setEmployees] = useState<Array<{ id: string; name: string; email?: string | null; numId?: number | null }>>([]);
   const [departments, setDepartments] = useState<Department[]>([]);
   const [referrerOpen, setReferrerOpen] = useState(false);
   const [referrerQuery, setReferrerQuery] = useState("");
@@ -530,7 +530,8 @@ export function UserProfileForm({user, branches, canEdit = true}: UserProfileFor
                 const selected = employees.find(e => e.id === field.value);
                 const filtered = referrerQuery
                   ? employees.filter(e =>
-                      (e.name + " " + (e.email || "")).toLowerCase().includes(referrerQuery.toLowerCase())
+                      (e.name + " " + (e.email || "")).toLowerCase().includes(referrerQuery.toLowerCase()) ||
+                      String(e.numId ?? '').includes(referrerQuery)
                     )
                   : employees;
                 return (

--- a/src/components/users/user-table.tsx
+++ b/src/components/users/user-table.tsx
@@ -161,7 +161,7 @@ export function  UserTable({ users, branches, currentUserRole }: UserTableProps)
     const matchesSearch =
       user.name?.toLowerCase().includes(search.toLowerCase()) ||
       user.email?.toLowerCase().includes(search.toLowerCase()) ||
-      user.numId?.toString().toLowerCase().includes(search.toLowerCase());
+      String(user.numId ?? '').includes(search);
 
     const matchesRole = roleFilter === "ALL" || user.role === roleFilter;
     const matchesBranch = branchFilter === "ALL" || user.branch?.id === branchFilter;

--- a/src/components/users/user-table.tsx
+++ b/src/components/users/user-table.tsx
@@ -25,6 +25,7 @@ import { ArrowUpDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { formatDateOnly } from "@/lib/utils";
 import { MultiSelect } from "@/components/ui/multi-select";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 
 interface UserTableProps {
   users: User[];
@@ -313,7 +314,9 @@ export function  UserTable({ users, branches, currentUserRole }: UserTableProps)
             {sortedUsers.map((user) => (
               <TableRow key={user.id}>
                 <TableCell>{user.numId || "-"}</TableCell>
-                <TableCell>{user.name}</TableCell>
+                <TableCell>
+                  <EmployeeIdentity user={user} size="md" href={`/users/${user.id}`} />
+                </TableCell>
                 <TableCell>{user.salary}</TableCell>
                 <TableCell>
                   <Badge variant="secondary" className={roleColors[user.role as keyof typeof roleColors]}>

--- a/src/components/users/warnings-list.tsx
+++ b/src/components/users/warnings-list.tsx
@@ -12,9 +12,9 @@ interface WarningItem {
   photoUrl?: string | null;
   isArchived?: boolean;
   archivedAt?: string | null;
-  archivedBy?: { id: string; name: string | null } | null;
+  archivedBy?: { id: string; name?: string | null; numId?: number | null; image?: string | null } | null;
   createdAt: string;
-  reportedBy?: { id: string; name: string | null } | null;
+  reportedBy?: { id: string; name?: string | null; numId?: number | null; image?: string | null } | null;
   warningType?: { id: string; name: string; description?: string | null } | null;
 }
 

--- a/src/components/warnings/warnings-management-page.tsx
+++ b/src/components/warnings/warnings-management-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { EmployeeIdentity } from "@/components/ui/employee-identity";
 import {
   Select,
   SelectContent,
@@ -45,12 +46,13 @@ interface Warning {
   user: {
     id: string;
     name: string | null;
-    numId: number;
+    numId?: number | null;
+    image?: string | null;
     email: string | null;
     branch: { id: string; name: string } | null;
   };
-  reportedBy: { id: string; name: string | null } | null;
-  archivedBy: { id: string; name: string | null } | null;
+  reportedBy: { id: string; name?: string | null; numId?: number | null; image?: string | null } | null;
+  archivedBy: { id: string; name?: string | null; numId?: number | null; image?: string | null } | null;
   warningType: { id: string; name: string; description: string | null } | null;
 }
 
@@ -138,7 +140,7 @@ export function WarningsManagementPage({ branches, warningTypes, userRole }: War
     const rows = filteredWarnings.map(w => [
       formatDateOnly(w.createdAt),
       w.user.name || "",
-      w.user.numId || "",
+      w.user.numId?.toString() || "",
       w.user.branch?.name || "",
       w.warningType?.name || "",
       w.reason || "",
@@ -392,10 +394,7 @@ export function WarningsManagementPage({ branches, warningTypes, userRole }: War
                     <TableRow key={warning.id}>
                       <TableCell>{formatDateOnly(warning.createdAt)}</TableCell>
                       <TableCell>
-                        <div>
-                          <div className="font-medium">{warning.user.name}</div>
-                          <div className="text-sm text-muted-foreground">#{warning.user.numId}</div>
-                        </div>
+                        <EmployeeIdentity user={warning.user} size="md" />
                       </TableCell>
                       <TableCell>{warning.user.branch?.name || "-"}</TableCell>
                       <TableCell>
@@ -408,7 +407,13 @@ export function WarningsManagementPage({ branches, warningTypes, userRole }: War
                           )}
                         </div>
                       </TableCell>
-                      <TableCell>{warning.reportedBy?.name || "-"}</TableCell>
+                      <TableCell>
+                        {warning.reportedBy ? (
+                          <EmployeeIdentity user={warning.reportedBy} size="sm" />
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
                       <TableCell>
                         <Badge variant={warning.isArchived ? "secondary" : "default"}>
                           {warning.isArchived ? "Archived" : "Active"}

--- a/src/lib/__tests__/get-initials.test.ts
+++ b/src/lib/__tests__/get-initials.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { getInitials } from '@/lib/utils';
+
+describe('getInitials', () => {
+  it('uses first letters of first and last whitespace-separated tokens', () => {
+    expect(getInitials('Rohit Kumar')).toBe('RK');
+  });
+
+  it('returns a single uppercase letter for one-word names', () => {
+    expect(getInitials('Rohit')).toBe('R');
+  });
+
+  it('ignores middle tokens', () => {
+    expect(getInitials('Rohit Kumar Singh')).toBe('RS');
+  });
+
+  it('collapses extra whitespace', () => {
+    expect(getInitials('  Rohit   Kumar  ')).toBe('RK');
+  });
+
+  it('returns "?" for null/undefined/empty input', () => {
+    expect(getInitials(null)).toBe('?');
+    expect(getInitials(undefined)).toBe('?');
+    expect(getInitials('')).toBe('?');
+    expect(getInitials('   ')).toBe('?');
+  });
+
+  it('uppercases lowercase input', () => {
+    expect(getInitials('rohit kumar')).toBe('RK');
+  });
+});

--- a/src/lib/__tests__/string-to-hue.test.ts
+++ b/src/lib/__tests__/string-to-hue.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { stringToHue } from '@/lib/utils';
+
+describe('stringToHue', () => {
+  it('returns a number in [0, 359]', () => {
+    const h = stringToHue('Rohit Kumar');
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThan(360);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(stringToHue('Anya Sharma')).toBe(stringToHue('Anya Sharma'));
+  });
+
+  it('produces different hues for different inputs', () => {
+    expect(stringToHue('Rohit')).not.toBe(stringToHue('Anya'));
+  });
+
+  it('handles the empty string', () => {
+    expect(stringToHue('')).toBe(0);
+  });
+});

--- a/src/lib/data/notes.ts
+++ b/src/lib/data/notes.ts
@@ -30,7 +30,11 @@ export async function getNote(id: string): Promise<Note | null> {
       sharedWith: {
         include: {
           user: {
-            select: userIdentitySelect
+            select: {
+              ...userIdentitySelect,
+              role: true,
+              branch: { select: { id: true, name: true } },
+            },
           }
         }
       },

--- a/src/lib/data/notes.ts
+++ b/src/lib/data/notes.ts
@@ -1,6 +1,7 @@
 import { auth } from '@/auth';
 import { prisma } from '@/lib/prisma';
 import { Note } from '@/models/models';
+import { userIdentitySelect } from '@/lib/select-presets';
 
 class NoteNotFoundError extends Error {
   constructor(message = 'Note not found') {
@@ -25,7 +26,18 @@ export async function getNote(id: string): Promise<Note | null> {
 
   const note = await prisma.note.findUnique({
     where: { id: id },
-    include: { sharedWith: true, owner: true },
+    include: {
+      sharedWith: {
+        include: {
+          user: {
+            select: userIdentitySelect
+          }
+        }
+      },
+      owner: {
+        select: userIdentitySelect
+      }
+    },
   });
 
   if (!note || note.isDeleted) {

--- a/src/lib/select-presets.ts
+++ b/src/lib/select-presets.ts
@@ -1,0 +1,11 @@
+/**
+ * Prisma `select` presets for stable cross-cutting projections.
+ * Spread these into a `.select` block so every consumer gets the same shape.
+ */
+
+export const userIdentitySelect = {
+  id: true,
+  name: true,
+  numId: true,
+  image: true,
+} as const;

--- a/src/lib/services/activity-log.ts
+++ b/src/lib/services/activity-log.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { ActivityType, Prisma } from "@prisma/client";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 export interface ActivityLogInput {
   activityType: ActivityType;
@@ -167,16 +168,14 @@ export async function getActivityLogs(options: {
       include: {
         user: {
           select: {
-            id: true,
-            name: true,
+            ...userIdentitySelect,
             email: true,
             role: true,
           },
         },
         targetUser: {
           select: {
-            id: true,
-            name: true,
+            ...userIdentitySelect,
             email: true,
             role: true,
           },

--- a/src/lib/services/attendance-conflicts.ts
+++ b/src/lib/services/attendance-conflicts.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { endOfMonth, startOfMonth } from "date-fns";
+import { userIdentitySelect } from "@/lib/select-presets";
 
 const ATTENDANCE_TIMEZONE_OFFSET_MINUTES = Number(
   process.env.ATTENDANCE_TIMEZONE_OFFSET_MINUTES ?? 330 // Default to IST (+5:30)
@@ -29,6 +30,8 @@ type AttendanceConflictEntry = {
 export type AttendanceConflictGroup = {
   userId: string;
   userName: string | null;
+  userNumId: number | null;
+  userImage: string | null;
   department: string | null;
   branchName: string | null;
   date: string;
@@ -68,8 +71,7 @@ export async function getAttendanceConflicts(month: number, year: number) {
     include: {
       user: {
         select: {
-          id: true,
-          name: true,
+          ...userIdentitySelect,
           department: {
             select: {
               id: true,
@@ -106,6 +108,8 @@ export async function getAttendanceConflicts(month: number, year: number) {
       grouped.set(mapKey, {
         userId: record.userId,
         userName: record.user?.name ?? null,
+        userNumId: record.user?.numId ?? null,
+        userImage: record.user?.image ?? null,
         department: record.user?.department?.name ?? null,
         branchName: record.user?.branch?.name ?? null,
         date: dayKey,

--- a/src/lib/types/salary-stats.dto.ts
+++ b/src/lib/types/salary-stats.dto.ts
@@ -17,6 +17,8 @@ export interface SalaryStatsDTO {
   employee: {
     id: string;
     name: string | null;
+    numId?: number | null;
+    image?: string | null;
     email: string | null;
   };
   attendance: {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,6 +53,18 @@ export function formatCurrency(amount: number): string {
 }
 
 /**
+ * Hash a string into a hue value [0, 360). Used to give each person/department
+ * a stable color (e.g. for avatar fallback backgrounds, department pills).
+ */
+export function stringToHue(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+  }
+  return hash % 360;
+}
+
+/**
  * Generates a predictable password: first 3 letters of name + special symbol + 4 random digits
  * Format: abc@1234
  */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -65,6 +65,21 @@ export function stringToHue(input: string): number {
 }
 
 /**
+ * Extract up to two initials from a person's name:
+ * first letter of first token + first letter of last token, uppercased.
+ * Returns "?" for null/empty input.
+ */
+export function getInitials(name: string | null | undefined): string {
+  if (!name) return '?';
+  const tokens = name.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return '?';
+  if (tokens.length === 1) return tokens[0].charAt(0).toUpperCase();
+  const first = tokens[0].charAt(0);
+  const last = tokens[tokens.length - 1].charAt(0);
+  return (first + last).toUpperCase();
+}
+
+/**
  * Generates a predictable password: first 3 letters of name + special symbol + 4 random digits
  * Format: abc@1234
  */

--- a/src/models/attendance.ts
+++ b/src/models/attendance.ts
@@ -4,6 +4,8 @@ import {Attendance} from "@/models/models";
 export interface AttendanceFormProps {
   userId?: string;
   userName?: string | null;
+  userNumId?: number | null;
+  userImage?: string | null;
   date?: Date;
   currentAttendance?: Attendance;
   isOpen?: boolean;

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -456,3 +456,10 @@ export interface JobOffer {
   user: User;
   department?: Department | null;
 }
+
+export type EmployeeIdentityUser = {
+  id: string;
+  name: string | null;
+  numId: number | null;
+  image: string | null;
+};

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -459,7 +459,7 @@ export interface JobOffer {
 
 export type EmployeeIdentityUser = {
   id: string;
-  name: string | null;
-  numId: number | null;
-  image: string | null;
+  name?: string | null;
+  numId?: number | null;
+  image?: string | null;
 };


### PR DESCRIPTION
## Summary

Standardizes employee identity display across the entire app. Every place that previously rendered just the employee name now shows **avatar + name + `#numId`** via a new shared `<EmployeeIdentity />` component.

- New `src/components/ui/employee-identity.tsx` with `sm`/`md`/`lg` size variants.
- New `userIdentitySelect` Prisma preset (`{ id, name, numId, image }`) spread into ~25 server fetches so payload shape is consistent.
- `stringToHue` promoted from `leave-request-table.tsx` into `src/lib/utils.ts`; new `getInitials` helper added (both unit-tested).
- Avatar fallback: stable color (hashed from name) with initials. Image is lazy-loaded.
- Top-nav session extended to carry `numId` + `image` via NextAuth JWT/session callbacks.
- `#numId` now matches in every employee search input (some already did; the rest now do too).

## Surfaces migrated

Attendance · Salary · Advances · Users/Employees · Leave · Warnings · Notes · Referrals · Activity Logs · Top-nav.

## Out of scope (deliberately)

PDF templates, CSV/Excel exports, and email bodies. UI only — per spec.

## Docs

- Spec: `docs/superpowers/specs/2026-05-21-employee-identity-display-design.md`
- Plan: `docs/superpowers/plans/2026-05-21-employee-identity-display.md`

## Test plan

- [x] `npm run build` compiles successfully (90/90 static pages)
- [x] `npx vitest run` — 140/140 pass (8 new tests across `stringToHue` and `getInitials`)
- [x] `npx tsc --noEmit` — 0 new errors (one pre-existing `TS2578` in `salary-create.test.ts:113` is unrelated)
- [ ] Manual smoke pass: log in and confirm avatar + name + #ID render on
  - `/dashboard` (pending signatures widget + top-nav)
  - `/users`, `/users/[id]`, `/users/[id]/joining-form-signature`, `/users/[id]/warnings`
  - `/employees`
  - `/attendance`, `/hr/branch-attendance`, `/hr/manage-attendance`, `/hr/pending-attendance`, `/hr/attendance-verification`, `/hr/attendance-conflicts`
  - `/salary`, `/salary/[id]`
  - `/advances`
  - `/leave-requests`
  - `/warnings`
  - any note detail page
  - `/referrals` and the referral panel on user detail pages
  - `/activity-logs`
- [ ] Search by employee number works on every list (`/users`, `/salary`, `/advances`, `/warnings`, `/employees`, and the new spots in `/activity-logs`, `/users/[id]` referrer picker, note share modal)
- [ ] Image fallback (initials on colored bg) shows for users without an uploaded image

🤖 Generated with [Claude Code](https://claude.com/claude-code)