### PR TITLE
chore: gitignore graphify-out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 
 azure-functions/.venv
 
+
+# graphify
+graphify-out/


### PR DESCRIPTION
One-line gitignore addition so the local \`graphify-out/\` directory (generated by the graphify post-commit hook) stays out of version control.

Generated by graphify on commit, not source. Safe to ignore for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)