### PR TITLE
feat(maintenance): asset image (primary photo per asset)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-asset-image.md
+++ b/docs/superpowers/plans/2026-06-10-asset-image.md
@@ -1,0 +1,414 @@
+# Asset Image — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each equipment asset a single optional primary photo — uploaded in the Add/Edit form, shown on the detail page (hero) and as a list thumbnail, and deleted on archive.
+
+**Architecture:** Add `Equipment.imageUrl`. Reuse the existing base64→Azure Blob upload pattern (`maintenance-upload.ts`) with a new `uploadAssetImage` helper and the existing `deleteMaintenanceFiles` for cleanup. The create/update API handles upload/replace/clear; the archive (ACTIVE→RETIRED) flow deletes the image alongside maintenance blobs. UI: an image picker in the form, a hero on detail, a thumbnail in the list.
+
+**Tech Stack:** Next.js 15, Prisma + Postgres, Azure Blob, Vitest (node), React/Tailwind. Spec: `docs/superpowers/specs/2026-06-10-asset-labeling-qr-design.md` (§2A).
+
+**Conventions:** prisma `@/lib/prisma`; tests under `src/**/__tests__/**/*.test.ts`; client file→base64 via `@/lib/file-to-base64` (`fileToBase64`); uploads as `{ base64, contentType }` (see `maintenance-record-form.tsx`). Ignore the pre-existing `salary-create.test.ts` tsc error.
+
+---
+
+## File Structure
+
+**Modified:**
+- `prisma/schema.prisma` — `Equipment.imageUrl String?` (+ migration).
+- `src/lib/maintenance-upload.ts` — add `uploadAssetImage`.
+- `src/lib/validations/equipment.ts` — `image` on create; `image` + `removeImage` on update.
+- `src/app/api/equipment/route.ts` (POST) — upload image on create.
+- `src/app/api/equipment/[id]/route.ts` (PATCH) — replace/clear image; delete image in archive cleanup.
+- `src/components/equipment/equipment-form.tsx` — single image picker.
+- `src/app/(auth)/equipment/[id]/page.tsx` — hero image in the header card.
+- `src/components/equipment/equipment-table.tsx` / `equipment-cards.tsx` — thumbnail in the Item cell.
+- `src/components/equipment/archive-dialog.tsx` — include the asset image in the deleted-files count.
+
+---
+
+## Task 1: Schema — `Equipment.imageUrl`
+
+**Files:** Modify `prisma/schema.prisma`
+
+- [ ] **Step 1: Add the field** — in `model Equipment`, after `notes String?`:
+
+```prisma
+  imageUrl         String?           @map("image_url")
+```
+
+- [ ] **Step 2: Validate**
+
+Run: `npx prisma validate`
+Expected: `valid 🚀`
+
+- [ ] **Step 3: Create + apply migration**
+
+Run: `npx prisma migrate dev --name add_equipment_image_url`
+Expected: migration created + applied; client regenerated.
+> If `migrate dev` is blocked by the known prod/kiosk drift, fall back to the additive pattern used before: write `prisma/migrations/<ts>_add_equipment_image_url/migration.sql` containing `ALTER TABLE "equipment" ADD COLUMN "image_url" TEXT;`, apply via `npx prisma db execute --file <that>.sql --schema prisma/schema.prisma`, then `npx prisma migrate resolve --applied <name>` and `npx prisma generate`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat(asset-image): add Equipment.imageUrl"
+```
+
+---
+
+## Task 2: `uploadAssetImage` helper
+
+**Files:** Modify `src/lib/maintenance-upload.ts`; Test `src/lib/services/__tests__/asset-image-upload.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/services/__tests__/asset-image-upload.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { uploadAssetImage } from "@/lib/maintenance-upload";
+
+const uploadImage = vi.fn();
+vi.mock("@/lib/azure-storage", () => ({
+  AzureStorageService: class {
+    uploadImage = uploadImage;
+  },
+}));
+
+beforeEach(() => {
+  uploadImage.mockReset();
+  uploadImage.mockImplementation(async (_buf, fileName: string, folder: string) => `https://blob.test/${folder}/${fileName}`);
+});
+
+describe("uploadAssetImage", () => {
+  it("returns null for no image", async () => {
+    expect(await uploadAssetImage(null, "eq-1", "b-1")).toBeNull();
+    expect(uploadImage).not.toHaveBeenCalled();
+  });
+  it("uploads to the asset-images folder and returns the url", async () => {
+    const url = await uploadAssetImage({ base64: "data:image/jpeg;base64,QQ==", contentType: "image/jpeg" }, "eq-1", "b-1");
+    expect(url).toContain("equipment/b-1/asset-images/");
+    expect(url).toMatch(/\.jpg$/);
+    expect(Buffer.isBuffer(uploadImage.mock.calls[0][0])).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run → fail**
+
+Run: `npx vitest run src/lib/services/__tests__/asset-image-upload.test.ts`
+Expected: FAIL — `uploadAssetImage` not exported.
+
+- [ ] **Step 3: Implement** — append to `src/lib/maintenance-upload.ts` (reuses the file's existing `decodeBase64`, `extFor`, `UploadFile`, `AzureStorageService`):
+
+```typescript
+/**
+ * Uploads a single primary asset image to Azure Blob and returns its URL,
+ * or null when no image is provided. Folder: equipment/{branchId}/asset-images.
+ */
+export async function uploadAssetImage(
+  image: UploadFile | null | undefined,
+  equipmentId: string,
+  branchId: string
+): Promise<string | null> {
+  if (!image) return null;
+  const azure = new AzureStorageService();
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const fileName = `asset-${equipmentId}-${stamp}.${extFor(image.contentType)}`;
+  return azure.uploadImage(
+    decodeBase64(image.base64),
+    fileName,
+    `equipment/${branchId}/asset-images`,
+    image.contentType
+  );
+}
+```
+
+- [ ] **Step 4: Run → pass**
+
+Run: `npx vitest run src/lib/services/__tests__/asset-image-upload.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/maintenance-upload.ts src/lib/services/__tests__/asset-image-upload.test.ts
+git commit -m "feat(asset-image): uploadAssetImage helper"
+```
+
+---
+
+## Task 3: Validation schemas
+
+**Files:** Modify `src/lib/validations/equipment.ts`; Test `src/lib/services/__tests__/equipment-image-validations.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// src/lib/services/__tests__/equipment-image-validations.test.ts
+import { describe, it, expect } from "vitest";
+import { equipmentCreateSchema, equipmentUpdateSchema } from "@/lib/validations/equipment";
+
+const img = { base64: "data:image/png;base64,QQ==", contentType: "image/png" };
+
+describe("equipment image validation", () => {
+  it("accepts an optional image on create", () => {
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b", image: img }).success).toBe(true);
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b" }).success).toBe(true);
+  });
+  it("accepts image + removeImage on update", () => {
+    expect(equipmentUpdateSchema.safeParse({ image: img }).success).toBe(true);
+    expect(equipmentUpdateSchema.safeParse({ removeImage: true }).success).toBe(true);
+  });
+  it("rejects a malformed image object", () => {
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b", image: { base64: "" } }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run → fail**
+
+Run: `npx vitest run src/lib/services/__tests__/equipment-image-validations.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement** — in `src/lib/validations/equipment.ts`, add `image` to create and `image`/`removeImage` to update. Change:
+
+```typescript
+export const equipmentCreateSchema = z.object({
+  name: z.string().trim().min(1, "Name is required"),
+  category: z.enum(EQUIPMENT_CATEGORIES),
+  branchId: z.string().min(1, "Outlet is required"),
+  location: z.string().trim().optional().nullable(),
+  frequencyMonths: z.coerce.number().int().positive().nullable().optional(),
+  reminderLeadDays: z.coerce.number().int().min(0).max(365).default(15),
+  nextDueDate: dateStr.optional().nullable(),
+  notes: z.string().trim().optional().nullable(),
+  image: uploadFile.optional().nullable(),
+});
+
+export const equipmentUpdateSchema = equipmentCreateSchema
+  .omit({ branchId: true })
+  .partial()
+  .extend({
+    status: z.enum(["ACTIVE", "RETIRED"]).optional(),
+    removeImage: z.boolean().optional(),
+  });
+```
+
+- [ ] **Step 4: Run → pass**
+
+Run: `npx vitest run src/lib/services/__tests__/equipment-image-validations.test.ts`
+Expected: PASS. Also confirm the existing `equipment-validations.test.ts` still passes: `npx vitest run src/lib/services/__tests__/equipment-validations.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/validations/equipment.ts src/lib/services/__tests__/equipment-image-validations.test.ts
+git commit -m "feat(asset-image): image fields on create/update schemas"
+```
+
+---
+
+## Task 4: Create route — upload image
+
+**Files:** Modify `src/app/api/equipment/route.ts`
+
+- [ ] **Step 1: Implement** — in the `POST` handler, after the record is validated (`const data = parsed.data;`) and `canManageBranch` passes, upload the image and include `imageUrl` in the create. Add the import and the logic:
+
+```typescript
+import { uploadAssetImage } from "@/lib/maintenance-upload";
+```
+
+Replace the `prisma.equipment.create({ data: { … } })` call so it includes the uploaded URL. Just before the create:
+
+```typescript
+    const imageUrl = await uploadAssetImage(data.image ?? null, "new", data.branchId);
+```
+
+> `equipmentId` isn't known until after create; using `"new"` in the blob filename is fine (the filename also has a timestamp). Add `imageUrl,` to the `data: { … }` object of `prisma.equipment.create`.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors (ignore salary-create.test.ts).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/equipment/route.ts
+git commit -m "feat(asset-image): store image on equipment create"
+```
+
+---
+
+## Task 5: Update route — replace/clear image + archive deletion
+
+**Files:** Modify `src/app/api/equipment/[id]/route.ts`
+
+- [ ] **Step 1: Implement** — in the `PATCH` handler:
+
+Add imports:
+```typescript
+import { uploadAssetImage, deleteMaintenanceFiles } from "@/lib/maintenance-upload";
+```
+(`deleteMaintenanceFiles` may already be imported for the archive block — don't double-import.)
+
+After validation (`const d = parsed.data;`) and the branch authorization, compute the image change BEFORE the `prisma.equipment.update`:
+
+```typescript
+    // Asset image: explicit new image replaces (and deletes old); removeImage clears it.
+    let imageUrlUpdate: { imageUrl: string | null } | null = null;
+    if (d.image) {
+      const newUrl = await uploadAssetImage(d.image, id, guardItem.branchId);
+      imageUrlUpdate = { imageUrl: newUrl };
+      if (guardItem.imageUrl) await deleteMaintenanceFiles([guardItem.imageUrl]);
+    } else if (d.removeImage) {
+      imageUrlUpdate = { imageUrl: null };
+      if (guardItem.imageUrl) await deleteMaintenanceFiles([guardItem.imageUrl]);
+    }
+```
+
+Add `...(imageUrlUpdate ?? {})` to the `data: { … }` object of the existing `prisma.equipment.update`.
+
+Then, in the existing **archive (ACTIVE→RETIRED)** cleanup block, include the asset image when collecting URLs to delete and clear it. Where the block gathers record blob URLs and calls `deleteMaintenanceFiles(urls)`, add the asset image:
+
+```typescript
+      const urls = recs.flatMap((r) => [r.billUrl, ...r.photoUrls]).filter((u): u is string => !!u);
+      if (guardItem.imageUrl) urls.push(guardItem.imageUrl);
+```
+
+And add `imageUrl: null` to the `updateMany`/equipment update that nulls the record references on archive — specifically null the equipment's `imageUrl` as part of the archive `prisma.equipment.update` (the one that set status RETIRED already ran; add a follow-up or include it). Implement: after the archive cleanup deletes blobs, also run:
+
+```typescript
+      if (guardItem.imageUrl) {
+        await prisma.equipment.update({ where: { id }, data: { imageUrl: null } });
+      }
+```
+
+> Use the handler's actual loaded-item variable name (it is `guardItem` per the records-route fix; confirm by reading the file — it's `const guardItem = guard.item!`). `guardItem` must include `imageUrl` and `branchId` (it's the full `prisma.equipment.findUnique`, so it does).
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "src/app/api/equipment/[id]/route.ts"
+git commit -m "feat(asset-image): replace/clear on update, delete on archive"
+```
+
+---
+
+## Task 6: Form image picker
+
+**Files:** Modify `src/components/equipment/equipment-form.tsx`
+
+- [ ] **Step 1: Implement** — add a single optional asset-image picker. The form posts JSON; convert the picked file to base64 with `fileToBase64` (from `@/lib/file-to-base64`) and include it as `image` in the POST/PATCH body. On edit, show the existing `initial.imageUrl` as a preview with a "Remove" control that sends `removeImage: true`.
+
+Add to the component:
+```tsx
+import { fileToBase64 } from "@/lib/file-to-base64";
+```
+Extend `EquipmentFormValues` with `imageUrl?: string | null`. Add state:
+```tsx
+const [imageFile, setImageFile] = useState<File | null>(null);
+const [removeImage, setRemoveImage] = useState(false);
+const existingImageUrl = initial?.imageUrl ?? null;
+```
+In the JSX (a sensible spot, e.g. above Notes), add:
+```tsx
+<div className="space-y-2">
+  <Label htmlFor="asset-image">Asset photo (optional)</Label>
+  {existingImageUrl && !imageFile && !removeImage && (
+    <div className="flex items-center gap-3">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={existingImageUrl} alt="Asset" className="h-16 w-16 rounded object-cover" />
+      <Button type="button" variant="ghost" size="sm" onClick={() => setRemoveImage(true)}>Remove</Button>
+    </div>
+  )}
+  <Input
+    id="asset-image"
+    type="file"
+    accept="image/*"
+    onChange={(e) => { setImageFile(e.target.files?.[0] ?? null); setRemoveImage(false); }}
+  />
+  {imageFile && <p className="text-xs text-muted-foreground">{imageFile.name}</p>}
+</div>
+```
+In the submit handler, before `fetch`, build the image payload and merge into the JSON body:
+```tsx
+const imagePayload = imageFile ? await fileToBase64(imageFile) : null;
+// ...body: JSON.stringify({ ...form, /* existing fields */, image: imagePayload, removeImage })
+```
+(For create, send `image: imagePayload`; `removeImage` is harmless on create. For edit, send both.)
+
+- [ ] **Step 2: Verify** — `npx tsc --noEmit` clean; in the browser, add an item with a photo → it persists; edit → preview shows; Remove clears it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/equipment/equipment-form.tsx
+git commit -m "feat(asset-image): image picker in the item form"
+```
+
+---
+
+## Task 7: Detail hero + list thumbnail + archive count
+
+**Files:** Modify `src/app/(auth)/equipment/[id]/page.tsx`, `equipment-table.tsx`, `equipment-cards.tsx`, `archive-dialog.tsx`
+
+- [ ] **Step 1: Detail hero** — in `[id]/page.tsx`, the header card renders a category-icon tile. When `item.imageUrl` is set, show the photo instead of (or beside) the icon tile. Replace the icon-tile block with:
+
+```tsx
+{item.imageUrl ? (
+  // eslint-disable-next-line @next/next/no-img-element
+  <img
+    src={item.imageUrl}
+    alt={item.name}
+    className="h-[44px] w-[44px] flex-none rounded-[11px] object-cover"
+  />
+) : (
+  <div
+    className="flex h-[44px] w-[44px] flex-none items-center justify-center rounded-[11px]"
+    style={{ background: cm.bg, color: cm.fg }}
+  >
+    <CategoryIcon name={cm.icon} size={22} strokeWidth={2.1} />
+  </div>
+)}
+```
+
+- [ ] **Step 2: List thumbnail** — the list page's `rows` already map item fields; add `imageUrl: i.imageUrl` to the row shape in `src/app/(auth)/equipment/page.tsx` and to the `EquipmentRow` interface in `equipment-table.tsx`. In `equipment-table.tsx`'s Item cell and `equipment-cards.tsx`'s card, render a 28–36px thumbnail before the name when `row.imageUrl` exists, else the existing `CategoryIcon`/pill. Example for the table Item cell:
+
+```tsx
+{row.imageUrl ? (
+  // eslint-disable-next-line @next/next/no-img-element
+  <img src={row.imageUrl} alt="" className="h-8 w-8 flex-none rounded object-cover" />
+) : null}
+```
+Add `imageUrl: string | null;` to `EquipmentRow`, and pass `imageUrl` through from the page. (Do the same for `equipment-cards.tsx`'s `EquipmentCardRow`/props.)
+
+- [ ] **Step 3: Archive count includes the image** — in `archive-dialog.tsx`, the dialog fetches the item's records to count photos/bills. The asset image lives on the equipment, not records — pass a `hasImage` prop from the trigger (table/cards/detail already have the row/item) and add it to the count copy, e.g. `{counts.photos} photo(s), {counts.bills} bill(s)${hasImage ? ", and the asset photo" : ""}`. Add `hasImage?: boolean` to `ArchiveDialog` props and thread it from the call sites (`row.imageUrl != null` / `item.imageUrl != null`).
+
+- [ ] **Step 4: Verify** — `npx tsc --noEmit` + `npx eslint src/components/equipment "src/app/(auth)/equipment"` clean. Browser: an item with a photo shows a hero on detail and a thumbnail in the list; archiving it mentions the asset photo and removes the blob.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "src/app/(auth)/equipment/[id]/page.tsx" "src/app/(auth)/equipment/page.tsx" src/components/equipment/equipment-table.tsx src/components/equipment/equipment-cards.tsx src/components/equipment/archive-dialog.tsx
+git commit -m "feat(asset-image): detail hero, list thumbnail, archive count"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1:** `npx vitest run src/lib` (asset-image-upload + image-validations green; existing suites unaffected).
+- [ ] **Step 2:** `npx tsc --noEmit` clean (ignore salary-create.test.ts).
+- [ ] **Step 3:** Stop the dev server, then `npm run build` → exit 0.
+- [ ] **Step 4: Manual** — create an item with a photo; verify hero + thumbnail; edit to replace the photo (old blob deleted) and to remove it; archive an item with a photo (image blob deleted, `imageUrl` nulled). HR can't add/edit (read-only).
+- [ ] **Step 5:** Restart the dev server.
+
+## Done criteria
+- An asset can carry one optional photo, shown on detail + list; replacing deletes the old blob; archiving deletes it; HR stays read-only; build + `src/lib` tests green.

--- a/docs/superpowers/specs/2026-06-10-asset-labeling-qr-design.md
+++ b/docs/superpowers/specs/2026-06-10-asset-labeling-qr-design.md
@@ -1,0 +1,176 @@
+# Asset Labeling & QR Tracking — Design Spec
+
+**Date:** 2026-06-10
+**Status:** Approved design, pending implementation plan
+**Module:** Maintenance (Equipment items) — extends the merged module (PRs #52–55).
+
+## 1. Purpose
+
+Turn each equipment item into a labeled, scannable asset. Print a **50×25mm QR
+label** for any device; scanning it with a phone's native camera opens that asset's
+existing detail page (identity + full maintenance/service history), behind login.
+This gives staff a physical → digital link to track an asset and its service record.
+
+Each asset also carries a **primary photo** for visual identification (on its record,
+not the label). Scope is intentionally narrow: **labels + scan-to-view + an asset
+photo** on top of the existing equipment registry. Broader asset-management features (depreciation, assignments,
+warranties, audits) are out of scope and would be separate specs.
+
+## 2. Asset tag & outlet codes
+
+- Add a short **`code`** field to the `Branch` model — a human-curated outlet code
+  (e.g. `CHD` for Chandivali). `String?`, **`@unique`**, set by Management on the
+  branch edit screen.
+- The **asset tag** is **computed, not stored**:
+  `assetTag = ‹outlet code›-‹numId zero-padded to 4›` → e.g. `CHD-0042`.
+  - `numId` already exists on `Equipment` (sequential).
+  - Items cannot move between outlets (branchId is immutable on update), so the tag
+    is stable for an asset's life.
+  - **Fallback** when `branch.code` is null: derive a 3-letter code from the outlet
+    name (first three alphanumeric chars, uppercased), so labels still render. The UI
+    surfaces a gentle "set an outlet code" hint; the fallback is not guaranteed unique
+    and is only a stopgap.
+
+## 2A. Asset image
+
+- Add an **`imageUrl String?`** field to `Equipment` — a single, optional primary photo
+  of the device.
+- **Upload:** the Add/Edit Item form gets an optional image picker (single image,
+  `image/*`). The browser reads it to base64 (same pattern as maintenance photos);
+  on create/update it's uploaded to Azure Blob via a small helper to folder
+  `equipment/‹branchId›/asset-images/`, and only the returned URL is stored in
+  `imageUrl`. Replacing the image uploads the new one and (best-effort) deletes the old
+  blob. Clearing it nulls `imageUrl` (and best-effort deletes the blob).
+- **Display:**
+  - **Detail page:** the image shown prominently in the header card (a thumbnail/hero
+    beside the name + category), with a tasteful placeholder when absent.
+  - **Items list:** a small thumbnail in the Item cell (desktop table + mobile card),
+    with a category-icon placeholder when absent.
+  - **Not** printed on the label (§3).
+- **Archive cleanup:** consistent with the existing archive flow (which deletes a
+  retired item's maintenance photos/bills), archiving an item also best-effort **deletes
+  the asset image blob and nulls `imageUrl`**. The archive confirmation's counts include
+  the asset image (e.g. "1 asset photo").
+
+## 3. The label (50×25mm)
+
+Layout per label (landscape 50mm wide × 25mm tall):
+- **Left:** QR code, ~20×20mm, vertically centered.
+- **Right column** (~26mm wide), top-to-bottom:
+  - `CHD-0042` — the asset tag, **bold**, largest text.
+  - Asset **name** (truncated/ellipsised to fit ~1 line).
+  - Outlet **name**.
+  - **Category** label (e.g. "Electrical").
+- No company logo (keeps it legible at this size).
+- Fonts small (≈6–9pt); the tag is the most prominent element.
+
+## 4. QR content & scanning
+
+- The QR encodes the **absolute URL** `‹APP_URL›/equipment/‹id›` (the cuid `id`).
+  `APP_URL` comes from `NEXTAUTH_URL` (already used elsewhere) with a sane fallback.
+- Scanning with the **phone's native camera** opens the browser at that URL. The
+  existing **auth middleware** redirects an unauthenticated user to login, then back
+  to the asset page. **Native-camera only — no in-app scanner is built.**
+- The **existing `/equipment/[id]` detail page is reused unchanged**: it already shows
+  identity + paginated service history and already enforces outlet scope (a
+  BRANCH_MANAGER scanning another outlet's device is redirected; MANAGEMENT sees all).
+
+## 5. Printing (react-pdf → PDF)
+
+- Output is a **PDF** rendered with `@react-pdf/renderer` (already a dependency).
+- **Page geometry:** two 50×25mm labels **side-by-side** per page → page ≈
+  **100mm × 25mm** with a small (~2mm) center gutter (constant, easy to tune). Built
+  for a 2-across label printer. Points: 1mm = 72/25.4 ≈ 2.8346pt (so a label is
+  ≈141.7pt × 70.9pt).
+- **Bulk:** items are laid out 2 per page across as many pages as needed (an odd count
+  leaves the last page's second cell blank).
+- **Entry points:**
+  - **Single:** "Print label" on the asset **detail page** → one label.
+  - **Per-row:** "Print label" in the items-list row menu → one label.
+  - **Bulk:** "Print labels" on the **Items list** → labels for the **current
+    filtered/scoped result set** (the user filters to what they want, then prints).
+- **Endpoint:** `GET /api/equipment/labels` — auth + `hasAccess(role,
+  "equipment.manage")` + outlet scope. Params:
+  - `ids=a,b,c` — explicit asset ids (single/per-row/selected), **or**
+  - no `ids` → the caller's full scoped set (mirrors the list/export scoping:
+    BRANCH_MANAGER = own outlet, MANAGEMENT = all; honors `outlet`/`category`/
+    `lifecycle` params if passed so "print current view" works).
+  - Returns `application/pdf` with `Content-Disposition: attachment;
+    filename="asset-labels-‹scope›-‹date›.pdf"`. A manager requesting another outlet's
+    `ids` gets those rows filtered out (never another outlet's labels).
+  - Reasonable cap (e.g. 1000 labels/request) to bound memory.
+
+## 6. New / changed code
+
+**New:**
+- `src/lib/asset-tag.ts` — `assetTag(outletCode: string | null, numId: number,
+  outletName: string)` → string (handles the fallback). Pure, unit-tested.
+- `src/lib/services/equipment-label-pdf.tsx` — the react-pdf `Document`/label
+  component + `renderEquipmentLabels(items): Promise<Buffer>` (mirrors
+  `src/lib/services/leave-application-pdf.tsx`). Generates each QR as a data URL via
+  the new **`qrcode`** dependency and embeds it as an `<Image>`.
+- `src/app/api/equipment/labels/route.ts` — the PDF endpoint (§5).
+
+**Modified:**
+- `prisma/schema.prisma` — add `code String? @unique` to `Branch` **and `imageUrl
+  String?` to `Equipment`** (one migration).
+- Branch create/edit form + API — an "Outlet code" input (Management).
+- `src/lib/validations/equipment.ts` — add the optional asset `image`
+  (base64 upload) to create + an `imageUrl`/clear flag to update schemas.
+- `src/lib/maintenance-upload.ts` — extend with `uploadAssetImage(...)` (folder
+  `equipment/‹branchId›/asset-images/`); reuse `deleteMaintenanceFiles` for old-blob
+  cleanup on replace/clear/archive.
+- `src/app/api/equipment/route.ts` (POST) + `[id]/route.ts` (PATCH) — handle asset
+  image upload on create, replace/clear on update, and **delete it in the archive
+  (ACTIVE→RETIRED) cleanup** alongside the maintenance blobs.
+- `src/components/equipment/equipment-form.tsx` — optional single asset-image picker.
+- `src/app/(auth)/equipment/[id]/page.tsx` — show the asset image in the header card.
+- `src/components/equipment/detail-actions.tsx` — a "Print label" button (gated on
+  `equipment.manage`).
+- `src/components/equipment/equipment-table.tsx` / `equipment-cards.tsx` — an asset
+  **thumbnail** in the Item cell + a "Print label" row action.
+- `src/components/equipment/archive-dialog.tsx` — include the asset image in the
+  deleted-files count/copy.
+- `src/app/(auth)/equipment/page.tsx` — a "Print labels" button (prints the current
+  scoped/filtered set), next to Export/Import, gated on `equipment.manage`.
+
+**Reused (unchanged):** `@react-pdf/renderer`, the `(print)`/PDF patterns, the
+`/equipment/[id]` detail page, `equipmentWhereForRole`/`canManageBranch`, `hasAccess`,
+`NEXTAUTH_URL`.
+
+## 7. Dependencies
+
+- Add **`qrcode`** (+ `@types/qrcode`) — generates QR codes as PNG/SVG data URLs
+  server-side. Small, widely-used, no native build.
+
+## 8. Testing
+
+- **Unit (`asset-tag.ts`)**: `CHD` + `42` → `CHD-0042`; padding for ≥4-digit numIds;
+  null code → 3-letter name fallback uppercased; name with short/punctuated value.
+- **Unit (QR url)**: builds `‹APP_URL›/equipment/‹id›` from `NEXTAUTH_URL`.
+- **Render smoke test**: `renderEquipmentLabels([...sample])` returns a non-empty
+  Buffer starting with `%PDF` for 1 item, 2 items, and an odd count (3).
+- **DB-integration (labels route)**: a BRANCH_MANAGER printing `ids` that include
+  another outlet's asset gets only their own outlet's labels; HR/EMPLOYEE → 403; an
+  empty scoped set → a clear 400 (`"No assets to label"`).
+- **Asset image**: `uploadAssetImage` writes to the `asset-images` folder and returns a
+  URL (mocked Azure); creating an item with an image stores `imageUrl`; replacing/
+  clearing it deletes the old blob; archiving an item deletes the asset image blob and
+  nulls `imageUrl` (covered in the archive test by asserting the count includes it).
+
+## 9. Success criteria
+
+- From an asset's page (or the list), a manager prints a 50×25mm label with the QR,
+  `CHD-0042` tag, name, outlet, and category — 2 labels per page on a label printer.
+- Scanning the label with a phone opens (after login) that asset's detail page with its
+  service history; outlet scope is respected.
+- Bulk printing produces a multi-page PDF for the current filtered/scoped set, bounded
+  and outlet-scoped.
+- Management can set/curate each outlet's short code; tags are unique and stable.
+
+## 10. Out of scope (YAGNI)
+
+In-app camera scanner; public/no-login scan pages; A4 tiled label sheets; depreciation/
+warranty/assignment/audit features; QR scan analytics; barcode (non-QR) formats;
+re-tagging when an item is (not) moved between outlets; **multiple asset images per
+item** (only one primary photo) or the asset photo on the printed label.

--- a/prisma/migrations/20260611120000_add_equipment_image_url/migration.sql
+++ b/prisma/migrations/20260611120000_add_equipment_image_url/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "equipment" ADD COLUMN "image_url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -800,6 +800,7 @@ model Equipment {
   snoozedUntil     DateTime?         @map("snoozed_until")
   status           EquipmentStatus   @default(ACTIVE)
   notes            String?
+  imageUrl         String?           @map("image_url")
   branchId         String            @map("branch_id")
   createdById      String            @map("created_by_id")
   createdAt        DateTime          @default(now()) @map("created_at")

--- a/src/app/(auth)/equipment/[id]/edit/page.tsx
+++ b/src/app/(auth)/equipment/[id]/edit/page.tsx
@@ -33,6 +33,7 @@ export default async function EditEquipmentPage({ params }: Props) {
       frequencyMonths: true,
       reminderLeadDays: true,
       notes: true,
+      imageUrl: true,
     },
   });
 
@@ -62,6 +63,7 @@ export default async function EditEquipmentPage({ params }: Props) {
             frequencyMonths: item.frequencyMonths,
             reminderLeadDays: item.reminderLeadDays,
             notes: item.notes,
+            imageUrl: item.imageUrl,
           }}
         />
       </div>

--- a/src/app/(auth)/equipment/[id]/page.tsx
+++ b/src/app/(auth)/equipment/[id]/page.tsx
@@ -156,13 +156,22 @@ export default async function EquipmentDetailPage({ params, searchParams }: Prop
       <div className="rounded-xl border bg-card p-4 md:p-[22px] shadow-sm">
         {/* Top row: icon + name/badges + actions */}
         <div className="flex items-start gap-3 md:gap-4">
-          {/* Category icon tile */}
-          <div
-            className="flex h-[44px] w-[44px] flex-none items-center justify-center rounded-[11px]"
-            style={{ background: cm.bg, color: cm.fg }}
-          >
-            <CategoryIcon name={cm.icon} size={22} strokeWidth={2.1} />
-          </div>
+          {/* Category icon tile or asset photo */}
+          {item.imageUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={item.imageUrl}
+              alt={item.name}
+              className="h-[44px] w-[44px] flex-none rounded-[11px] object-cover"
+            />
+          ) : (
+            <div
+              className="flex h-[44px] w-[44px] flex-none items-center justify-center rounded-[11px]"
+              style={{ background: cm.bg, color: cm.fg }}
+            >
+              <CategoryIcon name={cm.icon} size={22} strokeWidth={2.1} />
+            </div>
+          )}
 
           {/* Name + category + location */}
           <div className="min-w-0 flex-1">
@@ -199,6 +208,7 @@ export default async function EquipmentDetailPage({ params, searchParams }: Prop
               canSnooze={canSnooze}
               canLog={canLog}
               status={item.status}
+              hasImage={item.imageUrl != null}
             />
           </div>
         </div>
@@ -212,6 +222,7 @@ export default async function EquipmentDetailPage({ params, searchParams }: Prop
             canSnooze={canSnooze}
             canLog={canLog}
             status={item.status}
+            hasImage={item.imageUrl != null}
           />
         </div>
 

--- a/src/app/(auth)/equipment/page.tsx
+++ b/src/app/(auth)/equipment/page.tsx
@@ -148,6 +148,7 @@ export default async function EquipmentPage({ searchParams }: Props) {
       : null,
     snoozedUntil: item.snoozedUntil ? item.snoozedUntil.toISOString() : null,
     branch: item.branch,
+    imageUrl: item.imageUrl,
   }));
 
   const canManage = hasAccess(role, "equipment.manage");

--- a/src/app/api/equipment/[id]/route.ts
+++ b/src/app/api/equipment/[id]/route.ts
@@ -5,7 +5,7 @@ import { hasAccess } from "@/lib/access-control";
 import { canManageBranch } from "@/lib/maintenance-access";
 import { equipmentUpdateSchema } from "@/lib/validations/equipment";
 import { logEntityActivity } from "@/lib/services/activity-log";
-import { deleteMaintenanceFiles } from "@/lib/maintenance-upload";
+import { uploadAssetImage, deleteMaintenanceFiles } from "@/lib/maintenance-upload";
 import { ActivityType } from "@prisma/client";
 
 type SessionUser = { id?: string; role?: string; branchId?: string | null };
@@ -70,6 +70,19 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       return NextResponse.json({ error: "Invalid input", issues: parsed.error.flatten() }, { status: 400 });
     const d = parsed.data;
 
+    const guardItem = guard.item!;
+
+    // Asset image: explicit new image replaces (and deletes old); removeImage clears it.
+    let imageUrlUpdate: { imageUrl: string | null } | null = null;
+    if (d.image) {
+      const newUrl = await uploadAssetImage(d.image, id, guardItem.branchId);
+      imageUrlUpdate = { imageUrl: newUrl };
+      if (guardItem.imageUrl) await deleteMaintenanceFiles([guardItem.imageUrl]);
+    } else if (d.removeImage) {
+      imageUrlUpdate = { imageUrl: null };
+      if (guardItem.imageUrl) await deleteMaintenanceFiles([guardItem.imageUrl]);
+    }
+
     const updated = await prisma.equipment.update({
       where: { id },
       data: {
@@ -81,10 +94,10 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         ...(d.nextDueDate !== undefined ? { nextDueDate: d.nextDueDate ? new Date(d.nextDueDate) : null } : {}),
         ...(d.notes !== undefined ? { notes: d.notes ?? null } : {}),
         ...(d.status !== undefined ? { status: d.status } : {}),
+        ...(imageUrlUpdate ?? {}),
       },
     });
 
-    const guardItem = guard.item!;
     const archiving = guardItem.status !== "RETIRED" && d.status === "RETIRED";
 
     if (archiving) {
@@ -93,6 +106,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         select: { billUrl: true, photoUrls: true },
       });
       const urls = recs.flatMap((r) => [r.billUrl, ...r.photoUrls]).filter((u): u is string => !!u);
+      if (guardItem.imageUrl) urls.push(guardItem.imageUrl);
       const photoCount = recs.reduce((n, r) => n + r.photoUrls.length, 0);
       const billCount = recs.filter((r) => !!r.billUrl).length;
       // Clear the DB references first so the UI never points at deleted blobs...
@@ -102,6 +116,9 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       });
       // ...then best-effort delete the blobs (do not fail the archive if cleanup errors).
       try { await deleteMaintenanceFiles(urls); } catch (e) { console.error("Archive blob cleanup failed for", id, e); }
