### PR TITLE
hotfix(auth): protect jwt callback from DB errors to prevent forced logouts

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -83,28 +83,40 @@ export default {
         token.numId = user.numId;
         token.image = user.image;
       }
-      // Refresh numId/image from DB if absent (e.g. existing sessions)
+      // Refresh numId/image from DB if absent (e.g. existing sessions).
+      // Wrapped in try/catch so a transient DB error (pool exhaustion, timeout)
+      // doesn't throw out of the jwt callback and invalidate the session.
+      // Worst case on failure: token stays un-enriched and we retry next request.
       if (token.sub && (token.numId === undefined || token.image === undefined)) {
-        const dbUser = await prisma.user.findUnique({
-          where: { id: token.sub },
-          select: userIdentitySelect,
-        });
-        if (dbUser) {
-          token.numId = dbUser.numId;
-          token.image = dbUser.image;
-          token.name = dbUser.name;
+        try {
+          const dbUser = await prisma.user.findUnique({
+            where: { id: token.sub },
+            select: userIdentitySelect,
+          });
+          if (dbUser) {
+            token.numId = dbUser.numId;
+            token.image = dbUser.image;
+            token.name = dbUser.name;
+          }
+        } catch (err) {
+          console.error('[auth.jwt] bootstrap fetch failed (non-fatal):', err);
         }
       }
-      // Re-fetch identity from DB when session.update() is called (e.g. after profile picture upload)
+      // Re-fetch identity from DB when session.update() is called (e.g. after profile picture upload).
+      // Same try/catch protection.
       if (trigger === 'update' && token.sub) {
-        const dbUser = await prisma.user.findUnique({
-          where: { id: token.sub },
-          select: userIdentitySelect,
-        });
-        if (dbUser) {
-          token.numId = dbUser.numId;
-          token.image = dbUser.image;
-          token.name = dbUser.name;
+        try {
+          const dbUser = await prisma.user.findUnique({
+            where: { id: token.sub },
+            select: userIdentitySelect,
+          });
+          if (dbUser) {
+            token.numId = dbUser.numId;
+            token.image = dbUser.image;
+            token.name = dbUser.name;
+          }
+        } catch (err) {
+          console.error('[auth.jwt] update fetch failed (non-fatal):', err);
         }
       }
       return token;


### PR DESCRIPTION
## Incident

After the PR #42 deploy, users were reporting random logouts.

## Root cause

\`src/auth.config.ts\` jwt callback added a bootstrap path that runs \`prisma.user.findUnique\` on **every authenticated request** for sessions issued before the deploy (all sessions, since this was the first deploy with the new auth shape).

When that DB call throws (connection-pool saturation, transient network blip, query timeout), NextAuth treats the thrown jwt callback as an invalid session → **logs the user out**. The "random" pattern matches whoever happens to hit a saturated pool.

## Fix

Wrap both DB-touching branches (bootstrap and \`trigger === 'update'\`) in try/catch. On failure: log the error, swallow it, and let the un-enriched token survive. The token will be retried on the next request. Session stays valid.

Worst-case on persistent failure: top-nav avatar / employee number isn't populated until DB recovers — acceptable degradation vs. forced logout.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` compiles
- [ ] Deploy → monitor: random logouts should stop within minutes (as soon as the new code is live)
- [ ] Login flow still works
- [ ] Top-nav still shows avatar + #ID for fresh logins

🤖 Generated with [Claude Code](https://claude.com/claude-code)