### PR TITLE
feat(kiosk): punch pipeline — sync, grooming, punch-service, route, runbook (Phase 2)

### DIFF
--- a/docs/superpowers/runbooks/kiosk-endpoint-smoke.md
+++ b/docs/superpowers/runbooks/kiosk-endpoint-smoke.md
@@ -1,0 +1,189 @@
+# Kiosk Endpoint Smoke — Phase 1+2
+
+End-to-end manual smoke for the kiosk backend. Run before opening the PR and after every backend change.
+
+## Prerequisites
+
+- `next dev` is running on `http://localhost:3000`
+- You are signed in to opsy as an `HR` or `MANAGEMENT` user in a browser; copy the session cookie if needed for device provisioning
+- Postgres is healthy and `npm run seed:shifts` has been run
+- `.env` has `AZURE_AI_FOUNDRY_*` set (the grooming endpoint will reject without them — that's fine, you'll see `ERROR` verdicts but the punch still records)
+- Have two small JPEGs ready: `uniform.jpg` (≤512KB) and `nails.jpg` (≤512KB)
+
+## Variables
+
+Replace `<BRANCH_A_ID>` and `<BRANCH_B_ID>` with two real Branch IDs (different outlets). `<USER_ID>` is an `ACTIVE` employee currently assigned to `<BRANCH_A_ID>`.
+
+```bash
+BASE=http://localhost:3000
+BRANCH_A=<BRANCH_A_ID>
+BRANCH_B=<BRANCH_B_ID>
+USER_ID=<USER_ID>
+```
+
+## 1. Provision a kiosk device
+
+Uses your NextAuth session — easiest from the browser DevTools console:
+
+```js
+await fetch('/api/kiosk/devices', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ name: 'Smoke Kiosk', branchId: '<BRANCH_A_ID>' })
+}).then(r => r.json())
+```
+
+**Expected:** `201` with `{ device: { id, ... }, token: "<RAW_TOKEN_ONCE>", warning }`. **Copy the token** — you can't retrieve it again.
+
+```bash
+DEVICE_ID=<from response>
+TOKEN=<from response>
+```
+
+## 2. Handshake
+
+```bash
+curl -s "$BASE/api/kiosk/handshake" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Kiosk-Device-Id: $DEVICE_ID" | jq
+```
+
+**Expected:** `{ device: { id, branchId }, branch: { id, name }, serverTime }`. A bad token returns 401.
+
+## 3. Shifts list
+
+```bash
+curl -s "$BASE/api/kiosk/shifts" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Kiosk-Device-Id: $DEVICE_ID" | jq
+```
+
+**Expected:** three shifts (Full Day / Break One / Mid-Night). "Break One" has two segments.
+
+## 4. Enroll a fingerprint (any base64 stand-in for the smoke)
+
+```bash
+curl -s -X POST "$BASE/api/kiosk/fingerprints/enroll" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Kiosk-Device-Id: $DEVICE_ID" \
+  -H "Content-Type: application/json" \
+  -d "{\"userId\":\"$USER_ID\",\"fingerIndex\":1,\"templateData\":\"VEVTVF9URU1QTEFURQ==\"}" | jq
+```
+
+**Expected:** `201 { enrollment: { id, userId, fingerIndex: 1, isActive: true, updatedAt } }`.
+
+## 5. Sync — full reconcile
+
+```bash
+curl -s "$BASE/api/kiosk/fingerprints" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Kiosk-Device-Id: $DEVICE_ID" | jq '.enrollments | length, .serverTime'
+```
+
+**Expected:** count ≥ 1; `serverTime` is current. Each enrollment carries `branchId` (the owner's current outlet).
+
+## 6. Sync — delta (should return at least the enrollment we just made)
+
+```bash
+curl -s "$BASE/api/kiosk/fingerprints?updatedSince=2020-01-01T00:00:00Z" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Kiosk-Device-Id: $DEVICE_ID" | jq '.enrollments | length'
+```
+
+**Expected:** ≥ 1.
+
+## 7. Punch at the **wrong** outlet → 403 + BLOCKED_WRONG_OUTLET PunchEvent + no Attendance
+
+First, **move the user to Branch B in the web app** (so their `branchId` ≠ this kiosk's branch):
+
+```bash
+# In a separate shell, via your existing employee-edit endpoint or directly in Prisma Studio:
+npx prisma studio
+# → users1 table → set branchId of <USER_ID> to <BRANCH_B_ID>
+```
+
+Grab a shift ID for the punch:
+
+```bash
+SHIFT_ID=$(curl -s "$BASE/api/kiosk/shifts" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Kiosk-Device-Id: $DEVICE_ID" | jq -r '.shifts[0].id')
+echo "Using shift: $SHIFT_ID"
+```
+
+Now punch (build the JSON with base64-encoded JPEGs):
+
+```bash
+UNIFORM_B64=$(base64 -i uniform.jpg | tr -d '\n')
+NAILS_B64=$(base64 -i nails.jpg | tr -d '\n')
+
+cat > /tmp/punch-wrong.json <<EOF
+{
+  "userId": "$USER_ID",
+  "shiftId": "$SHIFT_ID",
+  "direction": "IN",
+  "punchedAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "uniformPhoto": "$UNIFORM_B64",
+  "nailsPhoto": "$NAILS_B64"
+}
+EOF
+
+curl -s -X POST "$BASE/api/kiosk/punch" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Kiosk-Device-Id: $DEVICE_ID" \
+  -H "Content-Type: application/json" \
+  --data-binary @/tmp/punch-wrong.json -w "\nHTTP %{http_code}\n" | jq
+```
+
+**Expected:** `HTTP 403`, body: `{ blocked: true, reason: "WRONG_OUTLET", assignedBranch: { id: "<BRANCH_B>", name }, punchEventId }`.
+
+Verify in DB:
+
+```bash
+npx tsx -e "import { prisma } from './src/lib/prisma'; (async () => {
+  const pe = await prisma.punchEvent.findMany({ where: { outcome: 'BLOCKED_WRONG_OUTLET' }, orderBy: { createdAt: 'desc' }, take: 1 });
+  console.log('PunchEvent:', pe);
+  const att = await prisma.attendance.findMany({ where: { userId: '$USER_ID' }, orderBy: { createdAt: 'desc' }, take: 1 });
+  console.log('Attendance:', att);
+  await prisma.\$disconnect();
+})()"
+```
+
+**Expected:** one `BLOCKED_WRONG_OUTLET` PunchEvent with `attendanceId: null`, `uniformPhotoUrl: null`. NO Attendance row created by this punch.
+
+## 8. Move the user back to Branch A → punch succeeds
+
+Move user back via Prisma Studio (`branchId = <BRANCH_A_ID>`), then re-run the punch curl above.
+
+**Expected:** `HTTP 200`, body has `punchEventId`, `attendanceId`, `grooming`, `overallGroomingPass`.
+
+Verify:
+
+```bash
+npx tsx -e "import { prisma } from './src/lib/prisma'; (async () => {
+  const att = await prisma.attendance.findFirst({ where: { userId: '$USER_ID' }, orderBy: { date: 'desc' } });
+  console.log('Latest Attendance:', att);
+  await prisma.\$disconnect();
+})()"
+```
+
+**Expected:** `isPresent: true`, `checkIn` is an `HH:mm` IST string, `branchId == <BRANCH_A_ID>`, `status: 'PENDING_VERIFICATION'`.
+
+## 9. Punch OUT same user same day → checkOut set on the same Attendance row
+
+Re-run the punch curl with `direction: "OUT"`.
+
+**Expected:** same `attendanceId` as the IN punch, `checkOut` populated, no second Attendance row.
+
+## 10. HR can still verify/edit the kiosk-created Attendance
+
+In the existing HR UI, open the attendance row from step 8/9. Verify and approve. Confirm the existing flow works unchanged.
+
+## 11. Cleanup
+
+```bash
+npx tsx -e "import { prisma } from './src/lib/prisma'; (async () => {
+  await prisma.kioskDevice.update({ where: { id: '$DEVICE_ID' }, data: { isActive: false } });
+  await prisma.\$disconnect();
+})()"
+```

--- a/src/app/api/kiosk/fingerprints/enroll/route.ts
+++ b/src/app/api/kiosk/fingerprints/enroll/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { ActivityType } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { authenticateKiosk } from "@/lib/kiosk-auth";
+import { logEntityActivity } from "@/lib/services/activity-log";
+
+/**
+ * POST /api/kiosk/fingerprints/enroll
+ *
+ * Body: { userId: string; fingerIndex: number (0..9); templateData: string (base64 ISO 19794-2) }
+ *
+ * Globally enrollable — any kiosk in HR enroll-mode can enroll any active user
+ * (the spec calls this out: identification is global so the user can punch
+ * anywhere they're assigned). Upserts on (userId, fingerIndex) so re-enrolling
+ * a finger replaces the old template.
+ */
+export async function POST(req: Request) {
+  const authed = await authenticateKiosk(req);
+  if (!authed) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { userId?: string; fingerIndex?: number; templateData?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { userId, fingerIndex, templateData } = body;
+  if (!userId || typeof fingerIndex !== "number" || !templateData) {
+    return NextResponse.json(
+      { error: "userId, fingerIndex (number), and templateData are required" },
+      { status: 400 }
+    );
+  }
+  if (fingerIndex < 0 || fingerIndex > 9 || !Number.isInteger(fingerIndex)) {
+    return NextResponse.json({ error: "fingerIndex must be an integer 0..9" }, { status: 400 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, status: true },
+  });
+  if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
+  if (user.status !== "ACTIVE") {
+    return NextResponse.json({ error: "User is not ACTIVE" }, { status: 409 });
+  }
+
+  const enrollment = await prisma.fingerprintEnrollment.upsert({
+    where: { userId_fingerIndex: { userId, fingerIndex } },
+    create: {
+      userId,
+      fingerIndex,
+      templateData,
+      enrolledByDeviceId: authed.device.id,
+      isActive: true,
+    },
+    update: {
+      templateData,
+      isActive: true,
+      enrolledByDeviceId: authed.device.id,
+    },
+    select: { id: true, userId: true, fingerIndex: true, isActive: true, updatedAt: true },
+  });
+
+  await logEntityActivity(
+    ActivityType.FINGERPRINT_ENROLLED,
+    user.id,
+    "FingerprintEnrollment",
+    enrollment.id,
+    `Fingerprint enrolled for ${user.name} (finger ${fingerIndex})`,
+    { userId, fingerIndex, kioskDeviceId: authed.device.id },
+    req
+  );
+
+  return NextResponse.json({ enrollment }, { status: 201 });
+}

--- a/src/app/api/kiosk/fingerprints/route.ts
+++ b/src/app/api/kiosk/fingerprints/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { authenticateKiosk } from "@/lib/kiosk-auth";
+
+const PAGE_SIZE = 200;
+
+/**
+ * GET /api/kiosk/fingerprints
+ *
+ * Query params:
+ *   ?updatedSince=ISO  → delta (returns enrollments whose enrollment-or-user changed since that instant; INCLUDES tombstones)
+ *   (no updatedSince)  → full reconcile (returns ALL enrollments whose owner is currently ACTIVE; no tombstones — kiosk diffs locally)
+ *   ?cursor=enrollmentId → pagination cursor
+ *
+ * Returns:
+ *   {
+ *     enrollments: [{ id, userId, fingerIndex, templateData, isActive, branchId (owner's current outlet), updatedAt }],
+ *     nextCursor: string | null,
+ *     serverTime: ISO  (kiosk persists as its new updatedSince)
+ *   }
+ *
+ * Effective active = enrollment.isActive AND user.status === "ACTIVE".
+ * A tombstone is a row with isActive=false the kiosk should DELETE from its local cache.
+ */
+export async function GET(req: Request) {
+  const authed = await authenticateKiosk(req);
+  if (!authed) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(req.url);
+  const updatedSinceParam = url.searchParams.get("updatedSince");
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+  const updatedSince = updatedSinceParam ? new Date(updatedSinceParam) : null;
+  if (updatedSinceParam && isNaN(updatedSince!.getTime())) {
+    return NextResponse.json({ error: "Invalid updatedSince" }, { status: 400 });
+  }
+
+  // Build the where:
+  //   - Delta mode: include EVERY enrollment whose enrollment.updatedAt > since OR whose user.updatedAt > since.
+  //     We don't filter by user.status here — tombstones (user moved to LEFT) must propagate.
+  //   - Full reconcile mode: only enrollments whose user is currently ACTIVE; no tombstones.
+  const where = updatedSince
+    ? {
+        OR: [
+          { updatedAt: { gt: updatedSince } },
+          { user: { is: { updatedAt: { gt: updatedSince } } } },
+        ],
+      }
+    : {
+        isActive: true,
+        user: { is: { status: "ACTIVE" as const } },
+      };
+
+  const rows = await prisma.fingerprintEnrollment.findMany({
+    where,
+    take: PAGE_SIZE + 1, // peek for "more"
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    orderBy: { id: "asc" },
+    select: {
+      id: true,
+      userId: true,
+      fingerIndex: true,
+      templateData: true,
+      isActive: true,
+      updatedAt: true,
+      user: { select: { status: true, branchId: true, updatedAt: true } },
+    },
+  });
+
+  const more = rows.length > PAGE_SIZE;
+  const page = more ? rows.slice(0, PAGE_SIZE) : rows;
+
+  const enrollments = page.map((r) => ({
+    id: r.id,
+    userId: r.userId,
+    fingerIndex: r.fingerIndex,
+    templateData: r.templateData,
+    // Effective active for the kiosk: must be active on both sides to be matchable
+    isActive: r.isActive && r.user.status === "ACTIVE",
+    // Owner's current outlet — for the kiosk's local outlet pre-check
+    branchId: r.user.branchId,
+    // Use the max of enrollment.updatedAt and user.updatedAt so the kiosk's next
+    // updatedSince checkpoint covers both kinds of changes
+    updatedAt: new Date(
+      Math.max(r.updatedAt.getTime(), r.user.updatedAt.getTime())
+    ).toISOString(),
+  }));
+
+  return NextResponse.json({
+    enrollments,
+    nextCursor: more ? page[page.length - 1].id : null,
+    serverTime: new Date().toISOString(),
+  });
+}

--- a/src/app/api/kiosk/punch/route.ts
+++ b/src/app/api/kiosk/punch/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import { PunchDirection, PunchOutcome } from "@prisma/client";
+import { authenticateKiosk } from "@/lib/kiosk-auth";
+import { recordPunch } from "@/lib/services/punch-service";
+
+export const runtime = "nodejs";
+export const maxDuration = 30; // 8s grooming + safety margin
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/kiosk/punch
+ *
+ * Body:
+ *   {
+ *     userId: string,
+ *     shiftId: string,
+ *     direction: "IN" | "OUT",
+ *     punchedAt: ISO-UTC string,          // kiosk-stamped
+ *     uniformPhoto: base64 string,         // no data: prefix
+ *     nailsPhoto:   base64 string
+ *   }
+ *
+ * Responses:
+ *   200 OK { punchEventId, attendanceId, direction, punchedAt, grooming, overallGroomingPass }
+ *   403 { blocked: true, reason: "WRONG_OUTLET", assignedBranch: { id, name } }  ← outlet gate
+ *   400 invalid body, 401 bad auth, 404 user missing, 500 unexpected
+ */
+export async function POST(req: Request) {
+  const authed = await authenticateKiosk(req);
+  if (!authed) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: {
+    userId?: string;
+    shiftId?: string;
+    direction?: string;
+    punchedAt?: string;
+    uniformPhoto?: string;
+    nailsPhoto?: string;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { userId, shiftId, direction, punchedAt, uniformPhoto, nailsPhoto } = body;
+  if (!userId || !shiftId || !direction || !punchedAt || !uniformPhoto || !nailsPhoto) {
+    return NextResponse.json(
+      { error: "userId, shiftId, direction, punchedAt, uniformPhoto, nailsPhoto are all required" },
+      { status: 400 }
+    );
+  }
+  if (direction !== "IN" && direction !== "OUT") {
+    return NextResponse.json({ error: 'direction must be "IN" or "OUT"' }, { status: 400 });
+  }
+  const punchedAtDate = new Date(punchedAt);
+  if (isNaN(punchedAtDate.getTime())) {
+    return NextResponse.json({ error: "punchedAt must be a valid ISO date" }, { status: 400 });
+  }
+
+  try {
+    const result = await recordPunch({
+      device: { id: authed.device.id, branchId: authed.device.branchId },
+      userId,
+      shiftId,
+      direction: direction as PunchDirection,
+      punchedAt: punchedAtDate,
+      uniformPhotoBase64: uniformPhoto,
+      nailsPhotoBase64: nailsPhoto,
+      request: req,
+    });
+
+    if (result.outcome === PunchOutcome.BLOCKED_WRONG_OUTLET) {
+      return NextResponse.json(
+        {
+          blocked: true,
+          reason: "WRONG_OUTLET",
+          assignedBranch:
+            result.assignedBranchId
+              ? { id: result.assignedBranchId, name: result.assignedBranchName ?? null }
+              : null,
+          punchEventId: result.punchEventId,
+        },
+        { status: 403 }
+      );
+    }
+
+    return NextResponse.json({
+      punchEventId: result.punchEventId,
+      attendanceId: result.attendanceId,
+      direction: result.direction,
+      punchedAt: result.punchedAt,
+      grooming: result.grooming,
+      overallGroomingPass: result.grooming?.overallPass ?? false,
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg === "EMPLOYEE_NOT_FOUND") {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+    console.error("[kiosk/punch] unexpected error:", e);
+    return NextResponse.json({ error: "Internal error" }, { status: 500 });
+  }
+}

--- a/src/app/api/kiosk/punch/route.ts
+++ b/src/app/api/kiosk/punch/route.ts
@@ -55,9 +55,28 @@ export async function POST(req: Request) {
   if (direction !== "IN" && direction !== "OUT") {
     return NextResponse.json({ error: 'direction must be "IN" or "OUT"' }, { status: 400 });
   }
+  // Require explicit UTC or numeric offset. A bare "2026-05-26T03:30:00" parses
+  // as server-local time and lands on the wrong IST day near midnight; the spec
+  // is explicit that the kiosk sends UTC.
+  if (!/(Z|[+-]\d{2}:?\d{2})$/.test(punchedAt)) {
+    return NextResponse.json(
+      { error: "punchedAt must be a timezone-explicit ISO string (end with Z or ±HH:MM)" },
+      { status: 400 }
+    );
+  }
   const punchedAtDate = new Date(punchedAt);
   if (isNaN(punchedAtDate.getTime())) {
     return NextResponse.json({ error: "punchedAt must be a valid ISO date" }, { status: 400 });
+  }
+  // Reject oversized photos before they touch Azure or grooming. ~7.5MB of
+  // base64 ≈ 5.6MB of raw image — far above the 1024px JPEG the kiosk produces
+  // (~150-300KB), but well below Vercel's 4.5MB sync body limit when summed.
+  const MAX_BASE64 = 7_500_000;
+  if (uniformPhoto.length > MAX_BASE64 || nailsPhoto.length > MAX_BASE64) {
+    return NextResponse.json(
+      { error: `Photo too large (max ${MAX_BASE64} base64 chars per photo)` },
+      { status: 413 }
+    );
   }
 
   try {

--- a/src/lib/__tests__/kiosk-auth.test.ts
+++ b/src/lib/__tests__/kiosk-auth.test.ts
@@ -16,6 +16,25 @@ function reqWith(headers: Record<string, string>): Request {
   return new Request('http://localhost/api/kiosk/handshake', { headers });
 }
 
+// Helper: builds a complete KioskDevice for mocking findUnique. The production
+// code only `select`s a subset, but vi.mocked types the return as the full
+// model — so we fill in defaults for the un-touched fields.
+function mockDevice(overrides: {
+  id: string;
+  branchId: string;
+  name: string;
+  tokenHash: string;
+  isActive: boolean;
+}) {
+  return {
+    numId: 1,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    lastSeenAt: null,
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -52,13 +71,13 @@ describe('authenticateKiosk', () => {
   });
 
   it('returns null when device is inactive', async () => {
-    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce(mockDevice({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',
       tokenHash: hashKioskToken('correct-token'),
       isActive: false,
-    });
+    }));
     const result = await authenticateKiosk(
       reqWith({ Authorization: 'Bearer correct-token', 'X-Kiosk-Device-Id': 'dev_1' })
     );
@@ -66,13 +85,13 @@ describe('authenticateKiosk', () => {
   });
 
   it('returns null when token hash mismatches', async () => {
-    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce(mockDevice({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',
       tokenHash: hashKioskToken('correct-token'),
       isActive: true,
-    });
+    }));
     const result = await authenticateKiosk(
       reqWith({ Authorization: 'Bearer WRONG', 'X-Kiosk-Device-Id': 'dev_1' })
     );
@@ -80,13 +99,13 @@ describe('authenticateKiosk', () => {
   });
 
   it('returns { device } on a valid match and fires lastSeenAt update', async () => {
-    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce(mockDevice({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',
       tokenHash: hashKioskToken('correct-token'),
       isActive: true,
-    });
+    }));
     const result = await authenticateKiosk(
       reqWith({ Authorization: 'Bearer correct-token', 'X-Kiosk-Device-Id': 'dev_1' })
     );
@@ -99,13 +118,13 @@ describe('authenticateKiosk', () => {
   });
 
   it('uses timing-safe compare (different hash lengths return null)', async () => {
-    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce(mockDevice({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',
       tokenHash: 'short',
       isActive: true,
-    });
+    }));
     const result = await authenticateKiosk(
       reqWith({ Authorization: 'Bearer anything', 'X-Kiosk-Device-Id': 'dev_1' })
     );

--- a/src/lib/__tests__/kiosk-auth.test.ts
+++ b/src/lib/__tests__/kiosk-auth.test.ts
@@ -44,7 +44,7 @@ describe('authenticateKiosk', () => {
   });
 
   it('returns null when device not found', async () => {
-    (prisma.kioskDevice.findUnique as any).mockResolvedValueOnce(null);
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce(null);
     const result = await authenticateKiosk(
       reqWith({ Authorization: 'Bearer abc', 'X-Kiosk-Device-Id': 'dev_x' })
     );
@@ -52,7 +52,7 @@ describe('authenticateKiosk', () => {
   });
 
   it('returns null when device is inactive', async () => {
-    (prisma.kioskDevice.findUnique as any).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',
@@ -66,7 +66,7 @@ describe('authenticateKiosk', () => {
   });
 
   it('returns null when token hash mismatches', async () => {
-    (prisma.kioskDevice.findUnique as any).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',
@@ -80,7 +80,7 @@ describe('authenticateKiosk', () => {
   });
 
   it('returns { device } on a valid match and fires lastSeenAt update', async () => {
-    (prisma.kioskDevice.findUnique as any).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',
@@ -99,7 +99,7 @@ describe('authenticateKiosk', () => {
   });
 
   it('uses timing-safe compare (different hash lengths return null)', async () => {
-    (prisma.kioskDevice.findUnique as any).mockResolvedValueOnce({
+    vi.mocked(prisma.kioskDevice.findUnique).mockResolvedValueOnce({
       id: 'dev_1',
       branchId: 'b1',
       name: 'Smoke Kiosk',

--- a/src/lib/services/__tests__/grooming-check.test.ts
+++ b/src/lib/services/__tests__/grooming-check.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { checkGrooming } from '@/lib/services/grooming-check';
+
+const ENV = {
+  AZURE_AI_FOUNDRY_ENDPOINT: 'https://example.openai.azure.com',
+  AZURE_AI_FOUNDRY_KEY: 'fake-key',
+  AZURE_AI_FOUNDRY_DEPLOYMENT: 'gpt-4o',
+  AZURE_AI_FOUNDRY_TIMEOUT_MS: '8000',
+};
+
+function mockFetchResponse(jsonContent: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => ({
+      choices: [{ message: { content: JSON.stringify(jsonContent) } }],
+    }),
+    text: async () => JSON.stringify({
+      choices: [{ message: { content: JSON.stringify(jsonContent) } }],
+    }),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  for (const [k, v] of Object.entries(ENV)) process.env[k] = v;
+  vi.restoreAllMocks();
+});
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('checkGrooming', () => {
+  it('returns PASS verdicts when both photos pass', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      mockFetchResponse({ pass: true, reason: 'Clean uniform', confidence: 0.92 })
+    );
+    const r = await checkGrooming('https://blob/uniform.jpg', 'https://blob/nails.jpg');
+    expect(r.uniform.status).toBe('PASS');
+    expect(r.uniform.confidence).toBe(0.92);
+    expect(r.nails.status).toBe('PASS');
+    expect(r.overallPass).toBe(true);
+  });
+
+  it('returns FAIL on one and PASS on the other; overallPass=false', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockFetchResponse({ pass: false, reason: 'Shirt not buttoned', confidence: 0.81 }))
+      .mockResolvedValueOnce(mockFetchResponse({ pass: true, reason: 'Trimmed', confidence: 0.88 }));
+    const r = await checkGrooming('https://blob/uniform.jpg', 'https://blob/nails.jpg');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(r.uniform.status).toBe('FAIL');
+    expect(r.uniform.reason).toBe('Shirt not buttoned');
+    expect(r.nails.status).toBe('PASS');
+    expect(r.overallPass).toBe(false);
+  });
+
+  it('returns PENDING when the per-call timeout fires (AbortError)', async () => {
+    process.env.AZURE_AI_FOUNDRY_TIMEOUT_MS = '50';
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      (_input, init) => new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        signal?.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      })
+    );
+    const r = await checkGrooming('https://blob/uniform.jpg', 'https://blob/nails.jpg');
+    expect(r.uniform.status).toBe('PENDING');
+    expect(r.nails.status).toBe('PENDING');
+    expect(r.overallPass).toBe(false);
+  });
+
+  it('returns ERROR when the response JSON is unparseable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ choices: [{ message: { content: 'not-json{{{' } }] }),
+      text: async () => '...',
+    } as unknown as Response);
+    const r = await checkGrooming('https://blob/uniform.jpg', 'https://blob/nails.jpg');
+    expect(r.uniform.status).toBe('ERROR');
+    expect(r.nails.status).toBe('ERROR');
+    expect(r.overallPass).toBe(false);
+  });
+
+  it('returns ERROR when the upstream call fails with a non-200', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => 'internal error',
+    } as unknown as Response);
+    const r = await checkGrooming('https://blob/uniform.jpg', 'https://blob/nails.jpg');
+    expect(r.uniform.status).toBe('ERROR');
+    expect(r.nails.status).toBe('ERROR');
+  });
+
+  it('runs both calls in parallel (start times overlap)', async () => {
+    let startCount = 0;
+    let inFlightAtSecondStart = 0;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => new Promise((resolve) => {
+      startCount += 1;
+      if (startCount === 2) inFlightAtSecondStart = startCount;
+      setTimeout(() => resolve(mockFetchResponse({ pass: true, reason: 'ok', confidence: 0.9 })), 30);
+    }));
+    await checkGrooming('https://blob/uniform.jpg', 'https://blob/nails.jpg');
+    expect(inFlightAtSecondStart).toBe(2); // both started before first resolved
+  });
+});

--- a/src/lib/services/__tests__/punch-service.test.ts
+++ b/src/lib/services/__tests__/punch-service.test.ts
@@ -126,3 +126,123 @@ describe('recordPunch — outlet gate', () => {
     expect(events[0].nailsPhotoUrl).toContain('nails');
   });
 });
+
+describe('recordPunch — authorized path', () => {
+  it('creates Attendance with checkIn (IST) on first IN of the day', async () => {
+    const r = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id,
+      shiftId: shift.id,
+      direction: 'IN',
+      punchedAt: new Date('2026-05-26T03:30:00Z'), // 09:00 IST
+      uniformPhotoBase64: 'AAAA',
+      nailsPhotoBase64: 'BBBB',
+    });
+    const att = await prisma.attendance.findFirstOrThrow({ where: { id: r.attendanceId } });
+    expect(att.userId).toBe(user.id);
+    expect(att.branchId).toBe(branchA.id);
+    expect(att.checkIn).toBe('09:00');
+    expect(att.checkOut).toBeNull();
+    expect(att.isPresent).toBe(true);
+    expect(att.status).toBe('PENDING_VERIFICATION');
+  });
+
+  it('upserts the same Attendance and sets checkOut on the OUT punch', async () => {
+    const inR = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id, shiftId: shift.id, direction: 'IN',
+      punchedAt: new Date('2026-05-26T03:30:00Z'),
+      uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+    });
+    const outR = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id, shiftId: shift.id, direction: 'OUT',
+      punchedAt: new Date('2026-05-26T13:30:00Z'), // 19:00 IST
+      uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+    });
+    expect(outR.attendanceId).toBe(inR.attendanceId); // same row, upserted
+
+    const att = await prisma.attendance.findFirstOrThrow({ where: { id: inR.attendanceId } });
+    expect(att.checkIn).toBe('09:00');
+    expect(att.checkOut).toBe('19:00');
+
+    const events = await prisma.punchEvent.findMany({ where: { userId: user.id }, orderBy: { punchedAt: 'asc' } });
+    expect(events).toHaveLength(2);
+    expect(events[0].direction).toBe('IN');
+    expect(events[1].direction).toBe('OUT');
+    expect(events.every((e) => e.attendanceId === inR.attendanceId)).toBe(true);
+  });
+
+  it('places a near-midnight punch on the correct IST calendar day', async () => {
+    // 2026-05-26T18:35:00Z == 00:05 IST on 2026-05-27 — must be on the 27th
+    const r = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id, shiftId: shift.id, direction: 'IN',
+      punchedAt: new Date('2026-05-26T18:35:00Z'),
+      uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+    });
+    const att = await prisma.attendance.findFirstOrThrow({ where: { id: r.attendanceId } });
+    expect(att.date.toISOString().slice(0, 10)).toBe('2026-05-27');
+    expect(att.checkIn).toBe('00:05');
+  });
+
+  it('maps a split-shift IN at 07:00 IST to shift1 (best-effort legacy flag)', async () => {
+    // Break One: 07:00-15:00 + 19:00-23:00
+    const breakOne = await prisma.shift.create({
+      data: {
+        name: `Break One ${Math.random()}`,
+        branchId: null,
+        isActive: true,
+        sortOrder: 0,
+        segments: { create: [
+          { startTime: '07:00', endTime: '15:00', sortOrder: 0 },
+          { startTime: '19:00', endTime: '23:00', sortOrder: 1 },
+        ]},
+      },
+    });
+    const r = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id, shiftId: breakOne.id, direction: 'IN',
+      punchedAt: new Date('2026-05-26T01:30:00Z'), // 07:00 IST
+      uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+    });
+    const att = await prisma.attendance.findFirstOrThrow({ where: { id: r.attendanceId } });
+    expect(att.shift1).toBe(true);
+    expect(att.shift2 ?? false).toBe(false);
+    expect(att.shift3 ?? false).toBe(false);
+
+    // Cleanup
+    await prisma.punchEvent.deleteMany({ where: { shiftId: breakOne.id } });
+    await prisma.shiftSegment.deleteMany({ where: { shiftId: breakOne.id } });
+    await prisma.shift.delete({ where: { id: breakOne.id } });
+  });
+
+  it('handles concurrent IN punches for the same user/day (P2002 retry)', async () => {
+    // Two parallel IN punches with the same userId+date
+    const [r1, r2] = await Promise.all([
+      recordPunch({
+        device: { id: device.id, branchId: branchA.id },
+        userId: user.id, shiftId: shift.id, direction: 'IN',
+        punchedAt: new Date('2026-05-26T03:30:00Z'),
+        uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+      }),
+      recordPunch({
+        device: { id: device.id, branchId: branchA.id },
+        userId: user.id, shiftId: shift.id, direction: 'IN',
+        punchedAt: new Date('2026-05-26T03:30:00Z'),
+        uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+      }),
+    ]);
+    // Both succeed; both reference the same Attendance row
+    expect(r1.outcome).toBe('RECORDED');
+    expect(r2.outcome).toBe('RECORDED');
+    expect(r1.attendanceId).toBe(r2.attendanceId);
+    // Exactly one Attendance row exists
+    const atts = await prisma.attendance.findMany({ where: { userId: user.id } });
+    expect(atts).toHaveLength(1);
+    // Two PunchEvents exist, both referencing it
+    const events = await prisma.punchEvent.findMany({ where: { userId: user.id } });
+    expect(events).toHaveLength(2);
+    expect(events.every(e => e.attendanceId === r1.attendanceId)).toBe(true);
+  });
+});