+      if (guardItem.imageUrl) {
+        await prisma.equipment.update({ where: { id }, data: { imageUrl: null } });
+      }
       await logEntityActivity(
         ActivityType.EQUIPMENT_UPDATED, user.id!, "Equipment", id,
         `Archived "${updated.name}" and deleted ${photoCount} photo(s) + ${billCount} bill(s) from storage`,

--- a/src/app/api/equipment/[id]/route.ts
+++ b/src/app/api/equipment/[id]/route.ts
@@ -74,29 +74,40 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
 
     // Asset image: explicit new image replaces (and deletes old); removeImage clears it.
     let imageUrlUpdate: { imageUrl: string | null } | null = null;
+    let newlyUploadedImage: string | null = null;
     if (d.image) {
-      const newUrl = await uploadAssetImage(d.image, id, guardItem.branchId);
-      imageUrlUpdate = { imageUrl: newUrl };
-      if (guardItem.imageUrl) await deleteMaintenanceFiles([guardItem.imageUrl]);
+      newlyUploadedImage = await uploadAssetImage(d.image, id, guardItem.branchId);
+      imageUrlUpdate = { imageUrl: newlyUploadedImage };
     } else if (d.removeImage) {
       imageUrlUpdate = { imageUrl: null };
-      if (guardItem.imageUrl) await deleteMaintenanceFiles([guardItem.imageUrl]);
     }
 
-    const updated = await prisma.equipment.update({
-      where: { id },
-      data: {
-        ...(d.name !== undefined ? { name: d.name } : {}),
-        ...(d.category !== undefined ? { category: d.category } : {}),
-        ...(d.location !== undefined ? { location: d.location ?? null } : {}),
-        ...(d.frequencyMonths !== undefined ? { frequencyMonths: d.frequencyMonths ?? null } : {}),
-        ...(d.reminderLeadDays !== undefined ? { reminderLeadDays: d.reminderLeadDays } : {}),
-        ...(d.nextDueDate !== undefined ? { nextDueDate: d.nextDueDate ? new Date(d.nextDueDate) : null } : {}),
-        ...(d.notes !== undefined ? { notes: d.notes ?? null } : {}),
-        ...(d.status !== undefined ? { status: d.status } : {}),
-        ...(imageUrlUpdate ?? {}),
-      },
-    });
+    let updated;
+    try {
+      updated = await prisma.equipment.update({
+        where: { id },
+        data: {
+          ...(d.name !== undefined ? { name: d.name } : {}),
+          ...(d.category !== undefined ? { category: d.category } : {}),
+          ...(d.location !== undefined ? { location: d.location ?? null } : {}),
+          ...(d.frequencyMonths !== undefined ? { frequencyMonths: d.frequencyMonths ?? null } : {}),
+          ...(d.reminderLeadDays !== undefined ? { reminderLeadDays: d.reminderLeadDays } : {}),
+          ...(d.nextDueDate !== undefined ? { nextDueDate: d.nextDueDate ? new Date(d.nextDueDate) : null } : {}),
+          ...(d.notes !== undefined ? { notes: d.notes ?? null } : {}),
+          ...(d.status !== undefined ? { status: d.status } : {}),
+          ...(imageUrlUpdate ?? {}),
+        },
+      });
+    } catch (e) {
+      if (newlyUploadedImage) await deleteMaintenanceFiles([newlyUploadedImage]);
+      throw e;
+    }
+
+    // Best-effort delete the OLD blob now that the update has committed successfully.
+    if ((d.image || d.removeImage) && guardItem.imageUrl) {
+      try { await deleteMaintenanceFiles([guardItem.imageUrl]); }
+      catch (e) { console.error("Old asset image cleanup failed for", id, e); }
+    }
 
     const archiving = guardItem.status !== "RETIRED" && d.status === "RETIRED";
 

--- a/src/app/api/equipment/[id]/route.ts
+++ b/src/app/api/equipment/[id]/route.ts
@@ -112,12 +112,16 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     const archiving = guardItem.status !== "RETIRED" && d.status === "RETIRED";
 
     if (archiving) {
+      // The image currently on the row (a just-uploaded replacement, or the existing
+      // one if unchanged) — NOT the pre-update value, so a combined replace+archive
+      // can't orphan the newly-uploaded blob.
+      const effectiveImageUrl = imageUrlUpdate ? imageUrlUpdate.imageUrl : guardItem.imageUrl;
       const recs = await prisma.maintenanceRecord.findMany({
         where: { equipmentId: id },
         select: { billUrl: true, photoUrls: true },
       });
       const urls = recs.flatMap((r) => [r.billUrl, ...r.photoUrls]).filter((u): u is string => !!u);
-      if (guardItem.imageUrl) urls.push(guardItem.imageUrl);
+      if (effectiveImageUrl) urls.push(effectiveImageUrl);
       const photoCount = recs.reduce((n, r) => n + r.photoUrls.length, 0);
       const billCount = recs.filter((r) => !!r.billUrl).length;
       // Clear the DB references first so the UI never points at deleted blobs...
@@ -127,7 +131,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       });
       // ...then best-effort delete the blobs (do not fail the archive if cleanup errors).
       try { await deleteMaintenanceFiles(urls); } catch (e) { console.error("Archive blob cleanup failed for", id, e); }
