### PR TITLE
feat: track user status history, fix reactivated-user attendance calendar

### DIFF
--- a/docs/superpowers/plans/2026-05-21-user-status-history.md
+++ b/docs/superpowers/plans/2026-05-21-user-status-history.md
@@ -1,0 +1,647 @@
+# User Status History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track every `User.status` transition in a `UserStatusHistory` table so the per-user attendance calendar can distinguish "inactive day" from "active day with no attendance record" — fixing the bug where reactivated employees show every prior day as yellow PENDING.
+
+**Architecture:** Append-only history table + Prisma migration + one-off backfill script + helper service that returns a `Set<yyyy-MM-dd>` of inactive days in a range. Calendar checks the set first; days in it render as grey INACTIVE instead of yellow PENDING. Write path on `update-status` and `approve` routes also writes a `USER_STATUS_CHANGED` activity log (closing a pre-existing audit gap).
+
+**Tech Stack:** Next.js 14 App Router · Prisma · PostgreSQL · Vitest (node env). Branch: `feature/user-status-history` (already created).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-user-status-history-design.md`
+
+---
+
+## Task 1: Add `UserStatusHistory` Prisma model
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+
+- [ ] **Step 1: Add the model**
+
+After the existing enums (around line 30), keep them. Append a new model definition above the closing of the file (or near other relational tables — pick a clean location). The model body must match the spec exactly:
+
+```prisma
+model UserStatusHistory {
+  id          String      @id @default(cuid())
+  userId      String      @map("user_id")
+  fromStatus  UserStatus? @map("from_status")
+  toStatus    UserStatus  @map("to_status")
+  changedAt   DateTime    @default(now()) @map("changed_at")
+  changedById String?     @map("changed_by_id")
+  reason      String?
+
+  user      User  @relation("UserStatusHistoryUser", fields: [userId], references: [id], onDelete: Cascade)
+  changedBy User? @relation("UserStatusHistoryChangedBy", fields: [changedById], references: [id], onDelete: SetNull)
+
+  @@index([userId, changedAt])
+  @@map("user_status_history")
+}
+```
+
+- [ ] **Step 2: Add relations to `User`**
+
+Inside `model User { ... }` (around the existing relation block — search for `attendance         Attendance[]` to find that section), append two new relation lines:
+
+```prisma
+  statusHistory        UserStatusHistory[] @relation("UserStatusHistoryUser")
+  statusHistoryChanges UserStatusHistory[] @relation("UserStatusHistoryChangedBy")
+```
+
+- [ ] **Step 3: Run the migration**
+
+```bash
+npx prisma migrate dev --name add_user_status_history
+```
+
+Expected: a new SQL migration file is created under `prisma/migrations/`, and the local DB has the new table.
+
+- [ ] **Step 4: Regenerate Prisma client**
+
+```bash
+npx prisma generate
+```
+
+Expected: TypeScript types for `prisma.userStatusHistory` are now available.
+
+- [ ] **Step 5: Verify**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 0 NEW errors (one pre-existing `TS2578` in `salary-create.test.ts:113` is unrelated; ignore).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat(schema): add UserStatusHistory table for status audit + queries"
+```
+
+---
+
+## Task 2: Write the helper service with TDD
+
+**Files:**
+- Create: `src/lib/services/user-status-history.ts`
+- Create: `src/lib/services/__tests__/user-status-history.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/lib/services/__tests__/user-status-history.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveStatusOnDate, NOT_WORKING_STATUSES } from '@/lib/services/user-status-history';
+import type { UserStatusHistory } from '@prisma/client';
+
+const mkRow = (toStatus: 'ACTIVE' | 'INACTIVE' | 'PARTIAL_INACTIVE' | 'PENDING', changedAt: string, fromStatus: 'ACTIVE' | 'INACTIVE' | 'PARTIAL_INACTIVE' | 'PENDING' | null = null): UserStatusHistory => ({
+  id: `r-${changedAt}`,
+  userId: 'u1',
+  fromStatus: fromStatus as any,
+  toStatus: toStatus as any,
+  changedAt: new Date(changedAt),
+  changedById: null,
+  reason: null,
+});
+
+describe('NOT_WORKING_STATUSES', () => {
+  it('contains INACTIVE and PARTIAL_INACTIVE', () => {
+    expect(NOT_WORKING_STATUSES.has('INACTIVE' as any)).toBe(true);
+    expect(NOT_WORKING_STATUSES.has('PARTIAL_INACTIVE' as any)).toBe(true);
+  });
+  it('does not contain ACTIVE or PENDING', () => {
+    expect(NOT_WORKING_STATUSES.has('ACTIVE' as any)).toBe(false);
+    expect(NOT_WORKING_STATUSES.has('PENDING' as any)).toBe(false);
+  });
+});
+
+describe('resolveStatusOnDate', () => {
+  const history = [
+    mkRow('ACTIVE', '2026-01-01'),
+    mkRow('INACTIVE', '2026-02-15', 'ACTIVE'),
+    mkRow('ACTIVE', '2026-04-01', 'INACTIVE'),
+  ];
+
+  it('returns null for dates before any history entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2025-12-31'))).toBeNull();
+  });
+
+  it('returns ACTIVE for dates between first and second entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-01-15'))).toBe('ACTIVE');
+  });
+
+  it('returns INACTIVE for dates between second and third entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-03-15'))).toBe('INACTIVE');
+  });
+
+  it('returns ACTIVE for dates after the final entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-06-01'))).toBe('ACTIVE');
+  });
+
+  it('treats the changedAt boundary inclusively (status on the day-of equals the new status)', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-02-15'))).toBe('INACTIVE');
+  });
+
+  it('returns null for empty history', () => {
+    expect(resolveStatusOnDate([], new Date('2026-01-01'))).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/lib/services/__tests__/user-status-history.test.ts`
+Expected: FAIL — `resolveStatusOnDate`/`NOT_WORKING_STATUSES` not exported yet.
+
+- [ ] **Step 3: Implement the service**
+
+Create `src/lib/services/user-status-history.ts`:
+
+```ts
+import { prisma } from '@/lib/prisma';
+import { UserStatus, type UserStatusHistory } from '@prisma/client';
+import { eachDayOfInterval, format } from 'date-fns';
+
+export const NOT_WORKING_STATUSES: ReadonlySet<UserStatus> = new Set<UserStatus>([
+  UserStatus.INACTIVE,
+  UserStatus.PARTIAL_INACTIVE,
+]);
+
+/**
+ * Resolve the effective UserStatus on a given date by walking sorted history.
+ * Returns null if the date predates the earliest history entry.
+ *
+ * `history` MUST be sorted ascending by `changedAt`.
+ */
+export function resolveStatusOnDate(
+  history: UserStatusHistory[],
+  date: Date,
+): UserStatus | null {
+  if (history.length === 0) return null;
+  let effective: UserStatus | null = null;
+  for (const row of history) {
+    if (row.changedAt.getTime() <= date.getTime()) {
+      effective = row.toStatus;
+    } else {
+      break;
+    }
+  }
+  return effective;
+}
+
+/**
+ * Return the set of date keys ("yyyy-MM-dd") within [startDate, endDate]
+ * during which the user was in a NOT_WORKING_STATUSES status.
+ *
+ * Returns an empty Set when no history exists (defensive for pre-backfill users).
+ */
+export async function getInactiveDateKeysInRange(
+  userId: string,
+  startDate: Date,
+  endDate: Date,
+): Promise<Set<string>> {
+  const history = await prisma.userStatusHistory.findMany({
+    where: { userId, changedAt: { lte: endDate } },
+    orderBy: { changedAt: 'asc' },
+  });
+
+  const keys = new Set<string>();
+  if (history.length === 0) return keys;
+
+  const days = eachDayOfInterval({ start: startDate, end: endDate });
+  for (const day of days) {
+    const status = resolveStatusOnDate(history, day);
+    if (status !== null && NOT_WORKING_STATUSES.has(status)) {
+      keys.add(format(day, 'yyyy-MM-dd'));
+    }
+  }
+  return keys;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/services/__tests__/user-status-history.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Full test suite**
+
+Run: `npx vitest run`
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/services/user-status-history.ts src/lib/services/__tests__/user-status-history.test.ts
+git commit -m "feat(status-history): add resolveStatusOnDate + getInactiveDateKeysInRange"
+```
+
+---
+
+## Task 3: Backfill script
+
+**Files:**
+- Create: `scripts/backfill-user-status-history.ts`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/backfill-user-status-history.ts`:
+
+```ts
+import { PrismaClient, UserStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const users = await prisma.user.findMany({
+    select: { id: true, status: true, createdAt: true, updatedAt: true },
+  });
+
+  let seeded = 0;
+  let skipped = 0;
+
+  for (const user of users) {
+    const existing = await prisma.userStatusHistory.count({ where: { userId: user.id } });
+    if (existing > 0) {
+      skipped++;
+      continue;
+    }
+
+    // Always insert an initial-state row at user.createdAt assuming ACTIVE.
+    await prisma.userStatusHistory.create({
+      data: {
+        userId: user.id,
+        fromStatus: null,
+        toStatus: UserStatus.ACTIVE,
+        changedAt: user.createdAt,
+        reason: 'backfill: initial state',
+      },
+    });
+
+    // If current status isn't ACTIVE, insert a transition row at updatedAt.
+    if (user.status !== UserStatus.ACTIVE && user.updatedAt > user.createdAt) {
+      await prisma.userStatusHistory.create({
+        data: {
+          userId: user.id,
+          fromStatus: UserStatus.ACTIVE,
+          toStatus: user.status,
+          changedAt: user.updatedAt,
+          reason: 'backfill: current state from updatedAt',
+        },
+      });
+    }
+    seeded++;
+  }
+
+  console.log(`Backfill complete. Seeded ${seeded} user(s). Skipped ${skipped} (already had history).`);
+  console.log('Note: history granularity is limited for users with multiple past transitions.');
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());
+```
+
+- [ ] **Step 2: Run the script against local DB**
+
+```bash
+npx tsx scripts/backfill-user-status-history.ts
+```
+
+Expected: prints `Seeded N user(s). Skipped 0`. Run a second time to confirm idempotency: should print `Seeded 0. Skipped N`.
+
+- [ ] **Step 3: Sanity-check DB rows**
+
+```bash
+npx prisma studio
+```
+
+Open `user_status_history` table. Spot-check: every user has at least one row. Users with non-ACTIVE status have two rows.
+
+Or via SQL one-liner:
+```bash
+npx prisma db execute --stdin <<'SQL'
+SELECT u.status, COUNT(h.*)
+FROM users1 u
+LEFT JOIN user_status_history h ON h.user_id = u.id
+GROUP BY u.status;
+SQL
+```
+
+Expected: every status group has a positive count.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/backfill-user-status-history.ts
+git commit -m "feat(scripts): backfill UserStatusHistory from createdAt/updatedAt"
+```
+
+---
+
+## Task 4: Wire `update-status/route.ts` to write history + activity log
+
+**Files:**
+- Modify: `src/app/api/users/update-status/route.ts`
+
+- [ ] **Step 1: Add the imports**
+
+Already imports `ActivityType` and `logEntityActivity`. Add nothing new — just reuse them.
+
+- [ ] **Step 2: Refactor to capture old status before update**
+
+Around line 100, where `prisma.user.update(...)` is called, change the flow:
+
+```ts
+// Fetch the user's current status before updating.
+const existingUser = await prisma.user.findUnique({
+  where: { id: userId },
+  select: { status: true },
+});
+if (!existingUser) {
+  return NextResponse.json({ error: 'User not found' }, { status: 404 });
+}
+const oldStatus = existingUser.status;
+
+// Update + write history + log activity in a single transaction.
+const updatedUser = await prisma.$transaction(async (tx) => {
+  const u = await tx.user.update({
+    where: { id: userId },
+    data: { status: status as UserStatus, updatedAt: new Date() },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      status: true,
+      branch: { select: { id: true, name: true } },
+    },
+  });
+
+  await tx.userStatusHistory.create({
+    data: {
+      userId,
+      fromStatus: oldStatus,
+      toStatus: status as UserStatus,
+      changedById: currentUser.id,
+      reason: null,
+    },
+  });
+
+  return u;
+});
+
+// Log activity outside the transaction (it has its own error handling).
+await logEntityActivity(
+  ActivityType.USER_STATUS_CHANGED,
+  currentUser.id,
+  'User',
+  userId,
+  `Status changed from ${oldStatus} to ${status}`,
+  { fromStatus: oldStatus, toStatus: status },
+  request,
+);
+```
+
+The existing referral-archive code block (above the update) stays unchanged.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx tsc --noEmit && npx vitest run
+```
+
+Expected: 0 new errors, all tests pass.
+
+- [ ] **Step 4: Manual smoke**
+
+In the dev app: change a test user's status (HR → Users → toggle status). Check via Prisma Studio that:
+- a new `user_status_history` row was inserted with correct `fromStatus`/`toStatus`/`changedById`
+- a new `ActivityLog` row was inserted with type `USER_STATUS_CHANGED`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/users/update-status/route.ts
+git commit -m "feat(users): record status transitions to history + activity log"
+```
+
+---
+
+## Task 5: Wire `approve/route.ts` to write history
+
+**Files:**
+- Modify: `src/app/api/users/approve/route.ts`
+
+- [ ] **Step 1: Locate the approve flow**
+
+`grep -n "USER_STATUS_CHANGED\|prisma.user.update" src/app/api/users/approve/route.ts` to find the existing activity-log call and the user update.
+
+- [ ] **Step 2: Add the history insert in the same transaction (or alongside the existing update)**
+
+The approve route transitions a user from `PENDING` to `ACTIVE` (or similar). Capture the old status, wrap the user update in `prisma.$transaction`, and insert a `userStatusHistory.create` call with `fromStatus`/`toStatus`/`changedById`. Same pattern as Task 4.
+
+If the existing code already runs inside a `prisma.$transaction`, simply add the history insert inside that block.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx tsc --noEmit && npx vitest run
+```
+
+Expected: 0 new errors, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/users/approve/route.ts
+git commit -m "feat(users): record approve transition to status history"
+```
+
+---
+
+## Task 6: Wire the calendar read path
+
+**Files:**
+- Modify: `src/app/(auth)/attendance/[userId]/page.tsx`
+- Modify: `src/components/attendance/detailed-attendance-calendar.tsx`
+
+- [ ] **Step 1: Fetch inactive-day set on the server page**
+
+In `src/app/(auth)/attendance/[userId]/page.tsx`, after the existing `prisma.attendance.findMany` call (around line 118-136), add:
+
+```ts
+import { getInactiveDateKeysInRange } from '@/lib/services/user-status-history';
+
+// ... inside the page component, after attendance/salary fetches:
+const inactiveDateKeys = await getInactiveDateKeysInRange(userId, startDate, endDate);
+```
+
+Pass it down to `<DetailedAttendanceCalendar>`:
+
+```tsx
+<DetailedAttendanceCalendar
+  attendance={attendance}
+  month={startDate}
+  userId={employee.id}
+  userName={employee.name || ""}
+  userNumId={employee.numId}
+  userImage={employee.image}
+  userRole={role}
+  department={employee.department?.name || ''}
+  inactiveDateKeys={Array.from(inactiveDateKeys)}
+/>
+```
+
+(We pass an array — `Set<string>` is not serialisable across the server/client boundary in Next.js. The component will rebuild the Set on the client.)
+
+- [ ] **Step 2: Update the calendar component**
+
+In `src/components/attendance/detailed-attendance-calendar.tsx`:
+
+Add the prop:
+```ts
+interface DetailedAttendanceCalendarProps {
+  attendance: Attendance[];
+  month: Date;
+  userId: string;
+  userName: string;
+  userNumId?: number | null;
+  userImage?: string | null;
+  userRole: string;
+  department: string;
+  inactiveDateKeys?: string[];
+}
+```
+
+Rebuild the Set inside the component:
+```ts
+const inactiveSet = useMemo(
+  () => new Set(inactiveDateKeys ?? []),
+  [inactiveDateKeys],
+);
+```
+
+Add `INACTIVE` to `getAttendanceStatus`. The inactive check runs FIRST, before the `!record` check:
+
+```ts
+const getAttendanceStatus = (date: Date) => {
+  const dateKey = format(date, "yyyy-MM-dd");
+  if (inactiveSet.has(dateKey)) return "INACTIVE";
+  const record = attendanceMap.get(dateKey);
+  if (!record) return "PENDING";
+  if (record.status === "PENDING_VERIFICATION") {
+    return record.isPresent ? "PENDING_PRESENT" : "PENDING_ABSENT";
+  }
+  if (!record.isPresent) return "ABSENT";
+  if (record.isWeeklyOff) return "WEEKLY_OFF";
+  if (record.isWorkFromHome) return "WORK_FROM_HOME";
+  if (record.isHalfDay) return "HALF_DAY";
+  return "PRESENT";
+};
+```
+
+Add to `statusColors`:
+```ts
+INACTIVE: "bg-gray-100 text-gray-400",
+```
+
+Make INACTIVE days non-clickable. In `handleDateClick`, add an early-return:
+```ts
+const dateKey = format(date, "yyyy-MM-dd");
+if (inactiveSet.has(dateKey)) return;
+```
+
+If there's a legend or tooltip rendering somewhere in the file, add a row for `INACTIVE` so the UX is self-explanatory.
+
+- [ ] **Step 3: Verify**
+
+```bash
+npx tsc --noEmit && npx vitest run
+```
+
+Expected: 0 new errors, all tests pass.
+
+- [ ] **Step 4: Manual smoke**
+
+In the dev app:
+1. Pick a test user. Mark them `INACTIVE` (or `PARTIAL_INACTIVE`).
+2. Visit their attendance page (`/attendance/<userId>`). All days from the inactivation moment onwards should now show grey INACTIVE instead of yellow PENDING. Clicking an inactive tile should do nothing.
+3. Mark them back to `ACTIVE`. The inactive window persists (correct). Future days remain PENDING/colored normally based on attendance records.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/\(auth\)/attendance/\[userId\]/page.tsx src/components/attendance/detailed-attendance-calendar.tsx
+git commit -m "feat(attendance): render inactive-period days as INACTIVE on calendar"
+```
+
+---
+
+## Task 7: Final verification + open PR
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: every test passes.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: 0 errors (pre-existing `TS2578` unrelated).
+
+- [ ] **Step 3: Production build**
+
+```bash
+npm run build
+```
+
+Expected: compiles successfully, generates static pages.
+
+- [ ] **Step 4: Push + PR**
+
+```bash
+git push -u origin feature/user-status-history
+gh pr create --title "feat: track user status history, fix reactivated-user attendance calendar" --body "$(cat <<'EOF'
+## Summary
+- Adds `UserStatusHistory` table (append-only audit + queryable).
+- Records every status transition from `update-status` and `approve` routes, plus a `USER_STATUS_CHANGED` activity log entry (closes a pre-existing audit gap).
+- Per-user attendance calendar now renders inactive-period days as neutral grey INACTIVE instead of yellow PENDING.
+- Backfill script seeds best-effort initial history rows for every existing user.
+
+## Out of scope
+Salary calculations, monthly reports, and other date-range views. These can adopt the new `getInactiveDateKeysInRange` helper incrementally.
+
+## Test plan
+- [ ] `npm run build` succeeds
+- [ ] `npx vitest run` passes (new tests for `resolveStatusOnDate`)
+- [ ] `npx tsc --noEmit` clean
+- [ ] Manual: toggle a test user INACTIVE / PARTIAL_INACTIVE and verify their attendance calendar shows grey INACTIVE tiles for the inactive window; reactivate and verify post-reactivation days resume their normal coloring
+- [ ] DB inspection: every status change writes one row to `user_status_history` and one to `ActivityLog`
+
+Spec: `docs/superpowers/specs/2026-05-21-user-status-history-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review (already applied)
+
+- **Spec coverage:** ✓ Every spec section maps to a task. Schema (T1), helper + tests (T2), backfill (T3), write paths (T4, T5), read path (T6), verify + PR (T7).
+- **Placeholder scan:** ✓ No TBD/TODO. Every code step shows the exact code or a concrete pattern.
+- **Type consistency:** ✓ `UserStatusHistory` shape matches between schema, helper signature, write callsites, and read callsite. `NOT_WORKING_STATUSES` is defined once and referenced from both spec and code.
+- **Realism check:** ✓ Vitest is node-only; the helper is pure + DB-mockable. Calendar gets a manual smoke pass since the repo has no jsdom setup.

--- a/docs/superpowers/specs/2026-05-21-user-status-history-design.md
+++ b/docs/superpowers/specs/2026-05-21-user-status-history-design.md
@@ -98,7 +98,7 @@ export async function getInactiveDateKeysInRange(
 
 `resolveStatusOnDate` is a pure function — walks the sorted history and returns the status that was effective at `date`. Returns `null` if the user didn't exist yet (date < earliest `changedAt`).
 
-`getInactiveDateKeysInRange` is the DB-touching helper. It loads the user's history (`where: { userId, changedAt: { lte: endDate } }, orderBy: { changedAt: 'asc' }`), iterates each day in `[startDate, endDate]`, computes the effective status, and returns a Set of `yyyy-MM-dd` keys for days where the status is in `NOT_WORKING_STATUSES`.
+`getInactiveDateKeysInRange` is the DB-touching helper. It loads the user's history (`where: { userId, changedAt: { lte: endDate } }, orderBy: { changedAt: 'asc' }`), iterates each day in `[startDate, endDate]`, computes the effective status, and returns a Set of `yyyy-MM-dd` keys for days where the status is in `NOT_WORKING_STATUSES`. Internally, each day in the range is evaluated at `endOfDay(day)` so that a status change happening any time during a day correctly classifies that calendar tile.
 
 Returns an empty Set if there is no history (defensive — pre-backfill users won't crash the calendar).
 

--- a/docs/superpowers/specs/2026-05-21-user-status-history-design.md
+++ b/docs/superpowers/specs/2026-05-21-user-status-history-design.md
@@ -1,0 +1,201 @@
+# User Status History — Design
+
+**Status:** Approved
+**Date:** 2026-05-21
+**Author:** Kunal Sharma
+
+## Goal
+
+Fix the "attendance calendar shows every day as PENDING after a reactivated employee returns" bug by introducing a proper user status history. Days when the user was `INACTIVE` or `PARTIAL_INACTIVE` should render as inactive (neutral grey), not as pending attendance.
+
+## Motivation
+
+`User.status` is a single mutable field. The calendar in `src/components/attendance/detailed-attendance-calendar.tsx:80` paints every day in the month — when no attendance record exists for a day, it returns `"PENDING"` (yellow). For an employee who was inactive for part of the month and is now active again, the inactive days have no records and incorrectly render as pending attendance, suggesting HR action is required when none is.
+
+The current schema also has no audit trail of status transitions. `approve/route.ts` logs `USER_STATUS_CHANGED` to ActivityLog; `update-status/route.ts` does not. Both routes silently lose history of intermediate transitions.
+
+## Non-Goals
+
+- Fixing date-range views beyond the per-user attendance calendar in this PR (salary calculations, monthly reports, attendance-conflicts views). Those can adopt the new helpers opportunistically as follow-ups.
+- Backfilling perfect historical transitions for existing users. Backfill is best-effort using `createdAt` + `updatedAt`.
+- Changing existing attendance records or `User.status` semantics.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Storage | New table `UserStatusHistory` (append-only) |
+| Backfill | Best-effort using `User.createdAt` (and `updatedAt` for non-ACTIVE users) |
+| "Not working" classes | `INACTIVE` **and** `PARTIAL_INACTIVE` both treated as not-working for the calendar |
+| Calendar tile for not-working day | New `INACTIVE` status, neutral grey |
+| Audit gap fix | `update-status/route.ts` now writes both `UserStatusHistory` and `USER_STATUS_CHANGED` activity log |
+| Scope | Calendar UX + plumbing only. Other consumers can adopt the helper in follow-ups. |
+
+## Architecture
+
+### Schema
+
+`prisma/schema.prisma` — new model:
+
+```prisma
+model UserStatusHistory {
+  id          String      @id @default(cuid())
+  userId      String      @map("user_id")
+  fromStatus  UserStatus? @map("from_status")
+  toStatus    UserStatus  @map("to_status")
+  changedAt   DateTime    @default(now()) @map("changed_at")
+  changedById String?     @map("changed_by_id")
+  reason      String?
+
+  user      User  @relation("UserStatusHistoryUser", fields: [userId], references: [id], onDelete: Cascade)
+  changedBy User? @relation("UserStatusHistoryChangedBy", fields: [changedById], references: [id], onDelete: SetNull)
+
+  @@index([userId, changedAt])
+  @@map("user_status_history")
+}
+```
+
+`User` gets two new relations:
+```prisma
+statusHistory       UserStatusHistory[] @relation("UserStatusHistoryUser")
+statusHistoryChanges UserStatusHistory[] @relation("UserStatusHistoryChangedBy")
+```
+
+Append-only. No updates, no deletes (except via cascade when the user is deleted).
+
+### Backfill strategy
+
+A one-off script `scripts/backfill-user-status-history.ts` seeds history rows for every existing user:
+
+- For every user, insert `(fromStatus: null, toStatus: ACTIVE, changedAt: user.createdAt, reason: 'backfill: initial state')`. The assumption is everyone started ACTIVE.
+- For users whose `status !== 'ACTIVE'`, also insert `(fromStatus: ACTIVE, toStatus: user.status, changedAt: user.updatedAt, reason: 'backfill: current state from updatedAt')`.
+
+Idempotent: if the user already has any history rows, skip (so re-runs are safe).
+
+This is an approximation. A user who went `ACTIVE → INACTIVE → ACTIVE → INACTIVE` over time will appear in the backfill as having only one transition. For the calendar bug at hand this is acceptable — going forward, every transition writes a new row, so accuracy improves monotonically. Documented as a known limitation.
+
+### Helper service
+
+`src/lib/services/user-status-history.ts`:
+
+```ts
+export const NOT_WORKING_STATUSES: ReadonlySet<UserStatus> = new Set([
+  'INACTIVE',
+  'PARTIAL_INACTIVE',
+]);
+
+export function resolveStatusOnDate(
+  history: UserStatusHistory[],   // sorted ASC by changedAt
+  date: Date,
+): UserStatus | null;
+
+export async function getInactiveDateKeysInRange(
+  userId: string,
+  startDate: Date,
+  endDate: Date,
+): Promise<Set<string>>;          // returns { "yyyy-MM-dd", ... } for days the user was not-working
+```
+
+`resolveStatusOnDate` is a pure function — walks the sorted history and returns the status that was effective at `date`. Returns `null` if the user didn't exist yet (date < earliest `changedAt`).
+
+`getInactiveDateKeysInRange` is the DB-touching helper. It loads the user's history (`where: { userId, changedAt: { lte: endDate } }, orderBy: { changedAt: 'asc' }`), iterates each day in `[startDate, endDate]`, computes the effective status, and returns a Set of `yyyy-MM-dd` keys for days where the status is in `NOT_WORKING_STATUSES`.
+
+Returns an empty Set if there is no history (defensive — pre-backfill users won't crash the calendar).
+
+### Write path
+
+**`update-status/route.ts`** — after `prisma.user.update(...)`, insert:
+```ts
+await prisma.userStatusHistory.create({
+  data: {
+    userId,
+    fromStatus: oldStatus,
+    toStatus: newStatus,
+    changedById: currentUser.id,
+    reason: null,
+  },
+});
+```
+And log to ActivityLog:
+```ts
+await logEntityActivity(
+  ActivityType.USER_STATUS_CHANGED,
+  currentUser.id,
+  'User',
+  userId,
+  `Status changed from ${oldStatus} to ${newStatus}`,
+  { fromStatus: oldStatus, toStatus: newStatus },
+  request,
+);
+```
+
+(Wrapped in a transaction with the user update so a failure in either rolls back the other.)
+
+**`approve/route.ts`** — already logs the activity. Add the history row in the same transaction.
+
+### Read path (calendar)
+
+**Server page** (`src/app/(auth)/attendance/[userId]/page.tsx`):
+
+```ts
+const inactiveDateKeys = await getInactiveDateKeysInRange(userId, startDate, endDate);
+```
+
+Pass `inactiveDateKeys` to `<DetailedAttendanceCalendar />` as a new prop (`Set<string>` of `yyyy-MM-dd`).
+
+**Calendar component** (`src/components/attendance/detailed-attendance-calendar.tsx`):
+
+```ts
+const getAttendanceStatus = (date: Date) => {
+  const dateKey = format(date, "yyyy-MM-dd");
+  if (inactiveDateKeys.has(dateKey)) return "INACTIVE";
+  const record = attendanceMap.get(dateKey);
+  if (!record) return "PENDING";
+  // ... existing branches
+};
+
+const statusColors = {
+  ...,
+  INACTIVE: "bg-gray-100 text-gray-400",
+};
+```
+
+The `INACTIVE` check runs FIRST, so an inactive day with no record shows INACTIVE — not PENDING.
+
+Clicking an INACTIVE tile is disabled (same UX as future dates — no edit affordance).
+
+## Testing
+
+- Unit tests for `resolveStatusOnDate`:
+  - Returns the effective status at a given point in history.
+  - Handles dates before the first entry (returns `null`).
+  - Handles dates after the last entry (returns the final `toStatus`).
+  - Handles multiple transitions correctly.
+- Unit tests for `getInactiveDateKeysInRange` with a stubbed Prisma client:
+  - All-active history → empty Set.
+  - INACTIVE for the whole range → all `yyyy-MM-dd` keys present.
+  - Transition mid-range → keys split at the transition date.
+  - PARTIAL_INACTIVE counts as inactive.
+- Manual smoke pass on the calendar after backfill.
+
+## Migration & deployment order
+
+1. Add the Prisma model.
+2. Run `prisma migrate dev`.
+3. Run the backfill script before deploying the new code paths (or right after — the helper handles empty history gracefully).
+4. Code changes (write-path + read-path).
+5. Verify on staging by toggling a test user INACTIVE → ACTIVE and checking the calendar.
+
+## Risk and mitigation
+
+- **Backfill imperfection.** Users with complex past status transitions show only the most-recent change. The calendar for those months may misclassify days. Acceptable for the immediate complaint (just-reactivated user); flagged as a known limitation in the script's log output.
+- **Transaction failure during write.** The user-status update and history insert are wrapped in `prisma.$transaction` so either both happen or neither.
+- **Schema migration.** New table, two new relations on User. No existing data is mutated. Migration is forward-only safe.
+- **Performance.** `getInactiveDateKeysInRange` loads at most O(transitions) history rows for the user. For typical users (1-3 transitions in their lifetime), this is negligible. Indexed on `(userId, changedAt)`.
+
+## Out of scope (explicit)
+
+- Salary calculations, monthly attendance reports, attendance-conflicts views. These also benefit from `getInactiveDateKeysInRange` but the migration is opt-in per consumer.
+- Multi-status workflows beyond what `UserStatus` already encodes.
+- UI for "view this user's status history" — the data is captured; surfacing it can be a follow-up.
+- Backfilling from ActivityLog `USER_STATUS_CHANGED` entries. The `approve/route.ts` log entries could in theory seed a more accurate history, but parsing free-text `description` strings is brittle. Keep backfill simple.

--- a/prisma/migrations/20260521120000_add_user_status_history/migration.sql
+++ b/prisma/migrations/20260521120000_add_user_status_history/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "user_status_history" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "from_status" "UserStatus",
+    "to_status" "UserStatus" NOT NULL,
+    "changed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "changed_by_id" TEXT,
+    "reason" TEXT,
+
+    CONSTRAINT "user_status_history_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_status_history_user_id_changed_at_idx" ON "user_status_history"("user_id", "changed_at");
+
+-- AddForeignKey
+ALTER TABLE "user_status_history" ADD CONSTRAINT "user_status_history_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users1"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_status_history" ADD CONSTRAINT "user_status_history_changed_by_id_fkey" FOREIGN KEY ("changed_by_id") REFERENCES "users1"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -224,6 +224,10 @@ model User {
   offerLetterSnippetsCreated OfferLetterSnippet[] @relation("OfferLetterSnippetCreatedBy")
   offerLetterSnippetsUpdated OfferLetterSnippet[] @relation("OfferLetterSnippetUpdatedBy")
 
+  // --- Status History Relations ---
+  statusHistory        UserStatusHistory[] @relation("UserStatusHistoryUser")
+  statusHistoryChanges UserStatusHistory[] @relation("UserStatusHistoryChangedBy")
+
   @@index([branchId])
   @@index([managedBranchId])
   @@index([selectedBranchId])
@@ -274,6 +278,22 @@ model Warning {
   @@index([isArchived])
   @@index([createdAt])
   @@map("warnings")
+}
+
+model UserStatusHistory {
+  id          String      @id @default(cuid())
+  userId      String      @map("user_id")
+  fromStatus  UserStatus? @map("from_status")
+  toStatus    UserStatus  @map("to_status")
+  changedAt   DateTime    @default(now()) @map("changed_at")
+  changedById String?     @map("changed_by_id")
+  reason      String?
+
+  user      User  @relation("UserStatusHistoryUser", fields: [userId], references: [id], onDelete: Cascade)
+  changedBy User? @relation("UserStatusHistoryChangedBy", fields: [changedById], references: [id], onDelete: SetNull)
+
+  @@index([userId, changedAt])
+  @@map("user_status_history")
 }
 
 model VerificationToken {

--- a/scripts/backfill-user-status-history.ts
+++ b/scripts/backfill-user-status-history.ts
@@ -1,0 +1,55 @@
+import { PrismaClient, UserStatus } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const users = await prisma.user.findMany({
+    select: { id: true, status: true, createdAt: true, updatedAt: true },
+  });
+
+  let seeded = 0;
+  let skipped = 0;
+
+  for (const user of users) {
+    const existing = await prisma.userStatusHistory.count({ where: { userId: user.id } });
+    if (existing > 0) {
+      skipped++;
+      continue;
+    }
+
+    // Always insert an initial-state row at user.createdAt assuming ACTIVE.
+    await prisma.userStatusHistory.create({
+      data: {
+        userId: user.id,
+        fromStatus: null,
+        toStatus: UserStatus.ACTIVE,
+        changedAt: user.createdAt,
+        reason: 'backfill: initial state',
+      },
+    });
+
+    // If current status isn't ACTIVE, insert a transition row at updatedAt.
+    if (user.status !== UserStatus.ACTIVE && user.updatedAt > user.createdAt) {
+      await prisma.userStatusHistory.create({
+        data: {
+          userId: user.id,
+          fromStatus: UserStatus.ACTIVE,
+          toStatus: user.status,
+          changedAt: user.updatedAt,
+          reason: 'backfill: current state from updatedAt',
+        },
+      });
+    }
+    seeded++;
+  }
+
+  console.log(`Backfill complete. Seeded ${seeded} user(s). Skipped ${skipped} (already had history).`);
+  console.log('Note: history granularity is limited for users with multiple past transitions.');
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/backfill-user-status-history.ts
+++ b/scripts/backfill-user-status-history.ts
@@ -17,25 +17,53 @@ async function main() {
       continue;
     }
 
-    // Always insert an initial-state row at user.createdAt assuming ACTIVE.
-    await prisma.userStatusHistory.create({
-      data: {
-        userId: user.id,
-        fromStatus: null,
-        toStatus: UserStatus.ACTIVE,
-        changedAt: user.createdAt,
-        reason: 'backfill: initial state',
-      },
-    });
+    if (user.status === UserStatus.PENDING) {
+      // Never approved; initial state IS PENDING.
+      await prisma.userStatusHistory.create({
+        data: {
+          userId: user.id,
+          fromStatus: null,
+          toStatus: UserStatus.PENDING,
+          changedAt: user.createdAt,
+          reason: 'backfill: initial state (pending)',
+        },
+      });
+    } else if (user.status === UserStatus.ACTIVE) {
+      // Single initial-state row at createdAt.
+      await prisma.userStatusHistory.create({
+        data: {
+          userId: user.id,
+          fromStatus: null,
+          toStatus: UserStatus.ACTIVE,
+          changedAt: user.createdAt,
+          reason: 'backfill: initial state',
+        },
+      });
+    } else {
+      // INACTIVE or PARTIAL_INACTIVE: assume created ACTIVE then transitioned.
+      // Use updatedAt for the transition row; if updatedAt === createdAt, bump by 1ms
+      // so the two rows sort deterministically.
+      const transitionAt =
+        user.updatedAt.getTime() > user.createdAt.getTime()
+          ? user.updatedAt
+          : new Date(user.createdAt.getTime() + 1);
 
-    // If current status isn't ACTIVE, insert a transition row at updatedAt.
-    if (user.status !== UserStatus.ACTIVE && user.updatedAt > user.createdAt) {
+      await prisma.userStatusHistory.create({
+        data: {
+          userId: user.id,
+          fromStatus: null,
+          toStatus: UserStatus.ACTIVE,
+          changedAt: user.createdAt,
+          reason: 'backfill: initial state',
+        },
+      });
+
       await prisma.userStatusHistory.create({
         data: {
           userId: user.id,
           fromStatus: UserStatus.ACTIVE,
           toStatus: user.status,
-          changedAt: user.updatedAt,
+          changedAt: transitionAt,
           reason: 'backfill: current state from updatedAt',
         },
       });

--- a/src/app/(auth)/attendance/[userId]/page.tsx
+++ b/src/app/(auth)/attendance/[userId]/page.tsx
@@ -12,6 +12,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { DetailedAttendanceCalendar } from "@/components/attendance/detailed-attendance-calendar";
 import { SalaryActions } from "@/components/salary/salary-actions";
+import { getInactiveDateKeysInRange } from "@/lib/services/user-status-history";
 
 export const metadata: Metadata = {
   title: "Employee Attendance - HRMS",
@@ -134,6 +135,11 @@ export default async function EmployeeAttendancePage({
       date: "asc",
     },
   }) as Attendance[];
+
+  // Get inactive date keys for the selected month
+  const inactiveDateKeys = Array.from(
+    await getInactiveDateKeysInRange(userId, startDate, endDate)
+  );
 
   // Get salary for the selected month
   const salary = await prisma.salary.findFirst({
@@ -282,6 +288,7 @@ export default async function EmployeeAttendancePage({
               userImage={employee.image}
               userRole={role}
               department={employee.department?.name || ''}
+              inactiveDateKeys={inactiveDateKeys}
             />
           </div>
         </div>

--- a/src/app/api/users/approve/route.ts
+++ b/src/app/api/users/approve/route.ts
@@ -66,31 +66,49 @@ export async function POST(req: Request) {
       };
     }
 
-    const updatedUser = await prisma.user.update({
-      where: { id: userId },
-      data: updateData,
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        role: true,
-        status: true,
-        branchId: true,
-        branch: {
-          select: {
-            id: true,
-            name: true,
-            city: true,
+    const oldStatus = userToUpdate.status;
+
+    const updatedUser = await prisma.$transaction(async (tx) => {
+      const u = await tx.user.update({
+        where: { id: userId },
+        data: updateData,
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          status: true,
+          branchId: true,
+          branch: {
+            select: {
+              id: true,
+              name: true,
+              city: true,
+            },
           },
-        },
-        approvedBy: {
-          select: {
-            id: true,
-            name: true,
+          approvedBy: {
+            select: {
+              id: true,
+              name: true,
+            },
           },
+          createdAt: true,
         },
-        createdAt: true,
-      },
+      });
+
+      if (nextStatus) {
+        await tx.userStatusHistory.create({
+          data: {
+            userId,
+            fromStatus: oldStatus,
+            toStatus: nextStatus as UserStatus,
+            changedById: approver.id,
+            reason: nextStatus === 'ACTIVE' ? 'approved' : 'status_change',
+          },
+        });
+      }
+
+      return u;
     });
 
     // Log user approval/status change

--- a/src/app/api/users/approve/route.ts
+++ b/src/app/api/users/approve/route.ts
@@ -68,6 +68,11 @@ export async function POST(req: Request) {
 
     const oldStatus = userToUpdate.status;
 
+    // No-op transition: same status → don't record history or log activity.
+    if (nextStatus && oldStatus === nextStatus) {
+      return NextResponse.json({ ...userToUpdate });
+    }
+
     const updatedUser = await prisma.$transaction(async (tx) => {
       const u = await tx.user.update({
         where: { id: userId },

--- a/src/app/api/users/approve/route.ts
+++ b/src/app/api/users/approve/route.ts
@@ -68,10 +68,8 @@ export async function POST(req: Request) {
 
     const oldStatus = userToUpdate.status;
 
-    // No-op transition: same status → don't record history or log activity.
-    if (nextStatus && oldStatus === nextStatus) {
-      return NextResponse.json({ ...userToUpdate });
-    }
+    // statusChanged is true only when nextStatus is provided and differs from current.
+    const statusChanged = Boolean(nextStatus && oldStatus !== nextStatus);
 
     const updatedUser = await prisma.$transaction(async (tx) => {
       const u = await tx.user.update({
@@ -101,7 +99,8 @@ export async function POST(req: Request) {
         },
       });
 
-      if (nextStatus) {
+      // Only record status history when the status actually changes.
+      if (statusChanged) {
         await tx.userStatusHistory.create({
           data: {
             userId,
@@ -116,7 +115,7 @@ export async function POST(req: Request) {
       return u;
     });
 
-    // Log user approval/status change
+    // Log user approval/status change — only when status actually changed.
     const approverId = (session.user as { id?: string }).id;
     if (!approverId) {
       return NextResponse.json(updatedUser);
@@ -126,7 +125,7 @@ export async function POST(req: Request) {
     if (nextStatus) changes.push(`status: ${nextStatus}`);
     if (branchId) changes.push(`branchId: ${branchId}`);
 
-    if (nextStatus === 'ACTIVE') {
+    if (statusChanged && nextStatus === 'ACTIVE') {
       await logTargetUserActivity(
         ActivityType.USER_APPROVED,
         approverId,
@@ -141,7 +140,7 @@ export async function POST(req: Request) {
       );
     }
 
-    if (nextStatus && nextStatus !== 'ACTIVE') {
+    if (statusChanged && nextStatus && nextStatus !== 'ACTIVE') {
       await logTargetUserActivity(
         ActivityType.USER_STATUS_CHANGED,
         approverId,

--- a/src/app/api/users/update-status/route.ts
+++ b/src/app/api/users/update-status/route.ts
@@ -31,7 +31,34 @@ export async function POST(request: Request) {
       );
     }
 
-    // When marking user as PARTIAL_INACTIVE or INACTIVE, archive their referrals and reverse any paid bonuses
+    // Fetch the user's current status before anything else.
+    const existingUser = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { status: true },
+    });
+    if (!existingUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const oldStatus = existingUser.status;
+
+    // No-op transition: same status → don't run referral logic, record history, or log activity.
+    if (oldStatus === status) {
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          status: true,
+          branch: { select: { id: true, name: true } },
+        },
+      });
+      return NextResponse.json(user);
+    }
+
+    // When marking user as PARTIAL_INACTIVE or INACTIVE, archive their referrals and reverse any paid bonuses.
+    // This block only runs on a real status transition (no-op already returned above).
     let referralReversal: { paidCount: number; totalReversed: number } | null = null;
     if (status === 'PARTIAL_INACTIVE' || status === 'INACTIVE') {
       const referralsAsReferred = await prisma.referral.findMany({
@@ -94,35 +121,6 @@ export async function POST(request: Request) {
           request
         );
       }
-    }
-
-    // Fetch the user's current status before updating.
-    const existingUser = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { status: true },
-    });
-    if (!existingUser) {
-      return NextResponse.json({ error: 'User not found' }, { status: 404 });
-    }
-    const oldStatus = existingUser.status;
-
-    // No-op transition: same status → don't record history or activity.
-    if (oldStatus === status) {
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          id: true,
-          name: true,
-          email: true,
-          role: true,
-          status: true,
-          branch: { select: { id: true, name: true } },
-        },
-      });
-      return NextResponse.json({
-        ...user,
-        ...(referralReversal && { referralReversal }),
-      });
     }
 
     // Update user + record status transition in a single transaction.

--- a/src/app/api/users/update-status/route.ts
+++ b/src/app/api/users/update-status/route.ts
@@ -106,11 +106,30 @@ export async function POST(request: Request) {
     }
     const oldStatus = existingUser.status;
 
+    // No-op transition: same status → don't record history or activity.
+    if (oldStatus === status) {
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          status: true,
+          branch: { select: { id: true, name: true } },
+        },
+      });
+      return NextResponse.json({
+        ...user,
+        ...(referralReversal && { referralReversal }),
+      });
+    }
+
     // Update user + record status transition in a single transaction.
     const updatedUser = await prisma.$transaction(async (tx) => {
       const u = await tx.user.update({
         where: { id: userId },
-        data: { status: status as UserStatus, updatedAt: new Date() },
+        data: { status: status as UserStatus },
         select: {
           id: true,
           name: true,

--- a/src/app/api/users/update-status/route.ts
+++ b/src/app/api/users/update-status/route.ts
@@ -96,27 +96,54 @@ export async function POST(request: Request) {
       }
     }
 
-    // Update user's status
-    const updatedUser = await prisma.user.update({
+    // Fetch the user's current status before updating.
+    const existingUser = await prisma.user.findUnique({
       where: { id: userId },
-      data: {
-        status: status as UserStatus,
-        updatedAt: new Date(),
-      },
-      select: {
-        id: true,
-        name: true,
-        email: true,
-        role: true,
-        status: true,
-        branch: {
-          select: {
-            id: true,
-            name: true,
-          }
-        }
-      }
+      select: { status: true },
     });
+    if (!existingUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const oldStatus = existingUser.status;
+
+    // Update user + record status transition in a single transaction.
+    const updatedUser = await prisma.$transaction(async (tx) => {
+      const u = await tx.user.update({
+        where: { id: userId },
+        data: { status: status as UserStatus, updatedAt: new Date() },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          role: true,
+          status: true,
+          branch: { select: { id: true, name: true } },
+        },
+      });
+
+      await tx.userStatusHistory.create({
+        data: {
+          userId,
+          fromStatus: oldStatus,
+          toStatus: status as UserStatus,
+          changedById: currentUser.id,
+          reason: null,
+        },
+      });
+
+      return u;
+    });
+
+    // Activity log lives outside the transaction (has its own error handling).
+    await logEntityActivity(
+      ActivityType.USER_STATUS_CHANGED,
+      currentUser.id,
+      'User',
+      userId,
+      `Status changed from ${oldStatus} to ${status}`,
+      { fromStatus: oldStatus, toStatus: status },
+      request,
+    );
 
     return NextResponse.json({
       ...updatedUser,

--- a/src/components/attendance/detailed-attendance-calendar.tsx
+++ b/src/components/attendance/detailed-attendance-calendar.tsx
@@ -3,7 +3,7 @@
 import { eachDayOfInterval, endOfMonth, format, getDay, startOfMonth } from "date-fns";
 import { cn } from "@/lib/utils";
 import { Attendance } from "@/models/models";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { AttendanceForm } from "./attendance-form";
 import { Badge } from "@/components/ui/badge";
 
@@ -16,6 +16,7 @@ interface DetailedAttendanceCalendarProps {
   userImage?: string | null;
   userRole: string;
   department: string;
+  inactiveDateKeys?: string[];
 }
 
 export function DetailedAttendanceCalendar({
@@ -26,10 +27,16 @@ export function DetailedAttendanceCalendar({
   userNumId,
   userImage,
   userRole,
-  department
+  department,
+  inactiveDateKeys,
 }: DetailedAttendanceCalendarProps) {
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [selectedAttendance, setSelectedAttendance] = useState<Attendance | null>(null);
+
+  const inactiveSet = useMemo(
+    () => new Set(inactiveDateKeys ?? []),
+    [inactiveDateKeys],
+  );
 
   const days = eachDayOfInterval({
     start: startOfMonth(month),
@@ -48,6 +55,7 @@ export function DetailedAttendanceCalendar({
 
   const handleDateClick = (date: Date) => {
     const dateKey = format(date, "yyyy-MM-dd");
+    if (inactiveSet.has(dateKey)) return;
     const existingAttendance = attendanceMap.get(dateKey);
     
     const today = new Date();
@@ -76,6 +84,7 @@ export function DetailedAttendanceCalendar({
 
   const getAttendanceStatus = (date: Date) => {
     const dateKey = format(date, "yyyy-MM-dd");
+    if (inactiveSet.has(dateKey)) return "INACTIVE";
     const record = attendanceMap.get(dateKey);
     if (!record) return "PENDING";
     if (record.status === "PENDING_VERIFICATION") {
@@ -97,6 +106,7 @@ export function DetailedAttendanceCalendar({
     WORK_FROM_HOME: "bg-teal-100 text-teal-800",
     PENDING_PRESENT: "bg-green-100 text-green-800",
     PENDING_ABSENT: "bg-red-100 text-red-800",
+    INACTIVE: "bg-gray-100 text-gray-400",
   } as const;
 
   return (

--- a/src/lib/services/__tests__/user-status-history.test.ts
+++ b/src/lib/services/__tests__/user-status-history.test.ts
@@ -58,3 +58,18 @@ describe('resolveStatusOnDate', () => {
     expect(resolveStatusOnDate([], new Date('2026-01-01'))).toBeNull();
   });
 });
+
+describe('resolveStatusOnDate — wall-clock changedAt', () => {
+  const history = [
+    mkRow(UserStatus.ACTIVE, '2026-01-01T00:00:00Z'),
+    mkRow(UserStatus.INACTIVE, '2026-02-15T14:00:00Z', UserStatus.ACTIVE),
+  ];
+
+  it('returns ACTIVE for midnight of the change day (caller should use end-of-day)', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-02-15T00:00:00Z'))).toBe(UserStatus.ACTIVE);
+  });
+
+  it('returns INACTIVE for end-of-day on the change day', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-02-15T23:59:59Z'))).toBe(UserStatus.INACTIVE);
+  });
+});

--- a/src/lib/services/__tests__/user-status-history.test.ts
+++ b/src/lib/services/__tests__/user-status-history.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { resolveStatusOnDate, NOT_WORKING_STATUSES } from '@/lib/services/user-status-history';
-import type { UserStatusHistory } from '@prisma/client';
+import { UserStatus, type UserStatusHistory } from '@prisma/client';
 
-const mkRow = (toStatus: 'ACTIVE' | 'INACTIVE' | 'PARTIAL_INACTIVE' | 'PENDING', changedAt: string, fromStatus: 'ACTIVE' | 'INACTIVE' | 'PARTIAL_INACTIVE' | 'PENDING' | null = null): UserStatusHistory => ({
+const mkRow = (
+  toStatus: UserStatus,
+  changedAt: string,
+  fromStatus: UserStatus | null = null,
+): UserStatusHistory => ({
   id: `r-${changedAt}`,
   userId: 'u1',
-  fromStatus: fromStatus as any,
-  toStatus: toStatus as any,
+  fromStatus,
+  toStatus,
   changedAt: new Date(changedAt),
   changedById: null,
   reason: null,
@@ -14,20 +18,20 @@ const mkRow = (toStatus: 'ACTIVE' | 'INACTIVE' | 'PARTIAL_INACTIVE' | 'PENDING',
 
 describe('NOT_WORKING_STATUSES', () => {
   it('contains INACTIVE and PARTIAL_INACTIVE', () => {
-    expect(NOT_WORKING_STATUSES.has('INACTIVE' as any)).toBe(true);
-    expect(NOT_WORKING_STATUSES.has('PARTIAL_INACTIVE' as any)).toBe(true);
+    expect(NOT_WORKING_STATUSES.has(UserStatus.INACTIVE)).toBe(true);
+    expect(NOT_WORKING_STATUSES.has(UserStatus.PARTIAL_INACTIVE)).toBe(true);
   });
   it('does not contain ACTIVE or PENDING', () => {
-    expect(NOT_WORKING_STATUSES.has('ACTIVE' as any)).toBe(false);
-    expect(NOT_WORKING_STATUSES.has('PENDING' as any)).toBe(false);
+    expect(NOT_WORKING_STATUSES.has(UserStatus.ACTIVE)).toBe(false);
+    expect(NOT_WORKING_STATUSES.has(UserStatus.PENDING)).toBe(false);
   });
 });
 
 describe('resolveStatusOnDate', () => {
   const history = [
-    mkRow('ACTIVE', '2026-01-01'),
-    mkRow('INACTIVE', '2026-02-15', 'ACTIVE'),
-    mkRow('ACTIVE', '2026-04-01', 'INACTIVE'),
+    mkRow(UserStatus.ACTIVE, '2026-01-01'),
+    mkRow(UserStatus.INACTIVE, '2026-02-15', UserStatus.ACTIVE),
+    mkRow(UserStatus.ACTIVE, '2026-04-01', UserStatus.INACTIVE),
   ];
 
   it('returns null for dates before any history entry', () => {
@@ -35,19 +39,19 @@ describe('resolveStatusOnDate', () => {
   });
 
   it('returns ACTIVE for dates between first and second entry', () => {
-    expect(resolveStatusOnDate(history, new Date('2026-01-15'))).toBe('ACTIVE');
+    expect(resolveStatusOnDate(history, new Date('2026-01-15'))).toBe(UserStatus.ACTIVE);
   });
 
   it('returns INACTIVE for dates between second and third entry', () => {
-    expect(resolveStatusOnDate(history, new Date('2026-03-15'))).toBe('INACTIVE');
+    expect(resolveStatusOnDate(history, new Date('2026-03-15'))).toBe(UserStatus.INACTIVE);
   });
 
   it('returns ACTIVE for dates after the final entry', () => {
-    expect(resolveStatusOnDate(history, new Date('2026-06-01'))).toBe('ACTIVE');
+    expect(resolveStatusOnDate(history, new Date('2026-06-01'))).toBe(UserStatus.ACTIVE);
   });
 
   it('treats the changedAt boundary inclusively (status on the day-of equals the new status)', () => {
-    expect(resolveStatusOnDate(history, new Date('2026-02-15'))).toBe('INACTIVE');
+    expect(resolveStatusOnDate(history, new Date('2026-02-15'))).toBe(UserStatus.INACTIVE);
   });
 
   it('returns null for empty history', () => {

--- a/src/lib/services/__tests__/user-status-history.test.ts
+++ b/src/lib/services/__tests__/user-status-history.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStatusOnDate, NOT_WORKING_STATUSES } from '@/lib/services/user-status-history';
+import type { UserStatusHistory } from '@prisma/client';
+
+const mkRow = (toStatus: 'ACTIVE' | 'INACTIVE' | 'PARTIAL_INACTIVE' | 'PENDING', changedAt: string, fromStatus: 'ACTIVE' | 'INACTIVE' | 'PARTIAL_INACTIVE' | 'PENDING' | null = null): UserStatusHistory => ({
+  id: `r-${changedAt}`,
+  userId: 'u1',
+  fromStatus: fromStatus as any,
+  toStatus: toStatus as any,
+  changedAt: new Date(changedAt),
+  changedById: null,
+  reason: null,
+});
+
+describe('NOT_WORKING_STATUSES', () => {
+  it('contains INACTIVE and PARTIAL_INACTIVE', () => {
+    expect(NOT_WORKING_STATUSES.has('INACTIVE' as any)).toBe(true);
+    expect(NOT_WORKING_STATUSES.has('PARTIAL_INACTIVE' as any)).toBe(true);
+  });
+  it('does not contain ACTIVE or PENDING', () => {
+    expect(NOT_WORKING_STATUSES.has('ACTIVE' as any)).toBe(false);
+    expect(NOT_WORKING_STATUSES.has('PENDING' as any)).toBe(false);
+  });
+});
+
+describe('resolveStatusOnDate', () => {
+  const history = [
+    mkRow('ACTIVE', '2026-01-01'),
+    mkRow('INACTIVE', '2026-02-15', 'ACTIVE'),
+    mkRow('ACTIVE', '2026-04-01', 'INACTIVE'),
+  ];
+
+  it('returns null for dates before any history entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2025-12-31'))).toBeNull();
+  });
+
+  it('returns ACTIVE for dates between first and second entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-01-15'))).toBe('ACTIVE');
+  });
+
+  it('returns INACTIVE for dates between second and third entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-03-15'))).toBe('INACTIVE');
+  });
+
+  it('returns ACTIVE for dates after the final entry', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-06-01'))).toBe('ACTIVE');
+  });
+
+  it('treats the changedAt boundary inclusively (status on the day-of equals the new status)', () => {
+    expect(resolveStatusOnDate(history, new Date('2026-02-15'))).toBe('INACTIVE');
+  });
+
+  it('returns null for empty history', () => {
+    expect(resolveStatusOnDate([], new Date('2026-01-01'))).toBeNull();
+  });
+});

--- a/src/lib/services/user-status-history.ts
+++ b/src/lib/services/user-status-history.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { UserStatus, type UserStatusHistory } from '@prisma/client';
-import { eachDayOfInterval, format } from 'date-fns';
+import { eachDayOfInterval, endOfDay, format } from 'date-fns';
 
 export const NOT_WORKING_STATUSES: ReadonlySet<UserStatus> = new Set<UserStatus>([
   UserStatus.INACTIVE,
@@ -50,7 +50,9 @@ export async function getInactiveDateKeysInRange(
 
   const days = eachDayOfInterval({ start: startDate, end: endDate });
   for (const day of days) {
-    const status = resolveStatusOnDate(history, day);
+    // Evaluate at end-of-day so any status change happening during the day
+    // (or earlier) counts toward that day's classification.
+    const status = resolveStatusOnDate(history, endOfDay(day));
     if (status !== null && NOT_WORKING_STATUSES.has(status)) {
       keys.add(format(day, 'yyyy-MM-dd'));
     }

--- a/src/lib/services/user-status-history.ts
+++ b/src/lib/services/user-status-history.ts
@@ -1,0 +1,59 @@
+import { prisma } from '@/lib/prisma';
+import { UserStatus, type UserStatusHistory } from '@prisma/client';
+import { eachDayOfInterval, format } from 'date-fns';
+
+export const NOT_WORKING_STATUSES: ReadonlySet<UserStatus> = new Set<UserStatus>([
+  UserStatus.INACTIVE,
+  UserStatus.PARTIAL_INACTIVE,
+]);
+
+/**
+ * Resolve the effective UserStatus on a given date by walking sorted history.
+ * Returns null if the date predates the earliest history entry.
+ *
+ * `history` MUST be sorted ascending by `changedAt`.
+ */
+export function resolveStatusOnDate(
+  history: UserStatusHistory[],
+  date: Date,
+): UserStatus | null {
+  if (history.length === 0) return null;
+  let effective: UserStatus | null = null;
+  for (const row of history) {
+    if (row.changedAt.getTime() <= date.getTime()) {
+      effective = row.toStatus;
+    } else {
+      break;
+    }
+  }
+  return effective;
+}
+
+/**
+ * Return the set of date keys ("yyyy-MM-dd") within [startDate, endDate]
+ * during which the user was in a NOT_WORKING_STATUSES status.
+ *
+ * Returns an empty Set when no history exists (defensive for pre-backfill users).
+ */
+export async function getInactiveDateKeysInRange(
+  userId: string,
+  startDate: Date,
+  endDate: Date,
+): Promise<Set<string>> {
+  const history = await prisma.userStatusHistory.findMany({
+    where: { userId, changedAt: { lte: endDate } },
+    orderBy: { changedAt: 'asc' },
+  });
+
+  const keys = new Set<string>();
+  if (history.length === 0) return keys;
+
+  const days = eachDayOfInterval({ start: startDate, end: endDate });
+  for (const day of days) {
+    const status = resolveStatusOnDate(history, day);
+    if (status !== null && NOT_WORKING_STATUSES.has(status)) {
+      keys.add(format(day, 'yyyy-MM-dd'));
+    }
+  }
+  return keys;
+}


### PR DESCRIPTION
## Summary

Fixes the bug where reactivating an INACTIVE employee made the attendance calendar show every day in the month as yellow PENDING. The root cause: the calendar painted every day without an attendance record as PENDING regardless of whether the user was even working on that day.

- Adds `UserStatusHistory` table — append-only audit trail of every status transition.
- `update-status/route.ts` and `approve/route.ts` now record transitions to history + log `USER_STATUS_CHANGED` to ActivityLog (closes a pre-existing audit gap in `update-status`).
- New helper `getInactiveDateKeysInRange(userId, start, end)` returns the set of `yyyy-MM-dd` keys when the user was INACTIVE or PARTIAL_INACTIVE.
- Calendar checks the inactive-set FIRST; inactive days render as neutral grey `INACTIVE` (and are non-clickable).
- One-off `scripts/backfill-user-status-history.ts` seeds best-effort history for every existing user. Idempotent.

## Scope (out of scope intentionally)

- Salary calculations, monthly reports, and other date-range views are NOT modified. They can adopt `getInactiveDateKeysInRange` incrementally.
- Backfill uses `createdAt`/`updatedAt` as approximate timestamps — users with multiple past transitions show only one. Going forward every transition is captured accurately.

## Migration note

A new `prisma/migrations/20260521120000_add_user_status_history/migration.sql` is included. Apply with `npx prisma migrate deploy` on prod. After deploy, run the backfill once: `npx tsx scripts/backfill-user-status-history.ts` (idempotent).

## Test plan

- [x] `npm run build` compiles successfully
- [x] `npx vitest run` — 148/148 pass (8 new tests for `resolveStatusOnDate` covering boundary conditions)
- [x] `npx tsc --noEmit` — 0 new errors
- [ ] Manual: toggle a test user INACTIVE / PARTIAL_INACTIVE and verify their attendance calendar shows grey INACTIVE tiles for the inactive window; reactivate and verify post-reactivation days resume normal coloring
- [ ] DB inspection: every status change writes one row to `user_status_history` and one to `ActivityLog`

Spec: \`docs/superpowers/specs/2026-05-21-user-status-history-design.md\`
Plan: \`docs/superpowers/plans/2026-05-21-user-status-history.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)