--- a/src/lib/services/__tests__/punch-service.test.ts
+++ b/src/lib/services/__tests__/punch-service.test.ts
@@ -60,6 +60,7 @@ afterEach(async () => {
   await prisma.punchEvent.deleteMany({ where: { OR: [{ branchId: branchA.id }, { branchId: branchB.id }] } });
   await prisma.attendance.deleteMany({ where: { userId: user.id } });
   await prisma.fingerprintEnrollment.deleteMany({ where: { userId: user.id } });
+  await prisma.salary.deleteMany({ where: { userId: user.id } });
   await prisma.user.delete({ where: { id: user.id } }).catch(() => {});
   await prisma.shiftSegment.deleteMany({ where: { shiftId: shift.id } });
   await prisma.shift.delete({ where: { id: shift.id } }).catch(() => {});
@@ -244,5 +245,72 @@ describe('recordPunch — authorized path', () => {
     const events = await prisma.punchEvent.findMany({ where: { userId: user.id } });
     expect(events).toHaveLength(2);
     expect(events.every(e => e.attendanceId === r1.attendanceId)).toBe(true);
+  });
+});
+
+describe('recordPunch — salary recalc guard', () => {
+  it('no salary row → no recalc, punch succeeds', async () => {
+    const r = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id, shiftId: shift.id, direction: 'IN',
+      punchedAt: new Date('2026-05-26T03:30:00Z'),
+      uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+    });
+    expect(r.outcome).toBe('RECORDED');
+    // No throw, no salary row — nothing to assert beyond the punch succeeding
+  });
+
+  it('PROCESSING salary → punch succeeds, recalc SKIPPED (status preserved)', async () => {
+    const punchAt = new Date('2026-05-26T03:30:00Z');
+    const sal = await prisma.salary.create({
+      data: {
+        userId: user.id,
+        month: 5, // May in IST
+        year: 2026,
+        status: 'PROCESSING',
+        baseSalary: 0,
+        netSalary: 0,
+      } as any,
+    });
+    const r = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id, shiftId: shift.id, direction: 'IN',
+      punchedAt: punchAt, uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+    });
+    expect(r.outcome).toBe('RECORDED');
+    const after = await prisma.salary.findUnique({ where: { id: sal.id } });
+    expect(after?.status).toBe('PROCESSING');
+    await prisma.salary.delete({ where: { id: sal.id } });
+  });
+
+  it('PENDING salary → punch succeeds, calculateSalary called', async () => {
+    const punchAt = new Date('2026-05-26T03:30:00Z');
+    // calculateSalary() requires User.salary to be set; the default fixture
+    // user has no base salary, so the calculator would throw "Employee base
+    // salary not found". Give the user a base salary for this test.
+    await prisma.user.update({ where: { id: user.id }, data: { salary: 10000 } });
+    const sal = await prisma.salary.create({
+      data: {
+        userId: user.id,
+        month: 5,
+        year: 2026,
+        status: 'PENDING',
+        baseSalary: 0,
+        netSalary: 0,
+      } as any,
+    });
+    // We can't easily assert calculateSalary was called without mocking the module,
+    // so assert downstream: the Salary row was updated (updatedAt > created).
+    const beforeUpdatedAt = sal.updatedAt;
+    await new Promise((r) => setTimeout(r, 20));
+    const r = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id, shiftId: shift.id, direction: 'IN',
+      punchedAt: punchAt, uniformPhotoBase64: 'A', nailsPhotoBase64: 'B',
+    });
+    expect(r.outcome).toBe('RECORDED');
+    const after = await prisma.salary.findUnique({ where: { id: sal.id } });
+    expect(after!.updatedAt.getTime()).toBeGreaterThan(beforeUpdatedAt.getTime());
+    await prisma.salary.delete({ where: { id: sal.id } });
   });
 });

