### PR TITLE
fix(security): remove console.log of Azure storage connection string (hotfix)

### DIFF
--- a/src/lib/azure-storage.ts
+++ b/src/lib/azure-storage.ts
@@ -7,7 +7,6 @@ export class AzureStorageService {
   constructor() {
     const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING!;
     this.containerName = process.env.AZURE_STORAGE_CONTAINER_NAME!;
-    console.log(connectionString, this.containerName);
     this.blobServiceClient = BlobServiceClient.fromConnectionString(connectionString);
   }
 


### PR DESCRIPTION
> **Security hotfix — targeted directly at `main` to stop a connection-string leak that has been live in production for ~14 months.**

## What

`AzureStorageService`'s constructor was logging the full Azure Storage connection string (which embeds the **storage account key** — a permanent credential to the storage account) to stdout on every instantiation. One-line removal.

```diff
   constructor() {
     const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING!;
     this.containerName = process.env.AZURE_STORAGE_CONTAINER_NAME!;
-    console.log(connectionString, this.containerName);
     this.blobServiceClient = BlobServiceClient.fromConnectionString(connectionString);
   }
```

## Why now (not bundled with the kiosk PRs)

- **Pre-existing.** Introduced in commit `75c2481` ("add image upload", 2025-03-23) — ~14 months ago. Predates all kiosk work.
- **Currently leaking in production.** Every photo upload path (profile pictures, documents, etc.) hits this logger on cold start. Anyone with access to server logs / Sentry / Vercel logs has been able to read the storage account key for over a year.
- **About to get worse.** The kiosk feature on `kiosk-main` (PRs #46 + #47 merged, awaiting final `kiosk-main → main` PR) adds a per-punch photo upload path, which would amplify the leak further. Better to land this before the kiosk feature ships.
- Surfaced by the pre-merge review of PR #47 (kiosk punch pipeline) but explicitly flagged as outside that PR's scope.

## Risk assessment

- **Code change:** 1 line deleted. No behavior change to any upload path.
- **Test impact:** zero — no test asserts on the log line.
- **Compatibility:** none — `console.log` was a no-op for anything downstream.
- **Side effect:** logs become slightly less noisy (one debug line removed per service init).

## Recommended follow-ups (out of scope for this hotfix)

- **Rotate the storage account key.** Since the connection string has been in logs for 14 months, treat the current key as compromised. Generate a new key in Azure Portal, update `AZURE_STORAGE_CONNECTION_STRING` in all deployment envs, the old key becomes useless.
- **Audit historical log retention.** If your Vercel/Sentry/host log retention is >14 months, the key is in archived logs too — rotate the key regardless.
- **Add a CI check for `console.log` of env vars.** Simple ESLint rule (`no-restricted-syntax`) would catch this pattern.

## Verification

- `npm run build` succeeds locally (after `npx prisma generate` to refresh the client)
- `npm run test -- --run` — no test depends on the removed line
- Manual: confirm the upload flow still works (any existing image upload test or smoke check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
