### PR TITLE
perf(maintenance): cap equipment export to latest 200 active items per outlet

### DIFF
--- a/src/app/api/equipment/bulk-export/route.ts
+++ b/src/app/api/equipment/bulk-export/route.ts
@@ -3,12 +3,15 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { hasAccess } from "@/lib/access-control";
-import { equipmentWhereForRole } from "@/lib/maintenance-access";
 import { buildEquipmentWorkbook, type ExportItem } from "@/lib/services/equipment-bulk";
 
 export const runtime = "nodejs";
 export const maxDuration = 300;
 export const dynamic = "force-dynamic";
+
+// Cap the export at the latest N active items per outlet, so an all-outlet
+// (Management) export is bounded at n * N rows.
+const PER_OUTLET_LIMIT = 200;
 
 type SessionUser = { id?: string; role?: string; branchId?: string | null };
 
@@ -20,23 +23,41 @@ export async function GET() {
   if (!hasAccess(role, "equipment.manage"))
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
 
-  const items = await prisma.equipment.findMany({
-    where: equipmentWhereForRole(role, user.branchId ?? null),
-    include: { branch: { select: { name: true } } },
-    orderBy: [{ branch: { name: "asc" } }, { name: "asc" }],
-  });
-
-  // Outlet dropdown options: a manager only sees their own outlet; management sees all.
-  const branchNames =
+  // Outlets in scope: a BRANCH_MANAGER sees only their own; MANAGEMENT sees all.
+  const branches =
     role === "BRANCH_MANAGER"
-      ? [...new Set(items.map((i) => i.branch.name))]
-      : (await prisma.branch.findMany({ select: { name: true }, orderBy: { name: "asc" } })).map((b) => b.name);
+      ? user.branchId
+        ? await prisma.branch.findMany({ where: { id: user.branchId }, select: { id: true, name: true } })
+        : []
+      : await prisma.branch.findMany({ select: { id: true, name: true }, orderBy: { name: "asc" } });
 
-  const exportItems: ExportItem[] = items.map((i) => ({
-    id: i.id, name: i.name, category: i.category, branchName: i.branch.name,
-    location: i.location, frequencyMonths: i.frequencyMonths, reminderLeadDays: i.reminderLeadDays,
-    status: i.status, nextDueDate: i.nextDueDate, lastServiceDate: i.lastServiceDate, notes: i.notes,
-  }));
+  // Latest PER_OUTLET_LIMIT ACTIVE items per outlet (≤ n * PER_OUTLET_LIMIT total).
+  const perOutlet = await Promise.all(
+    branches.map((b) =>
+      prisma.equipment
+        .findMany({
+          where: { branchId: b.id, status: "ACTIVE" },
+          orderBy: { createdAt: "desc" },
+          take: PER_OUTLET_LIMIT,
+          select: {
+            id: true, name: true, category: true, location: true, frequencyMonths: true,
+            reminderLeadDays: true, status: true, nextDueDate: true, lastServiceDate: true, notes: true,
+          },
+        })
+        .then((rows) => rows.map((r) => ({ ...r, branchName: b.name })))
+    )
+  );
+
+  const exportItems: ExportItem[] = perOutlet
+    .flat()
+    .sort((a, b) => a.branchName.localeCompare(b.branchName) || a.name.localeCompare(b.name))
+    .map((i) => ({
+      id: i.id, name: i.name, category: i.category, branchName: i.branchName,
+      location: i.location, frequencyMonths: i.frequencyMonths, reminderLeadDays: i.reminderLeadDays,
+      status: i.status, nextDueDate: i.nextDueDate, lastServiceDate: i.lastServiceDate, notes: i.notes,
+    }));
+
+  const branchNames = branches.map((b) => b.name);
 
   const buffer = await buildEquipmentWorkbook(exportItems, { branchNames });
   const today = new Date().toISOString().slice(0, 10);

--- a/src/app/api/equipment/bulk-export/route.ts
+++ b/src/app/api/equipment/bulk-export/route.ts
@@ -50,7 +50,7 @@ export async function GET() {
 
   const exportItems: ExportItem[] = perOutlet
     .flat()
-    .sort((a, b) => a.branchName.localeCompare(b.branchName) || a.name.localeCompare(b.name))
+    .sort((a, b) => a.branchName.localeCompare(b.branchName, "en") || a.name.localeCompare(b.name, "en"))
     .map((i) => ({
       id: i.id, name: i.name, category: i.category, branchName: i.branchName,
       location: i.location, frequencyMonths: i.frequencyMonths, reminderLeadDays: i.reminderLeadDays,

--- a/src/lib/services/equipment-bulk.ts
+++ b/src/lib/services/equipment-bulk.ts
@@ -280,7 +280,8 @@ export async function buildEquipmentWorkbook(
     "4. Do not edit the 'Item ID' or 'Last serviced' columns (they are locked).",
     "5. Category and Outlet are dropdowns — pick from the list.",
     "6. Status defaults to Active if the cell is left blank.",
-    "7. Save as .xlsx and upload on the Maintenance > Import page.",
+    "7. This export lists up to 200 most-recent active items per outlet (retired items are not included).",
+    "8. Save as .xlsx and upload on the Maintenance > Import page.",
   ];
   instructions.forEach((line, i) => { help.getCell(i + 3, 1).value = line; });
   help.getColumn(1).width = 80;


### PR DESCRIPTION
Bounds the equipment export ("report") so it can't load an unbounded result set into memory.

- Fetches the **latest 200 ACTIVE items per outlet** (`createdAt desc`, `take: 200`).
- A Branch Manager export is ≤ 200 rows; a Management (all-outlets) export is ≤ `n × 200`.
- Retired items are excluded from the export (documented in the workbook's "How to use" sheet).

Resolves the unbounded in-memory load flagged in review. `tsc`/eslint clean; full suite + build green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>