--- a/src/lib/services/__tests__/punch-service.test.ts
+++ b/src/lib/services/__tests__/punch-service.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { prisma } from '@/lib/prisma';
+import { recordPunch } from '@/lib/services/punch-service';
+
+// Stub the grooming + upload services — punch-service tests should not hit Azure
+vi.mock('@/lib/services/grooming-check', () => ({
+  checkGrooming: vi.fn(async () => ({
+    uniform: { status: 'PASS', reason: 'ok', confidence: 0.9, rawResponse: '{}' },
+    nails:   { status: 'PASS', reason: 'ok', confidence: 0.9, rawResponse: '{}' },
+    overallPass: true,
+  })),
+}));
+vi.mock('@/lib/azure-storage', () => ({
+  AzureStorageService: class {
+    async uploadBase64Image(_b: string, fileName: string, folder: string) {
+      return `https://fake-blob/${folder}/${fileName}`;
+    }
+  },
+}));
+
+// Test fixtures — created fresh per test
+let branchA: { id: string };
+let branchB: { id: string };
+let device: { id: string };
+let user: { id: string };
+let shift: { id: string };
+
+beforeEach(async () => {
+  const suffix = `_${Math.random().toString(36).slice(2, 8)}`;
+  branchA = await prisma.branch.create({
+    data: { name: `BR-A${suffix}`, city: 'Mumbai', state: 'MH' },
+  });
+  branchB = await prisma.branch.create({
+    data: { name: `BR-B${suffix}`, city: 'Mumbai', state: 'MH' },
+  });
+  device = await prisma.kioskDevice.create({
+    data: { name: `dev${suffix}`, branchId: branchA.id, tokenHash: `hash${suffix}`, isActive: true },
+  });
+  user = await prisma.user.create({
+    data: {
+      name: `Punch User${suffix}`,
+      email: `punch${suffix}@test.local`,
+      branchId: branchA.id,
+      status: 'ACTIVE',
+    } as any,
+  });
+  shift = await prisma.shift.create({
+    data: {
+      name: `Full Day${suffix}`,
+      branchId: null,
+      isActive: true,
+      sortOrder: 0,
+      segments: { create: [{ startTime: '07:00', endTime: '19:00', sortOrder: 0 }] },
+    },
+  });
+});
+
+afterEach(async () => {
+  // Clean up in FK-safe order
+  await prisma.punchEvent.deleteMany({ where: { OR: [{ branchId: branchA.id }, { branchId: branchB.id }] } });
+  await prisma.attendance.deleteMany({ where: { userId: user.id } });
+  await prisma.fingerprintEnrollment.deleteMany({ where: { userId: user.id } });
+  await prisma.user.delete({ where: { id: user.id } }).catch(() => {});
+  await prisma.shiftSegment.deleteMany({ where: { shiftId: shift.id } });
+  await prisma.shift.delete({ where: { id: shift.id } }).catch(() => {});
+  await prisma.kioskDevice.delete({ where: { id: device.id } }).catch(() => {});
+  await prisma.branch.delete({ where: { id: branchA.id } }).catch(() => {});
+  await prisma.branch.delete({ where: { id: branchB.id } }).catch(() => {});
+});
+
+describe('recordPunch — outlet gate', () => {
+  it('REJECTS when employee.branchId != device.branchId', async () => {
+    // Move user to branchB but they punch at branchA's kiosk
+    await prisma.user.update({ where: { id: user.id }, data: { branchId: branchB.id } });
+
+    const result = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id,
+      shiftId: shift.id,
+      direction: 'IN',
+      punchedAt: new Date('2026-05-26T03:30:00Z'),
+      uniformPhotoBase64: 'AAAA',
+      nailsPhotoBase64: 'BBBB',
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(result.outcome).toBe('BLOCKED_WRONG_OUTLET');
+    expect(result.assignedBranchId).toBe(branchB.id);
+
+    // A PunchEvent exists with the right shape
+    const events = await prisma.punchEvent.findMany({ where: { userId: user.id } });
+    expect(events).toHaveLength(1);
+    expect(events[0].outcome).toBe('BLOCKED_WRONG_OUTLET');
+    expect(events[0].branchId).toBe(branchA.id);          // where the attempt happened
+    expect(events[0].assignedBranchId).toBe(branchB.id);  // where they should have punched
+    expect(events[0].attendanceId).toBeNull();
+    expect(events[0].uniformPhotoUrl).toBeNull();
+    expect(events[0].nailsPhotoUrl).toBeNull();
+
+    // No Attendance row created
+    const att = await prisma.attendance.findMany({ where: { userId: user.id } });
+    expect(att).toHaveLength(0);
+  });
+
+  it('RECORDS when employee.branchId == device.branchId', async () => {
+    const result = await recordPunch({
+      device: { id: device.id, branchId: branchA.id },
+      userId: user.id,
+      shiftId: shift.id,
+      direction: 'IN',
+      punchedAt: new Date('2026-05-26T03:30:00Z'),
+      uniformPhotoBase64: 'AAAA',
+      nailsPhotoBase64: 'BBBB',
+    });
+
+    expect(result.blocked).toBeFalsy();
+    expect(result.outcome).toBe('RECORDED');
+    expect(result.attendanceId).toBeTruthy();
+    expect(result.grooming?.overallPass).toBe(true);
+
+    const events = await prisma.punchEvent.findMany({ where: { userId: user.id } });
+    expect(events).toHaveLength(1);
+    expect(events[0].outcome).toBe('RECORDED');
+    expect(events[0].attendanceId).toBe(result.attendanceId);
+    expect(events[0].uniformPhotoUrl).toContain('uniform');
+    expect(events[0].nailsPhotoUrl).toContain('nails');
+  });
+});

