### PR TITLE
harden(maintenance): bulk-import status preservation + DoS guards

### DIFF
--- a/src/app/api/equipment/bulk-import/route.ts
+++ b/src/app/api/equipment/bulk-import/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
     const formData = await req.formData();
     const file = formData.get("file");
     if (!(file instanceof File)) return NextResponse.json({ ok: false, error: "Missing file field" }, { status: 400 });
-    if (file.size > 10 * 1024 * 1024) return NextResponse.json({ ok: false, error: "File too large (max 10MB)" }, { status: 400 });
+    if (file.size > 5 * 1024 * 1024) return NextResponse.json({ ok: false, error: "File too large (max 5MB)" }, { status: 400 });
     buffer = Buffer.from(await file.arrayBuffer());
   } catch {
     return NextResponse.json({ ok: false, error: "Invalid request body" }, { status: 400 });

--- a/src/lib/services/__tests__/equipment-bulk-validate.test.ts
+++ b/src/lib/services/__tests__/equipment-bulk-validate.test.ts
@@ -79,6 +79,15 @@ describe("validateRow", () => {
     expect(validateRow(raw({ nextDueDate: "not-a-date" }), mgmtCtx).ok).toBe(false);
     expect(validateRow(raw({ nextDueDate: null }), mgmtCtx).ok).toBe(true);
   });
+
+  it("flags statusProvided: false when the Status cell is blank, true when set", () => {
+    const blank = validateRow(raw({ status: null }), mgmtCtx);
+    expect(blank.ok && blank.value.statusProvided).toBe(false);
+    expect(blank.ok && blank.value.status).toBe("ACTIVE"); // still defaults for new rows
+    const set = validateRow(raw({ status: "RETIRED" }), mgmtCtx);
+    expect(set.ok && set.value.statusProvided).toBe(true);
+    expect(set.ok && set.value.status).toBe("RETIRED");
+  });
 });
 
 describe("deriveNextDue", () => {

--- a/src/lib/services/equipment-bulk.ts
+++ b/src/lib/services/equipment-bulk.ts
@@ -116,6 +116,7 @@ export interface NormalizedRow {
   frequencyMonths: number | null;
   reminderLeadDays: number;
   status: "ACTIVE" | "RETIRED";
+  statusProvided: boolean; // false when the Status cell was blank
   nextDueDate: Date | null; // explicit override; null when the cell was blank
   nextDueProvided: boolean;
   notes: string | null;
@@ -144,6 +145,7 @@ export function validateRow(r: RawRow, ctx: ValidateCtx): ValidateResult {
 
   const status = normalizeStatus(r.status);
   if (!status) errors.push(`Unknown status "${r.status ?? ""}" (use ACTIVE or RETIRED)`);
+  const statusProvided = r.status !== null && r.status.trim() !== "";
 
   // frequency: blank -> null; NaN -> error; must be a positive integer
   let frequencyMonths: number | null = null;
@@ -193,7 +195,7 @@ export function validateRow(r: RawRow, ctx: ValidateCtx): ValidateResult {
     value: {
       rowNumber: r.rowNumber, id: r.id, name, category: category!, branchId,
       location: r.location?.trim() || null, frequencyMonths, reminderLeadDays,
-      status: status!, nextDueDate, nextDueProvided, notes: r.notes?.trim() || null,
+      status: status!, statusProvided, nextDueDate, nextDueProvided, notes: r.notes?.trim() || null,
     },
   };
 }
@@ -349,6 +351,12 @@ export async function parseEquipmentWorkbook(buffer: Buffer): Promise<ParseResul
   const sheet = wb.getWorksheet(SHEET_ITEMS);
   if (!sheet) return { ok: false, fileError: `Missing "${SHEET_ITEMS}" sheet — use the exported template.` };
 
+  // Fast-fail an absurdly large sheet before iterating every cell (coarse DoS guard;
+  // the precise per-data-row cap is enforced below). A legit export is ~items+51 rows.
+  if (sheet.rowCount > MAX_ROWS_PER_UPLOAD * 10) {
+    return { ok: false, fileError: `Too many rows (max ${MAX_ROWS_PER_UPLOAD}).` };
+  }
+
   const rows: RawRow[] = [];
   try {
     sheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
@@ -439,7 +447,9 @@ export async function applyBulkImport(args: {
         const incoming = {
           name: row.name, category: row.category, location: row.location,
           frequencyMonths: row.frequencyMonths, reminderLeadDays: row.reminderLeadDays,
-          status: row.status, notes: row.notes, nextDueDate,
+          // Blank Status on an UPDATE row preserves the existing status (so clearing
+          // the cell can't silently un-retire an item); explicit value overrides.
+          status: row.statusProvided ? row.status : existing.status, notes: row.notes, nextDueDate,
         };
         const changes = diffEquipment(
           {


### PR DESCRIPTION
Follow-up to PR #53 addressing the two remaining minor review findings.

- **Preserve status on blank update**: a blank Status cell on an UPDATE row now keeps the item's existing status (via a `statusProvided` flag) instead of defaulting to ACTIVE — so clearing the cell can no longer silently un-retire an item. New rows still default to ACTIVE.
- **Bounded-DoS hardening**: `parseEquipmentWorkbook` fast-fails a sheet with an absurd `rowCount` before iterating every cell; the import file-size cap is tightened from 10MB to 5MB (a legit 2000-row equipment export is well under 200KB).

Unit test added for the `statusProvided` flag. Full suite + build green; `tsc`/eslint clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>