-      if (guardItem.imageUrl) {
+      if (effectiveImageUrl) {
         await prisma.equipment.update({ where: { id }, data: { imageUrl: null } });
       }
       await logEntityActivity(

--- a/src/app/api/equipment/route.ts
+++ b/src/app/api/equipment/route.ts
@@ -6,7 +6,7 @@ import { equipmentWhereForRole, canManageBranch } from "@/lib/maintenance-access
 import { equipmentCreateSchema, EQUIPMENT_CATEGORIES } from "@/lib/validations/equipment";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { computeNextDueDate } from "@/lib/services/maintenance-schedule";
-import { uploadAssetImage } from "@/lib/maintenance-upload";
+import { uploadAssetImage, deleteMaintenanceFiles } from "@/lib/maintenance-upload";
 import { ActivityType } from "@prisma/client";
 
 type SessionUser = { id?: string; role?: string; branchId?: string | null };
@@ -76,20 +76,26 @@ export async function POST(req: Request) {
 
     const imageUrl = await uploadAssetImage(data.image ?? null, "new", data.branchId);
 
-    const created = await prisma.equipment.create({
-      data: {
-        name: data.name,
-        category: data.category,
-        branchId: data.branchId,
-        location: data.location ?? null,
-        frequencyMonths: data.frequencyMonths ?? null,
-        reminderLeadDays: data.reminderLeadDays,
-        nextDueDate,
-        notes: data.notes ?? null,
-        imageUrl,
-        createdById: user.id,
-      },
-    });
+    let created;
+    try {
+      created = await prisma.equipment.create({
+        data: {
+          name: data.name,
+          category: data.category,
+          branchId: data.branchId,
+          location: data.location ?? null,
+          frequencyMonths: data.frequencyMonths ?? null,
+          reminderLeadDays: data.reminderLeadDays,
+          nextDueDate,
+          notes: data.notes ?? null,
+          imageUrl,
+          createdById: user.id,
+        },
+      });
+    } catch (e) {
+      if (imageUrl) await deleteMaintenanceFiles([imageUrl]);
+      throw e;
+    }
 
     await logEntityActivity(
       ActivityType.EQUIPMENT_CREATED,

--- a/src/app/api/equipment/route.ts
+++ b/src/app/api/equipment/route.ts
@@ -6,6 +6,7 @@ import { equipmentWhereForRole, canManageBranch } from "@/lib/maintenance-access
 import { equipmentCreateSchema, EQUIPMENT_CATEGORIES } from "@/lib/validations/equipment";
 import { logEntityActivity } from "@/lib/services/activity-log";
 import { computeNextDueDate } from "@/lib/services/maintenance-schedule";
+import { uploadAssetImage } from "@/lib/maintenance-upload";
 import { ActivityType } from "@prisma/client";
 
 type SessionUser = { id?: string; role?: string; branchId?: string | null };
@@ -73,6 +74,8 @@ export async function POST(req: Request) {
       ? new Date(data.nextDueDate)
       : computeNextDueDate(new Date(), data.frequencyMonths ?? null);
 
+    const imageUrl = await uploadAssetImage(data.image ?? null, "new", data.branchId);
+
     const created = await prisma.equipment.create({
       data: {
         name: data.name,
@@ -83,6 +86,7 @@ export async function POST(req: Request) {
         reminderLeadDays: data.reminderLeadDays,
         nextDueDate,
         notes: data.notes ?? null,
+        imageUrl,
         createdById: user.id,
       },
     });

--- a/src/components/equipment/archive-dialog.tsx
+++ b/src/components/equipment/archive-dialog.tsx
@@ -8,8 +8,8 @@ import { Download, Archive } from "lucide-react";
 import { setEquipmentStatus } from "@/lib/equipment-actions";
 
 export function ArchiveDialog({
-  equipmentId, equipmentName, open, onOpenChange,
-}: { equipmentId: string; equipmentName: string; open: boolean; onOpenChange: (o: boolean) => void; }) {
+  equipmentId, equipmentName, hasImage = false, open, onOpenChange,
+}: { equipmentId: string; equipmentName: string; hasImage?: boolean; open: boolean; onOpenChange: (o: boolean) => void; }) {
   const router = useRouter();
   const [counts, setCounts] = useState<{ photos: number; bills: number } | null>(null);
   const [busy, setBusy] = useState(false);
@@ -53,7 +53,9 @@ export function ArchiveDialog({
           <DialogTitle>Archive “{equipmentName}”?</DialogTitle>
           <DialogDescription>
             Archiving will mark this item inactive and <strong>permanently delete</strong>{" "}
-            {counts ? `${counts.photos} photo(s) and ${counts.bills} bill(s)` : "all attached photos and bills"}{" "}
+            {counts
+              ? `${counts.photos} photo(s) and ${counts.bills} bill(s)${hasImage ? ", and the asset photo" : ""}`
+              : `all attached photos and bills${hasImage ? ", and the asset photo" : ""}`}{" "}
             from storage to free space. This cannot be undone — restoring the item later will not recover the files.
           </DialogDescription>
         </DialogHeader>

--- a/src/components/equipment/detail-actions.tsx
+++ b/src/components/equipment/detail-actions.tsx
@@ -17,6 +17,7 @@ interface DetailActionsProps {
   canSnooze?: boolean;
   canLog?: boolean;
   status: "ACTIVE" | "RETIRED";
+  hasImage?: boolean;
 }
 
 export function DetailActions({
@@ -26,6 +27,7 @@ export function DetailActions({
   canSnooze = false,
   canLog = false,
   status,
+  hasImage = false,
 }: DetailActionsProps) {
   const router = useRouter();
   const [snoozeOpen, setSnoozeOpen] = useState(false);
@@ -140,6 +142,7 @@ export function DetailActions({
       <ArchiveDialog
         equipmentId={equipmentId}
         equipmentName={equipmentName ?? "this item"}
+        hasImage={hasImage}
         open={archiveOpen}
         onOpenChange={setArchiveOpen}
       />

--- a/src/components/equipment/equipment-cards.tsx
+++ b/src/components/equipment/equipment-cards.tsx
@@ -78,13 +78,18 @@ function ItemCard({ row, canManage, canSnooze, canLog, onSnooze, onArchive }: It
     >
       {/* Top row: icon + name/category/outlet + chevron */}
       <div className="flex items-start gap-[11px] p-3.5">
-        {/* Category icon tile */}
-        <div
-          className="flex h-[38px] w-[38px] flex-none items-center justify-center rounded-[9px]"
-          style={{ background: cm.bg, color: cm.fg }}
-        >
-          <CategoryIcon name={cm.icon} size={19} strokeWidth={2.1} />
-        </div>
+        {/* Category icon tile or asset photo */}
+        {row.imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={row.imageUrl} alt="" className="h-8 w-8 flex-none rounded object-cover" />
+        ) : (
+          <div
+            className="flex h-[38px] w-[38px] flex-none items-center justify-center rounded-[9px]"
+            style={{ background: cm.bg, color: cm.fg }}
+          >
+            <CategoryIcon name={cm.icon} size={19} strokeWidth={2.1} />
+          </div>
+        )}
 
         {/* Name + pills */}
         <div className="min-w-0 flex-1">
@@ -259,6 +264,7 @@ export function EquipmentCards({
         <ArchiveDialog
           equipmentId={archiveId}
           equipmentName={archiveRow?.name ?? "this item"}
+          hasImage={archiveRow?.imageUrl != null}
           open={!!archiveId}
           onOpenChange={(o) => {
             if (!o) setArchiveId(null);

--- a/src/components/equipment/equipment-form.tsx
+++ b/src/components/equipment/equipment-form.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/select";
 import { Card, CardContent } from "@/components/ui/card";
 import { ALL_CATEGORIES, categoryLabel } from "@/lib/equipment-display";
+import { fileToBase64 } from "@/lib/file-to-base64";
 
 interface BranchOption {
   id: string;
@@ -31,6 +32,7 @@ interface EquipmentFormValues {
   frequencyMonths?: number | null;
   reminderLeadDays?: number;
   notes?: string | null;
+  imageUrl?: string | null;
 }
 
 interface EquipmentFormState {
@@ -71,6 +73,9 @@ export function EquipmentForm({
   });
 
   const [submitting, setSubmitting] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [removeImage, setRemoveImage] = useState(false);
+  const existingImageUrl = initial?.imageUrl ?? null;
 
   const set = (k: keyof EquipmentFormState, v: string) =>
     setForm((s) => ({ ...s, [k]: v }));
@@ -89,6 +94,8 @@ export function EquipmentForm({
           : Number(form.frequencyMonths);
       const reminderLeadDays = Number(form.reminderLeadDays) || 15;
 
+      const imagePayload = imageFile ? await fileToBase64(imageFile) : null;
+
       const body = {
         name: form.name.trim(),
         category: form.category,
@@ -97,6 +104,8 @@ export function EquipmentForm({
         frequencyMonths: frequencyMonths ?? undefined,
         reminderLeadDays,
         notes: form.notes.trim() || undefined,
+        image: imagePayload,
+        removeImage,
       };
 
       const url = isEdit
@@ -248,6 +257,25 @@ export function EquipmentForm({
                 How many days before the due date to start reminding
               </p>
             </div>
+          </div>
+
+          {/* Asset photo */}
+          <div className="space-y-2">
+            <Label htmlFor="asset-image">Asset photo (optional)</Label>
+            {existingImageUrl && !imageFile && !removeImage && (
+              <div className="flex items-center gap-3">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={existingImageUrl} alt="Asset" className="h-16 w-16 rounded object-cover" />
+                <Button type="button" variant="ghost" size="sm" onClick={() => setRemoveImage(true)}>Remove</Button>
+              </div>
+            )}
+            <Input
+              id="asset-image"
+              type="file"
+              accept="image/*"
+              onChange={(e) => { setImageFile(e.target.files?.[0] ?? null); setRemoveImage(false); }}
+            />
+            {imageFile && <p className="text-xs text-muted-foreground">{imageFile.name}</p>}
           </div>
 
           {/* Notes */}

--- a/src/components/equipment/equipment-table.tsx
+++ b/src/components/equipment/equipment-table.tsx
@@ -41,6 +41,7 @@ export interface EquipmentRow {
   lastServiceDate: string | null;
   snoozedUntil: string | null;
   branch: { id: string; name: string };
+  imageUrl: string | null;
 }
 
 interface EquipmentTableProps {
@@ -129,6 +130,10 @@ export function EquipmentTable({
                 {/* Item */}
                 <TableCell>
                   <div className="flex items-center gap-2">
+                    {row.imageUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={row.imageUrl} alt="" className="h-8 w-8 flex-none rounded object-cover" />
+                    ) : null}
                     <span className="font-semibold text-foreground">{row.name}</span>
                     {isRetired && (
                       <Badge variant="secondary" className="text-[11px] text-muted-foreground">
@@ -292,6 +297,7 @@ export function EquipmentTable({
         <ArchiveDialog
           equipmentId={archiveId}
           equipmentName={archiveRow?.name ?? "this item"}
+          hasImage={archiveRow?.imageUrl != null}
           open={!!archiveId}
           onOpenChange={(o) => {
             if (!o) setArchiveId(null);

--- a/src/lib/maintenance-upload.ts
+++ b/src/lib/maintenance-upload.ts
@@ -74,6 +74,27 @@ export async function uploadMaintenanceFiles(
 }
 
 /**
+ * Uploads a single primary asset image to Azure Blob and returns its URL,
+ * or null when no image is provided. Folder: equipment/{branchId}/asset-images.
+ */
+export async function uploadAssetImage(
+  image: UploadFile | null | undefined,
+  equipmentId: string,
+  branchId: string
+): Promise<string | null> {
+  if (!image) return null;
+  const azure = new AzureStorageService();
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const fileName = `asset-${equipmentId}-${stamp}.${extFor(image.contentType)}`;
+  return azure.uploadImage(
+    decodeBase64(image.base64),
+    fileName,
+    `equipment/${branchId}/asset-images`,
+    image.contentType
+  );
+}
+
+/**
  * Best-effort deletion of previously-uploaded maintenance blobs by URL.
  * Used to clean up orphaned files when a subsequent DB write fails.
  */

--- a/src/lib/services/__tests__/asset-image-upload.test.ts
+++ b/src/lib/services/__tests__/asset-image-upload.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { uploadAssetImage } from "@/lib/maintenance-upload";
+
+const uploadImage = vi.fn();
+vi.mock("@/lib/azure-storage", () => ({
+  AzureStorageService: class {
+    uploadImage = uploadImage;
+  },
+}));
+
+beforeEach(() => {
+  uploadImage.mockReset();
+  uploadImage.mockImplementation(async (_buf, fileName: string, folder: string) => `https://blob.test/${folder}/${fileName}`);
+});
+
+describe("uploadAssetImage", () => {
+  it("returns null for no image", async () => {
+    expect(await uploadAssetImage(null, "eq-1", "b-1")).toBeNull();
+    expect(uploadImage).not.toHaveBeenCalled();
+  });
+  it("uploads to the asset-images folder and returns the url", async () => {
+    const url = await uploadAssetImage({ base64: "data:image/jpeg;base64,QQ==", contentType: "image/jpeg" }, "eq-1", "b-1");
+    expect(url).toContain("equipment/b-1/asset-images/");
+    expect(url).toMatch(/\.jpg$/);
+    expect(Buffer.isBuffer(uploadImage.mock.calls[0][0])).toBe(true);
+  });
+});

--- a/src/lib/services/__tests__/equipment-image-validations.test.ts
+++ b/src/lib/services/__tests__/equipment-image-validations.test.ts
@@ -16,4 +16,12 @@ describe("equipment image validation", () => {
   it("rejects a malformed image object", () => {
     expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b", image: { base64: "" } }).success).toBe(false);
   });
+  it("rejects an image larger than the 10MB cap, accepts one under it", () => {
+    // ~10.5MB decoded (14M base64 chars * 3/4) → over the cap.
+    const tooBig = { base64: "A".repeat(14 * 1024 * 1024), contentType: "image/png" };
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b", image: tooBig }).success).toBe(false);
+    // ~1.5MB decoded → under the cap.
+    const ok = { base64: "A".repeat(2 * 1024 * 1024), contentType: "image/png" };
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b", image: ok }).success).toBe(true);
+  });
 });

--- a/src/lib/services/__tests__/equipment-image-validations.test.ts
+++ b/src/lib/services/__tests__/equipment-image-validations.test.ts
@@ -1,0 +1,19 @@
+// src/lib/services/__tests__/equipment-image-validations.test.ts
+import { describe, it, expect } from "vitest";
+import { equipmentCreateSchema, equipmentUpdateSchema } from "@/lib/validations/equipment";
+
+const img = { base64: "data:image/png;base64,QQ==", contentType: "image/png" };
+
+describe("equipment image validation", () => {
+  it("accepts an optional image on create", () => {
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b", image: img }).success).toBe(true);
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b" }).success).toBe(true);
+  });
+  it("accepts image + removeImage on update", () => {
+    expect(equipmentUpdateSchema.safeParse({ image: img }).success).toBe(true);
+    expect(equipmentUpdateSchema.safeParse({ removeImage: true }).success).toBe(true);
+  });
+  it("rejects a malformed image object", () => {
+    expect(equipmentCreateSchema.safeParse({ name: "X", category: "OTHER", branchId: "b", image: { base64: "" } }).success).toBe(false);
+  });
+});

--- a/src/lib/validations/equipment.ts
+++ b/src/lib/validations/equipment.ts
@@ -12,7 +12,23 @@ export const MAINTENANCE_TYPES = [
   "REPAIR", "SERVICE", "AMC", "INSPECTION", "REPLACEMENT", "OTHER",
 ] as const;
 
-const uploadFile = z.object({ base64: z.string().min(1), contentType: z.string().min(1) });
+// Server-side upload size cap (bytes), shared by asset image + bill + service photos.
+// Bounds memory: a base64 body is decoded straight into a Buffer, so reject oversized
+// payloads as a clean 400 instead of allocating. ~10MB matches the form's stated limit.
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+function approxBase64Bytes(s: string): number {
+  const b64 = s.replace(/^data:[^;]+;base64,/, "");
+  const padding = b64.endsWith("==") ? 2 : b64.endsWith("=") ? 1 : 0;
+  return Math.floor((b64.length * 3) / 4) - padding;
+}
+
+const uploadFile = z.object({
+  base64: z
+    .string()
+    .min(1)
+    .refine((s) => approxBase64Bytes(s) <= MAX_UPLOAD_BYTES, "File too large (max 10MB)"),
+  contentType: z.string().min(1),
+});
 
 export const equipmentCreateSchema = z.object({
   name: z.string().trim().min(1, "Name is required"),

--- a/src/lib/validations/equipment.ts
+++ b/src/lib/validations/equipment.ts
@@ -23,6 +23,7 @@ export const equipmentCreateSchema = z.object({
   reminderLeadDays: z.coerce.number().int().min(0).max(365).default(15),
   nextDueDate: dateStr.optional().nullable(),
   notes: z.string().trim().optional().nullable(),
+  image: uploadFile.optional().nullable(),
 });
 
 // Items cannot be moved between outlets, so branchId is not updatable.
@@ -31,6 +32,7 @@ export const equipmentUpdateSchema = equipmentCreateSchema
   .partial()
   .extend({
     status: z.enum(["ACTIVE", "RETIRED"]).optional(),
+    removeImage: z.boolean().optional(),
   });
 
 export const maintenanceRecordCreateSchema = z.object({


### PR DESCRIPTION
Adds a single optional primary photo to each equipment asset (first half of the asset-labeling spec; QR labeling lands separately).

## What's included
- `Equipment.imageUrl` (additive migration).
- `uploadAssetImage` helper → Azure Blob `equipment/<branchId>/asset-images/`; only the URL is stored.
- Add/Edit form: optional image picker with preview + remove.
- Detail page hero + items-list thumbnail (table + mobile card); category-icon placeholder when absent.
- Create stores the image; update replaces/clears it; **archive (RETIRED) deletes it** along with maintenance blobs (archive dialog count includes it).
- `equipment.manage`-gated (HR can't add/edit); outlet scope enforced.

## Blob lifecycle (hardened after review)
- New blob is cleaned up if the create/update DB write fails (matches the records route).
- Old blob is deleted **only after** a successful update, best-effort — so a write failure can't orphan or break the reference.

## Verification
Full suite 240 pass / 1 skip; `tsc` + eslint clean; production build exit 0. Final review: MERGE-READY (the two blob-lifecycle issues it found were fixed).

Spec: `docs/superpowers/specs/2026-06-10-asset-labeling-qr-design.md` (§2A) · Plan: `docs/superpowers/plans/2026-06-10-asset-image.md`

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>