--- a/src/lib/services/__tests__/punch-service.test.ts
+++ b/src/lib/services/__tests__/punch-service.test.ts
@@ -42,6 +42,7 @@ beforeEach(async () => {
       email: `punch${suffix}@test.local`,
       branchId: branchA.id,
       status: 'ACTIVE',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
   });
   shift = await prisma.shift.create({
@@ -270,6 +271,7 @@ describe('recordPunch — salary recalc guard', () => {
         status: 'PROCESSING',
         baseSalary: 0,
         netSalary: 0,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
     });
     const r = await recordPunch({
@@ -297,6 +299,7 @@ describe('recordPunch — salary recalc guard', () => {
         status: 'PENDING',
         baseSalary: 0,
         netSalary: 0,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any,
     });
     // We can't easily assert calculateSalary was called without mocking the module,

--- a/src/lib/services/grooming-check.ts
+++ b/src/lib/services/grooming-check.ts
@@ -1,0 +1,148 @@
+/**
+ * Provider-agnostic grooming check.
+ *
+ * Default provider: Azure AI Foundry, GPT-4o vision deployment (confirmed 2026-05-26).
+ * The function shape is the only contract — switching to e.g. Claude vision is a
+ * matter of swapping the call inside `callVisionProvider` (or branching on env).
+ *
+ * Never throws. Each photo:
+ *   - PASS  / FAIL with reason + confidence
+ *   - PENDING on per-call AbortController timeout
+ *   - ERROR  on non-2xx, unparseable JSON, or unexpected shape
+ *
+ * Both photos run in parallel via Promise.all.
+ */
+
+import type { GroomingCheckStatus } from "@prisma/client";
+
+export interface GroomingVerdict {
+  status: GroomingCheckStatus; // PASS / FAIL / PENDING / ERROR
+  reason: string | null;
+  confidence: number | null;
+  rawResponse: string | null; // for audit
+}
+
+export interface GroomingResult {
+  uniform: GroomingVerdict;
+  nails: GroomingVerdict;
+  overallPass: boolean; // true only when BOTH are PASS
+}
+
+type CheckKind = "uniform" | "nails";
+
+const SYSTEM_PROMPT_UNIFORM =
+  "You are an attendance kiosk vision checker. Given a single photograph of an employee from the chest up, decide whether they are in clean, presentable uniform: shirt is the correct uniform shirt, tucked or worn neatly, free of obvious stains or damage. Respond strictly as JSON: {\"pass\": boolean, \"reason\": string (<=120 chars), \"confidence\": number 0..1}. Do not include any other text.";
+
+const SYSTEM_PROMPT_NAILS =
+  "You are an attendance kiosk vision checker. Given a single photograph of an employee's hand(s), decide whether their fingernails are trimmed short and clean (no long nails, no visible dirt). Respond strictly as JSON: {\"pass\": boolean, \"reason\": string (<=120 chars), \"confidence\": number 0..1}. Do not include any other text.";
+
+function timeoutMs(): number {
+  const raw = process.env.AZURE_AI_FOUNDRY_TIMEOUT_MS;
+  const n = raw ? parseInt(raw, 10) : 8000;
+  return Number.isFinite(n) && n > 0 ? n : 8000;
+}
+
+function endpointUrl(): string {
+  const base = process.env.AZURE_AI_FOUNDRY_ENDPOINT?.replace(/\/+$/, "");
+  const deployment = process.env.AZURE_AI_FOUNDRY_DEPLOYMENT;
+  if (!base || !deployment) {
+    throw new Error("AZURE_AI_FOUNDRY_ENDPOINT and AZURE_AI_FOUNDRY_DEPLOYMENT must be set");
+  }
+  // Azure OpenAI chat completions endpoint convention; api-version is the contract-stable one.
+  return `${base}/openai/deployments/${deployment}/chat/completions?api-version=2024-08-01-preview`;
+}
+
+async function callVisionProvider(
+  kind: CheckKind,
+  photoUrl: string
+): Promise<GroomingVerdict> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), timeoutMs());
+
+  const systemPrompt =
+    kind === "uniform" ? SYSTEM_PROMPT_UNIFORM : SYSTEM_PROMPT_NAILS;
+
+  try {
+    const res = await fetch(endpointUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "api-key": process.env.AZURE_AI_FOUNDRY_KEY ?? "",
+      },
+      signal: controller.signal,
+      body: JSON.stringify({
+        messages: [
+          { role: "system", content: systemPrompt },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Evaluate this photo." },
+              { type: "image_url", image_url: { url: photoUrl } },
+            ],
+          },
+        ],
+        response_format: { type: "json_object" },
+        max_tokens: 200,
+        temperature: 0,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      return { status: "ERROR", reason: `HTTP ${res.status}`, confidence: null, rawResponse: body || null };
+    }
+
+    const json = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    const content = json.choices?.[0]?.message?.content ?? "";
+    let parsed: { pass?: unknown; reason?: unknown; confidence?: unknown };
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      return { status: "ERROR", reason: "Unparseable JSON", confidence: null, rawResponse: content };
+    }
+
+    if (typeof parsed.pass !== "boolean") {
+      return { status: "ERROR", reason: "Missing 'pass' field", confidence: null, rawResponse: content };
+    }
+    const reason = typeof parsed.reason === "string" ? parsed.reason.slice(0, 240) : null;
+    const confidence =
+      typeof parsed.confidence === "number" && parsed.confidence >= 0 && parsed.confidence <= 1
+        ? parsed.confidence
+        : null;
+
+    return {
+      status: parsed.pass ? "PASS" : "FAIL",
+      reason,
+      confidence,
+      rawResponse: content,
+    };
+  } catch (e: unknown) {
+    const err = e as { name?: string; message?: string };
+    if (err?.name === "AbortError") {
+      return { status: "PENDING", reason: "Timeout", confidence: null, rawResponse: null };
+    }
+    return { status: "ERROR", reason: err?.message ?? "Unknown error", confidence: null, rawResponse: null };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+export async function checkGrooming(
+  uniformUrl: string | null,
+  nailsUrl: string | null
+): Promise<GroomingResult> {
+  const tasks: Array<Promise<GroomingVerdict>> = [
+    uniformUrl
+      ? callVisionProvider("uniform", uniformUrl)
+      : Promise.resolve<GroomingVerdict>({ status: "ERROR", reason: "No photo URL", confidence: null, rawResponse: null }),
+    nailsUrl
+      ? callVisionProvider("nails", nailsUrl)
+      : Promise.resolve<GroomingVerdict>({ status: "ERROR", reason: "No photo URL", confidence: null, rawResponse: null }),
+  ];
+  const [uniform, nails] = await Promise.all(tasks);
+  return {
+    uniform,
+    nails,
+    overallPass: uniform.status === "PASS" && nails.status === "PASS",
+  };
+}

--- a/src/lib/services/punch-service.ts
+++ b/src/lib/services/punch-service.ts
@@ -1,7 +1,9 @@
-import { ActivityType, PunchDirection, PunchOutcome } from "@prisma/client";
+import { ActivityType, Prisma, PunchDirection, PunchOutcome, type GroomingCheckStatus } from "@prisma/client";
 import { prisma } from "@/lib/prisma";
-import { type GroomingResult } from "@/lib/services/grooming-check";
+import { checkGrooming, type GroomingResult } from "@/lib/services/grooming-check";
 import { logEntityActivity } from "@/lib/services/activity-log";
+import { AzureStorageService } from "@/lib/azure-storage";
+import { toISTDate, toISTTimeString } from "@/lib/kiosk-time";
 
 export interface RecordPunchInput {
   device: { id: string; branchId: string };
@@ -27,8 +29,10 @@ export interface RecordPunchResult {
   grooming?: GroomingResult;
 }
 
+const azure = new AzureStorageService();
+
 export async function recordPunch(input: RecordPunchInput): Promise<RecordPunchResult> {
-  const { device, userId, direction, punchedAt, request } = input;
+  const { device, userId, shiftId, direction, punchedAt, request } = input;
 
   // Resolve the employee
   const employee = await prisma.user.findUnique({
@@ -86,6 +90,209 @@ export async function recordPunch(input: RecordPunchInput): Promise<RecordPunchR
     };
   }
 
-  // Authorized — TODO in next tasks: upload, grooming, PunchEvent, Attendance upsert, salary guard
-  throw new Error("NOT_IMPLEMENTED_YET");
+  // ─── Authorized path ───
+
+  // 1. Create the PunchEvent first (without urls/grooming) so we have a stable
+  //    id to use as the filename for the photo uploads.
+  const tempPunch = await prisma.punchEvent.create({
+    data: {
+      userId: employee.id,
+      kioskDeviceId: device.id,
+      branchId: device.branchId,
+      assignedBranchId: employee.branchId,
+      shiftId,
+      direction,
+      punchedAt,
+      outcome: PunchOutcome.RECORDED,
+    },
+    select: { id: true },
+  });
+
+  const ymd = toISTDate(punchedAt).toISOString().slice(0, 10);
+  const [uniformUrl, nailsUrl] = await Promise.all([
+    azure
+      .uploadBase64Image(
+        input.uniformPhotoBase64,
+        `${tempPunch.id}-uniform.jpg`,
+        `kiosk-punches/${ymd.replace(/-/g, "/")}`,
+        "image/jpeg"
+      )
+      .catch(() => null),
+    azure
+      .uploadBase64Image(
+        input.nailsPhotoBase64,
+        `${tempPunch.id}-nails.jpg`,
+        `kiosk-punches/${ymd.replace(/-/g, "/")}`,
+        "image/jpeg"
+      )
+      .catch(() => null),
+  ]);
+
+  // 2. Grooming verdicts (parallel inside the service; never throws)
+  const grooming = await checkGrooming(uniformUrl, nailsUrl);
+
+  // 3. Attendance upsert (IST date + IST HH:mm)
+  const istDate = toISTDate(punchedAt);
+  const istHHmm = toISTTimeString(punchedAt);
+
+  // Compute legacy shift flag (best-effort) by segment overlap at the punch instant
+  const shiftRow = await prisma.shift.findUnique({
+    where: { id: shiftId },
+    include: { segments: { orderBy: { sortOrder: "asc" } } },
+  });
+  const legacyFlag = pickLegacyShiftFlag(shiftRow?.segments ?? [], istHHmm);
+
+  // Race handling (P2002 on simultaneous upsert): Prisma's `upsert` is not atomic
+  // across processes — two concurrent IN punches for the same (userId, date) can
+  // both enter the create branch and one will throw P2002. The retry below
+  // re-attempts; on the second pass the row exists so it becomes a pure update.
+  const attendance = await upsertAttendanceWithRetry({
+    where: { userId_date: { userId: employee.id, date: istDate } },
+    create: {
+      userId: employee.id,
+      date: istDate,
+      isPresent: true,
+      checkIn: direction === PunchDirection.IN ? istHHmm : null,
+      checkOut: direction === PunchDirection.OUT ? istHHmm : null,
+      branchId: device.branchId,
+      status: "PENDING_VERIFICATION",
+      shift1: legacyFlag === 1,
+      shift2: legacyFlag === 2,
+      shift3: legacyFlag === 3,
+    } as any,
+    update: {
+      isPresent: true,
+      // On OUT: always set checkOut (latest OUT of the day wins)
+      ...(direction === PunchDirection.OUT ? { checkOut: istHHmm } : {}),
+      // On IN: do NOT set checkIn here — Prisma update can't do "set only if null".
+      //        We do that as a separate updateMany below so a re-punch IN
+      //        doesn't overwrite the original morning checkIn.
+    },
+  });
+
+  // Conditional "set checkIn only if empty" for IN punches
+  if (direction === PunchDirection.IN) {
+    await prisma.attendance.updateMany({
+      where: { id: attendance.id, checkIn: null },
+      data: { checkIn: istHHmm },
+    });
+  }
+
+  // 4. Patch the PunchEvent with photo URLs + grooming verdicts + attendanceId
+  const punchEvent = await prisma.punchEvent.update({
+    where: { id: tempPunch.id },
+    data: {
+      attendanceId: attendance.id,
+      uniformPhotoUrl: uniformUrl,
+      nailsPhotoUrl: nailsUrl,
+      uniformCheckStatus: grooming.uniform.status as GroomingCheckStatus,
+      nailsCheckStatus: grooming.nails.status as GroomingCheckStatus,
+      uniformCheckReason: grooming.uniform.reason,
+      nailsCheckReason: grooming.nails.reason,
+      uniformConfidence: grooming.uniform.confidence,
+      nailsConfidence: grooming.nails.confidence,
+      aiRawResponse: JSON.stringify({
+        uniform: grooming.uniform.rawResponse,
+        nails: grooming.nails.rawResponse,
+      }),
+    },
+    select: { id: true },
+  });
+
+  // 5. Salary recalc guard — implemented in Task 13
+  await maybeRecalcSalary(employee.id, punchedAt, request);
+
+  // 6. Activity logs
+  await logEntityActivity(
+    direction === PunchDirection.IN ? ActivityType.PUNCH_IN : ActivityType.PUNCH_OUT,
+    employee.id,
+    "PunchEvent",
+    punchEvent.id,
+    `${employee.name} punched ${direction} at ${istHHmm} IST`,
+    {
+      punchEventId: punchEvent.id,
+      attendanceId: attendance.id,
+      shiftId,
+      grooming: { uniform: grooming.uniform.status, nails: grooming.nails.status, overallPass: grooming.overallPass },
+    },
+    request
+  );
+  if (!grooming.overallPass) {
+    await logEntityActivity(
+      ActivityType.GROOMING_CHECK_FAILED,
+      employee.id,
+      "PunchEvent",
+      punchEvent.id,
+      `Grooming failed: uniform=${grooming.uniform.status} (${grooming.uniform.reason ?? "-"}), nails=${grooming.nails.status} (${grooming.nails.reason ?? "-"})`,
+      { punchEventId: punchEvent.id, grooming },
+      request
+    );
+  }
+
+  return {
+    punchEventId: punchEvent.id,
+    outcome: PunchOutcome.RECORDED,
+    attendanceId: attendance.id,
+    direction,
+    punchedAt: punchedAt.toISOString(),
+    grooming,
+  };
+}
+
+/**
+ * Best-effort legacy shift1/2/3 flag from segment start times (HH:mm in branch-local / IST).
+ *  - Segment starting < 12:00 → 1
+ *  - Segment starting 12:00..16:59 → 2
+ *  - Segment starting >= 17:00 → 3
+ * If a shift has multiple segments we pick the one whose [start, end] window covers `nowHHmm`,
+ * else fall back to the first segment.
+ */
+export function pickLegacyShiftFlag(
+  segments: Array<{ startTime: string; endTime: string }>,
+  nowHHmm: string
+): 1 | 2 | 3 | null {
+  if (segments.length === 0) return null;
+  const inWindow = segments.find((s) => withinWindow(s.startTime, s.endTime, nowHHmm)) ?? segments[0];
+  const startHour = parseInt(inWindow.startTime.split(":")[0], 10);
+  if (startHour < 12) return 1;
+  if (startHour < 17) return 2;
+  return 3;
+}
+
+function withinWindow(start: string, end: string, now: string): boolean {
+  // Compare as "HH:mm" — works for windows fully within a single day.
+  // For wrap-around windows (start > end, e.g. "22:00"-"06:00"), treat as crossing midnight.
+  if (start <= end) return now >= start && now <= end;
+  return now >= start || now <= end;
+}
+
+// Stub — implemented in Task 13
+async function maybeRecalcSalary(_userId: string, _punchedAt: Date, _req?: Request): Promise<void> {
+  // intentional no-op until Task 13
+}
+
+/**
+ * Wrap Prisma's upsert with a single retry for P2002 races. Two concurrent
+ * IN punches for the same (userId, date) can both enter the create branch
+ * and one will throw `Prisma.PrismaClientKnownRequestError` with code 'P2002'.
+ * On retry, the row exists, so the upsert collapses to a pure update.
+ */
+async function upsertAttendanceWithRetry(
+  args: Parameters<typeof prisma.attendance.upsert>[0],
+  attempts = 2
+): Promise<Awaited<ReturnType<typeof prisma.attendance.upsert>>> {
+  try {
+    return await prisma.attendance.upsert(args);
+  } catch (e) {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === "P2002" &&
+      attempts > 1
+    ) {
+      // The other request won the create race — re-attempt; this time the
+      // row exists, so it'll go through the update branch.
+      return upsertAttendanceWithRetry(args, attempts - 1);
+    }
+    throw e;
+  }
 }

--- a/src/lib/services/punch-service.ts
+++ b/src/lib/services/punch-service.ts
@@ -159,6 +159,7 @@ export async function recordPunch(input: RecordPunchInput): Promise<RecordPunchR
       shift1: legacyFlag === 1,
       shift2: legacyFlag === 2,
       shift3: legacyFlag === 3,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     update: {
       isPresent: true,
@@ -200,7 +201,7 @@ export async function recordPunch(input: RecordPunchInput): Promise<RecordPunchR
   });
 
   // 5. Salary recalc guard — implemented in Task 13
-  await maybeRecalcSalary(employee.id, punchedAt, request);
+  await maybeRecalcSalary(employee.id, punchedAt);
 
   // 6. Activity logs
   await logEntityActivity(
@@ -274,7 +275,7 @@ function withinWindow(start: string, end: string, now: string): boolean {
  *  - PENDING → recalc via calculateSalary() and update the Salary row, mirroring
  *    src/app/api/attendance/[id]/route.ts (lines 420-449).
  */
-async function maybeRecalcSalary(userId: string, punchedAt: Date, _req?: Request): Promise<void> {
+async function maybeRecalcSalary(userId: string, punchedAt: Date): Promise<void> {
   // The Salary key is (userId, month, year) in the punch's IST month.
   const istYMD = toISTDate(punchedAt).toISOString().slice(0, 10); // "YYYY-MM-DD"
   const [yearStr, monthStr] = istYMD.split("-");

--- a/src/lib/services/punch-service.ts
+++ b/src/lib/services/punch-service.ts
@@ -1,0 +1,91 @@
+import { ActivityType, PunchDirection, PunchOutcome } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { type GroomingResult } from "@/lib/services/grooming-check";
+import { logEntityActivity } from "@/lib/services/activity-log";
+
+export interface RecordPunchInput {
+  device: { id: string; branchId: string };
+  userId: string;
+  shiftId: string;
+  direction: PunchDirection;
+  punchedAt: Date; // UTC, sent by kiosk
+  uniformPhotoBase64: string;
+  nailsPhotoBase64: string;
+  request?: Request; // for activity-log IP/UA
+}
+
+export interface RecordPunchResult {
+  punchEventId: string;
+  outcome: PunchOutcome;
+  blocked?: boolean;
+  reason?: "WRONG_OUTLET";
+  assignedBranchId?: string;
+  assignedBranchName?: string;
+  attendanceId?: string;
+  direction?: PunchDirection;
+  punchedAt?: string;
+  grooming?: GroomingResult;
+}
+
+export async function recordPunch(input: RecordPunchInput): Promise<RecordPunchResult> {
+  const { device, userId, direction, punchedAt, request } = input;
+
+  // Resolve the employee
+  const employee = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, name: true, branchId: true, status: true },
+  });
+  if (!employee) {
+    throw new Error("EMPLOYEE_NOT_FOUND");
+  }
+
+  // ─── Outlet gate ───
+  if (employee.branchId !== device.branchId) {
+    const blocked = await prisma.punchEvent.create({
+      data: {
+        userId: employee.id,
+        kioskDeviceId: device.id,
+        branchId: device.branchId,
+        assignedBranchId: employee.branchId,
+        direction,
+        punchedAt,
+        outcome: PunchOutcome.BLOCKED_WRONG_OUTLET,
+        // no photos, no grooming, no shift, no attendanceId
+      },
+      select: { id: true },
+    });
+
+    const assignedBranch = employee.branchId
+      ? await prisma.branch.findUnique({
+          where: { id: employee.branchId },
+          select: { id: true, name: true },
+        })
+      : null;
+
+    await logEntityActivity(
+      ActivityType.PUNCH_BLOCKED_WRONG_OUTLET,
+      employee.id,
+      "PunchEvent",
+      blocked.id,
+      `Punch blocked: ${employee.name} attempted at kiosk branch ${device.branchId} but assigned to ${employee.branchId ?? "<none>"}`,
+      {
+        punchEventId: blocked.id,
+        attemptedBranchId: device.branchId,
+        assignedBranchId: employee.branchId,
+      },
+      request
+    );
+
+    return {
+      punchEventId: blocked.id,
+      outcome: PunchOutcome.BLOCKED_WRONG_OUTLET,
+      blocked: true,
+      reason: "WRONG_OUTLET",
+      assignedBranchId: employee.branchId ?? undefined,
+      assignedBranchName: assignedBranch?.name,
+    };
+  }
+
+  // Authorized — TODO in next tasks: upload, grooming, PunchEvent, Attendance upsert, salary guard
+  throw new Error("NOT_IMPLEMENTED_YET");
+}

--- a/src/lib/services/punch-service.ts
+++ b/src/lib/services/punch-service.ts
@@ -266,9 +266,45 @@ function withinWindow(start: string, end: string, now: string): boolean {
   return now >= start || now <= end;
 }
 
-// Stub — implemented in Task 13
-async function maybeRecalcSalary(_userId: string, _punchedAt: Date, _req?: Request): Promise<void> {
-  // intentional no-op until Task 13
+/**
+ * Kiosk salary-guard: NEVER block the punch.
+ *  - No salary row for (userId, month, year) → do nothing.
+ *  - PROCESSING → skip recalc, log "skipped" (the existing HR routes BLOCK in this case;
+ *    kiosk diverges deliberately because we can't refuse a clock-in over a salary state).
+ *  - PENDING → recalc via calculateSalary() and update the Salary row, mirroring
+ *    src/app/api/attendance/[id]/route.ts (lines 420-449).
+ */
+async function maybeRecalcSalary(userId: string, punchedAt: Date, _req?: Request): Promise<void> {
+  // The Salary key is (userId, month, year) in the punch's IST month.
+  const istYMD = toISTDate(punchedAt).toISOString().slice(0, 10); // "YYYY-MM-DD"
+  const [yearStr, monthStr] = istYMD.split("-");
+  const month = parseInt(monthStr, 10);
+  const year = parseInt(yearStr, 10);
+
+  const sal = await prisma.salary.findFirst({
+    where: { userId, month, year, status: { in: ["PENDING", "PROCESSING"] } },
+  });
+  if (!sal) return;
+
+  if (sal.status === "PROCESSING") {
+    console.warn(`[kiosk] Skipping salary recalc for user=${userId} ${month}/${year} (status=PROCESSING)`);
+    return;
+  }
+
+  // PENDING — recalc and update
+  const { calculateSalary } = await import("@/lib/services/salary-calculator");
+  const details = await calculateSalary(userId, month, year);
+  await prisma.salary.update({
+    where: { id: sal.id },
+    data: {
+      presentDays: details.presentDays,
+      overtimeDays: details.overtimeDays,
+      halfDays: details.halfDays,
+      leavesEarned: details.leavesEarned,
+      leaveSalary: details.leaveSalary,
+      netSalary: details.netSalary,
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
> **Ready for review.** Phase-2 of the kiosk biometric attendance backend — building on top of `kiosk-main` (which already has the foundation from #46). When this is merged, the next step is opening `kiosk-main → main` to ship the whole feature to prod.

## What

Completes the backend for the outlet-side biometric attendance kiosk. PR #46 landed the foundation (schema, auth, device provisioning, handshake, shifts seed+list). This PR adds:

- **Fingerprint sync** (enroll + delta-with-tombstones-and-owner-branchId)
- **GPT-4o grooming service** (provider-agnostic, never throws, never blocks the punch)
- **The full `punch-service`** — outlet gate + photo upload + parallel grooming + Attendance upsert with IST + P2002 retry + best-effort legacy `shift1/2/3` mapping + salary recalc guard
- **`POST /api/kiosk/punch`** — the core route
- **Endpoint smoke runbook** for manual verification

After this PR, the kiosk backend is **functionally complete and end-to-end testable** via curl. The Windows kiosk client itself remains out of scope (Phase 3 — separate spec under `opsy-kiosk/`).

## Branch strategy

```
main  ──────────────────────────────────────────────────────────►  prod
   └─ kiosk-main  (#46 already merged here)  ──────►  future PR → main
         └─ feat/kiosk-punch-pipeline  (this PR)
```

No path to prod from this PR directly. Reviewable in isolation.

## Commits (9, in order)

| Commit | What | Tests added |
|---|---|---|
| `8d12781` | `POST /api/kiosk/fingerprints/enroll` — upsert on `(userId, fingerIndex)`, rejects non-ACTIVE users, logs `FINGERPRINT_ENROLLED` | — (smoke-only) |
| `8f7dea9` | `GET /api/kiosk/fingerprints` sync — delta covers BOTH enrollment.updatedAt and user.updatedAt (so transfers propagate), tombstones, cursor pagination, each row carries owner's current `branchId` | — (smoke-only) |
| `001c6a2` | `checkGrooming()` GPT-4o vision — `Promise.all`, per-call `AbortController` timeout, never throws | +6 mocked-fetch tests |
| `39a0285` | `punch-service` outlet gate — `BLOCKED_WRONG_OUTLET` PunchEvent, no Attendance, snapshot `assignedBranchId` | +2 real-DB tests |
| `968f6b7` | `punch-service` authorized path — create-then-patch flow, parallel photo upload, `upsertAttendanceWithRetry` (handles P2002 race), `pickLegacyShiftFlag` start-hour bucket | +5 real-DB tests (incl. concurrent-IN P2002) |
| `2aeb0ac` | `punch-service` salary recalc guard — never blocks the punch; `PROCESSING` skips with a log; `PENDING` recalcs; no row → no-op | +3 real-DB tests |
| `6772eb1` | `POST /api/kiosk/punch` — thin route: 403 with `assignedBranch` on outlet mismatch; 200 with grooming verdicts on success; `runtime=nodejs, maxDuration=30, dynamic` | — (service is fully tested) |
| `59e420f` | `docs/superpowers/runbooks/kiosk-endpoint-smoke.md` — 11-step manual curl walkthrough end-to-end | — (docs) |
| `e8b7c93` | Lint fixes — `vi.mocked` over `as any`, eslint-disable comments matching codebase convention, drop unused `_req` param | — |

## State of the world after this PR

- **180/180 tests passing** (up from 164 on `kiosk-main`; +16 new)
- **`npm run build` succeeds** — all 6 `/api/kiosk/*` routes register
- **`tsc` clean** — only the unrelated pre-existing `src/lib/services/__tests__/salary-create.test.ts:113` "Unused @ts-expect-error" remains
- **0 destructive schema changes** (Phase-1 already did the schema work; this PR is pure code + docs)
- **No prod-impacting changes** until you open `kiosk-main → main`

## Locked design decisions (recap from #46)

- **Outlet gating:** punch allowed only when `employee.branchId == device.branchId`. Wrong outlet → 403 + `BLOCKED_WRONG_OUTLET` `PunchEvent` for audit; resolved by HR updating the employee's outlet via the existing web flow.
- **Grooming never blocks** — per-call 8s timeout → `PENDING`; errors → `ERROR`; punch records regardless.
- **Salary guard diverges from HR routes deliberately** — kiosk can't refuse a clock-in over salary state. `PROCESSING` → skip recalc + warn; `PENDING` → recalc; no row → no-op.
- **Timezone:** UTC `punchedAt` → IST `HH:mm` for `Attendance.checkIn/checkOut` + IST calendar day for `Attendance.date`.
- **P2002 retry:** concurrent IN punches for the same `(userId, date)` are handled by `upsertAttendanceWithRetry` (single retry; both succeed; 1 Attendance + 2 PunchEvents).
- **Audit-safe FKs (from #46 review fix D):** `PunchEvent.user` and `FingerprintEnrollment.user` are `onDelete: Restrict` so kiosk history outlives a user delete.

## Reviewer focus areas

1. **`src/lib/services/punch-service.ts`** — the heart of this PR. ~300 lines. Pay attention to the create-PunchEvent-then-patch flow (so the photo filename uses a stable ID), the `upsertAttendanceWithRetry` helper, and the post-update step that conditionally sets `checkIn` only when null (a re-IN doesn't overwrite the morning checkin).
2. **`src/lib/services/grooming-check.ts`** — the GPT-4o wrapper. Provider-agnostic shape; per-call AbortController; structured-output via `response_format: { type: "json_object" }`.
3. **`src/app/api/kiosk/fingerprints/route.ts`** (the sync route) — the trickiest of the route tasks. The delta query OR'd across both `enrollment.updatedAt` and `user.updatedAt` is what makes a web-side outlet move propagate to kiosks without bumping the enrollment.
4. **`docs/superpowers/runbooks/kiosk-endpoint-smoke.md`** — the runbook you (or anyone) can run manually right now against a local dev DB to confirm the wrong-outlet → 403 → fix → success flow works end-to-end.

## Out of scope (Phase 3+)

- Windows WPF kiosk app
- HR dashboard for grooming-flag review
- 90-day photo-purge timer (Azure Function alongside `opsy-timer/`)
- Push/SMS notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)
