### PR TITLE
feat(uploads): drag-and-drop file uploads everywhere (reusable FileDropzone)

### DIFF
--- a/src/components/branches/branch-document-upload.tsx
+++ b/src/components/branches/branch-document-upload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -31,7 +31,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Upload, Loader2, FileText } from "lucide-react";
+import { FileDropzone } from "@/components/ui/file-dropzone";
+import { Upload, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { DocumentType } from "@/models/models";
 
@@ -58,7 +59,6 @@ export function BranchDocumentUpload({ branchId, documentTypes = [] }: BranchDoc
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<z.infer<typeof documentFormSchema>>({
     resolver: zodResolver(documentFormSchema),
@@ -67,35 +67,6 @@ export function BranchDocumentUpload({ branchId, documentTypes = [] }: BranchDoc
       description: "",
     },
   });
-
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    // Validate file type
-    const allowedTypes = [
-      'application/pdf',
-      'image/jpeg',
-      'image/jpg',
-      'image/png',
-      'image/gif',
-      'application/zip',
-      'application/x-zip-compressed'
-    ];
-
-    if (!allowedTypes.includes(file.type)) {
-      toast.error('Invalid file type. Only PDF, images, and ZIP files are allowed');
-      return;
-    }
-
-    // Validate file size (max 10MB)
-    if (file.size > 10 * 1024 * 1024) {
-      toast.error('File size must be less than 10MB');
-      return;
-    }
-
-    setSelectedFile(file);
-  };
 
   const onSubmit = async (values: z.infer<typeof documentFormSchema>) => {
     if (!selectedFile) {
@@ -135,10 +106,6 @@ export function BranchDocumentUpload({ branchId, documentTypes = [] }: BranchDoc
     } finally {
       setIsLoading(false);
     }
-  };
-
-  const handleButtonClick = () => {
-    fileInputRef.current?.click();
   };
 
   return (
@@ -221,36 +188,17 @@ export function BranchDocumentUpload({ branchId, documentTypes = [] }: BranchDoc
 
             <div>
               <label className="block text-sm font-medium mb-2">File</label>
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full"
-                onClick={handleButtonClick}
-                disabled={isLoading}
-              >
-                {selectedFile ? (
-                  <>
-                    <FileText className="mr-2 h-4 w-4" />
-                    {selectedFile.name}
-                  </>
-                ) : (
-                  <>
-                    <Upload className="mr-2 h-4 w-4" />
-                    Select File
-                  </>
-                )}
-              </Button>
-              <input
-                type="file"
-                ref={fileInputRef}
-                className="hidden"
+              <FileDropzone
+                variant="file"
                 accept=".pdf,.jpg,.jpeg,.png,.gif,.zip"
-                onChange={handleFileChange}
+                maxSizeMB={10}
+                value={selectedFile ? [selectedFile] : []}
+                onFiles={(fs) => setSelectedFile(fs[0] ?? null)}
+                onRemoveFile={() => setSelectedFile(null)}
+                idleText="Drag & drop a file, or click to browse"
+                hint="PDF, image, or ZIP — up to 10MB"
                 disabled={isLoading}
               />
-              <p className="text-xs text-muted-foreground mt-1">
-                Supported: PDF, Images, ZIP. Max size: 10MB
-              </p>
             </div>
 
             <FormField

--- a/src/components/equipment/bulk-import-export.tsx
+++ b/src/components/equipment/bulk-import-export.tsx
@@ -1,7 +1,7 @@
 // src/components/equipment/bulk-import-export.tsx
 "use client";
 
-import { useRef, useState, type ChangeEvent } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Download, Upload } from "lucide-react";
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Card, CardContent } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { FileDropzone } from "@/components/ui/file-dropzone";
 
 interface BulkSummary {
   ok: boolean;
@@ -22,7 +23,6 @@ interface BulkSummary {
 
 export function BulkImportExport() {
   const router = useRouter();
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [exporting, setExporting] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -48,14 +48,6 @@ export function BulkImportExport() {
     } finally {
       setExporting(false);
     }
-  }
-
-  function handlePickFile(e: ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0];
-    e.target.value = ""; // allow re-picking the same file
-    if (!f) return;
-    setPendingFile(f);
-    setShowConfirm(true);
   }
 
   async function handleConfirmUpload() {
@@ -90,11 +82,10 @@ export function BulkImportExport() {
           <Download size={15} className="mr-1.5" />
           {exporting ? "Exporting…" : "Export"}
         </Button>
-        <Button variant="outline" size="sm" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+        <Button variant="outline" size="sm" onClick={() => setShowConfirm(true)} disabled={uploading}>
           <Upload size={15} className="mr-1.5" />
           Import
         </Button>
-        <input ref={fileInputRef} type="file" accept=".xlsx" onChange={handlePickFile} className="hidden" />
       </div>
 
       {summary && (
@@ -133,11 +124,21 @@ export function BulkImportExport() {
               Invalid rows are skipped and reported. This does not delete anything.
             </DialogDescription>
           </DialogHeader>
+          <FileDropzone
+            accept=".xlsx"
+            variant="file"
+            maxSizeMB={10}
+            value={pendingFile ? [pendingFile] : []}
+            onFiles={(fs) => setPendingFile(fs[0] ?? null)}
+            onRemoveFile={() => setPendingFile(null)}
+            idleText="Drag & drop an .xlsx, or click to browse"
+            hint="Excel .xlsx export file"
+          />
           <DialogFooter className="gap-2">
             <Button variant="outline" disabled={uploading} onClick={() => { setShowConfirm(false); setPendingFile(null); }}>
               Cancel
             </Button>
-            <Button disabled={uploading} onClick={handleConfirmUpload}>
+            <Button disabled={uploading || !pendingFile} onClick={handleConfirmUpload}>
               {uploading ? "Importing…" : "Import"}
             </Button>
           </DialogFooter>

--- a/src/components/equipment/bulk-import-export.tsx
+++ b/src/components/equipment/bulk-import-export.tsx
@@ -127,12 +127,12 @@ export function BulkImportExport() {
           <FileDropzone
             accept=".xlsx"
             variant="file"
-            maxSizeMB={10}
+            maxSizeMB={5}
             value={pendingFile ? [pendingFile] : []}
             onFiles={(fs) => setPendingFile(fs[0] ?? null)}
             onRemoveFile={() => setPendingFile(null)}
             idleText="Drag & drop an .xlsx, or click to browse"
-            hint="Excel .xlsx export file"
+            hint="Excel .xlsx export file (max 5MB)"
           />
           <DialogFooter className="gap-2">
             <Button variant="outline" disabled={uploading} onClick={() => { setShowConfirm(false); setPendingFile(null); }}>

--- a/src/components/equipment/equipment-form.tsx
+++ b/src/components/equipment/equipment-form.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { FileDropzone } from "@/components/ui/file-dropzone";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -261,21 +262,19 @@ export function EquipmentForm({
 
           {/* Asset photo */}
           <div className="space-y-2">
-            <Label htmlFor="asset-image">Asset photo (optional)</Label>
-            {existingImageUrl && !imageFile && !removeImage && (
-              <div className="flex items-center gap-3">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={existingImageUrl} alt="Asset" className="h-16 w-16 rounded object-cover" />
-                <Button type="button" variant="ghost" size="sm" onClick={() => setRemoveImage(true)}>Remove</Button>
-              </div>
-            )}
-            <Input
-              id="asset-image"
-              type="file"
+            <Label>Asset photo (optional)</Label>
+            <FileDropzone
+              variant="image"
               accept="image/*"
-              onChange={(e) => { setImageFile(e.target.files?.[0] ?? null); setRemoveImage(false); }}
+              maxSizeMB={10}
+              value={imageFile ? [imageFile] : []}
+              onFiles={(fs) => { setImageFile(fs[0] ?? null); setRemoveImage(false); }}
+              onRemoveFile={() => setImageFile(null)}
+              existingUrl={!imageFile && !removeImage ? existingImageUrl : null}
+              onRemoveExisting={() => setRemoveImage(true)}
+              idleText={<>Drag & drop a photo, or <span className="text-primary">browse</span></>}
+              hint="PNG or JPG, up to 10MB"
             />
-            {imageFile && <p className="text-xs text-muted-foreground">{imageFile.name}</p>}
           </div>
 
           {/* Notes */}

--- a/src/components/equipment/maintenance-record-form.tsx
+++ b/src/components/equipment/maintenance-record-form.tsx
@@ -3,10 +3,10 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { X, UploadCloud, Image as ImageIcon, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { FileDropzone } from "@/components/ui/file-dropzone";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -47,10 +47,6 @@ export function MaintenanceRecordForm({ equipmentId }: Props) {
   const [photos, setPhotos] = useState<File[]>([]);
 
   const [saving, setSaving] = useState(false);
-
-  function removePhoto(index: number) {
-    setPhotos((prev) => prev.filter((_, i) => i !== index));
-  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -242,113 +238,32 @@ export function MaintenanceRecordForm({ equipmentId }: Props) {
           {/* Bill / invoice upload */}
           <div className="flex flex-col gap-1.5">
             <Label>Bill / invoice</Label>
-            {bill ? (
-              <div className="flex items-center gap-3 rounded-lg border bg-muted/40 px-3 py-2.5">
-                <div className="flex h-10 w-10 flex-none items-center justify-center rounded-lg border bg-card text-muted-foreground">
-                  <FileText size={18} />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="truncate text-[13px] font-semibold">{bill.name}</p>
-                  <p className="text-[11.5px] text-muted-foreground">
-                    {(bill.size / 1024).toFixed(0)} KB · uploaded
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setBill(null)}
-                  className="flex h-7 w-7 flex-none items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-                  aria-label="Remove bill"
-                >
-                  <X size={14} />
-                </button>
-              </div>
-            ) : (
-              <label className="flex cursor-pointer items-center gap-3.5 rounded-lg border border-dashed bg-muted/20 px-4 py-4 transition-colors hover:bg-muted/40">
-                <div className="flex h-10 w-10 flex-none items-center justify-center rounded-lg border bg-card text-muted-foreground">
-                  <UploadCloud size={18} />
-                </div>
-                <div>
-                  <p className="text-[13px] font-semibold">
-                    Drop bill / invoice, or{" "}
-                    <span className="text-primary">browse</span>
-                  </p>
-                  <p className="text-[11.5px] text-muted-foreground">
-                    Single PDF or image · max 10 MB
-                  </p>
-                </div>
-                <input
-                  type="file"
-                  accept="application/pdf,image/*"
-                  className="sr-only"
-                  onChange={(e) => {
-                    const f = e.target.files?.[0] ?? null;
-                    setBill(f);
-                    e.target.value = "";
-                  }}
-                />
-              </label>
-            )}
+            <FileDropzone
+              variant="auto"
+              accept="application/pdf,image/*"
+              maxSizeMB={10}
+              value={bill ? [bill] : []}
+              onFiles={(fs) => setBill(fs[0] ?? null)}
+              onRemoveFile={() => setBill(null)}
+              idleText={<>Drop bill / invoice, or <span className="text-primary">browse</span></>}
+              hint="PDF or image, up to 10MB"
+            />
           </div>
 
           {/* Service photos upload */}
           <div className="flex flex-col gap-1.5">
             <Label>Service photos</Label>
-
-            {/* Photo thumbnails */}
-            {photos.length > 0 && (
-              <div className="mb-2 flex flex-wrap gap-2">
-                {photos.map((photo, i) => (
-                  <div key={i} className="relative">
-                    <div className="flex h-[64px] w-[64px] items-center justify-center rounded-lg border bg-muted text-[11px] text-muted-foreground overflow-hidden">
-                      <span className="truncate px-1 text-center leading-tight">
-                        {photo.name.length > 10
-                          ? photo.name.slice(0, 9) + "…"
-                          : photo.name}
-                      </span>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => removePhoto(i)}
-                      className="absolute -right-1.5 -top-1.5 flex h-[18px] w-[18px] items-center justify-center rounded-full bg-foreground/70 text-background transition-colors hover:bg-foreground"
-                      aria-label={`Remove photo ${photo.name}`}
-                    >
-                      <X size={11} strokeWidth={2.5} />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            <label className="flex cursor-pointer items-center gap-3.5 rounded-lg border border-dashed bg-muted/20 px-4 py-4 transition-colors hover:bg-muted/40">
-              <div className="flex h-10 w-10 flex-none items-center justify-center rounded-lg border bg-card text-muted-foreground">
-                <ImageIcon size={18} />
-              </div>
-              <div>
-                <p className="text-[13px] font-semibold">
-                  Add service photos, or{" "}
-                  <span className="text-primary">browse</span>
-                </p>
-                <p className="text-[11.5px] text-muted-foreground">
-                  Multiple JPG/PNG · before &amp; after
-                  {photos.length > 0 && (
-                    <span className="ml-1 font-medium text-foreground">
-                      ({photos.length} selected)
-                    </span>
-                  )}
-                </p>
-              </div>
-              <input
-                type="file"
-                accept="image/*"
-                multiple
-                className="sr-only"
-                onChange={(e) => {
-                  const files = Array.from(e.target.files ?? []);
-                  if (files.length) setPhotos((prev) => [...prev, ...files]);
-                  e.target.value = "";
-                }}
-              />
-            </label>
+            <FileDropzone
+              variant="image"
+              accept="image/*"
+              multiple
+              maxSizeMB={10}
+              value={photos}
+              onFiles={(fs) => setPhotos((p) => [...p, ...fs])}
+              onRemoveFile={(i) => setPhotos((p) => p.filter((_, idx) => idx !== i))}
+              idleText={<>Add service photos, or <span className="text-primary">browse</span></>}
+              hint="Add one or more photos"
+            />
           </div>
 
           {/* Footer actions */}

--- a/src/components/salary/bulk-import-export.tsx
+++ b/src/components/salary/bulk-import-export.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useEffect, useState, useRef, type ChangeEvent } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
+import { FileDropzone } from '@/components/ui/file-dropzone'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -81,7 +82,6 @@ export function BulkImportExport({
   const [summary, setSummary] = useState<BulkImportSummary | null>(null)
   const [pendingFile, setPendingFile] = useState<File | null>(null)
   const [showConfirm, setShowConfirm] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -162,14 +162,6 @@ export function BulkImportExport({
     }
   }
 
-  function handlePickFile(e: ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0]
-    if (!f) return
-    setPendingFile(f)
-    setShowConfirm(true)
-    e.target.value = ''
-  }
-
   async function handleConfirmUpload() {
     if (!pendingFile) return
     setShowConfirm(false)
@@ -198,14 +190,6 @@ export function BulkImportExport({
 
   return (
     <>
-      <input
-        type="file"
-        accept=".xlsx"
-        ref={fileInputRef}
-        onChange={handlePickFile}
-        className="hidden"
-      />
-
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="outline" className="gap-2">
@@ -258,7 +242,7 @@ export function BulkImportExport({
             disabled={isUploading}
             onSelect={(event) => {
               event.preventDefault()
-              fileInputRef.current?.click()
+              setShowConfirm(true)
             }}
           >
             <Upload className="h-4 w-4" />
@@ -318,18 +302,29 @@ export function BulkImportExport({
         </Card>
       )}
 
-      <AlertDialog open={showConfirm} onOpenChange={setShowConfirm}>
+      <AlertDialog open={showConfirm} onOpenChange={(open) => { setShowConfirm(open); if (!open) setPendingFile(null) }}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Apply bulk salary changes?</AlertDialogTitle>
             <AlertDialogDescription>
-              Upload <span className="font-medium">{pendingFile?.name}</span> and apply
-              changes for {monthLabels[month - 1]} {year}? Paid salaries will be skipped.
+              {pendingFile
+                ? <>Upload <span className="font-medium">{pendingFile.name}</span> and apply changes for {monthLabels[month - 1]} {year}? Paid salaries will be skipped.</>
+                : <>Choose an .xlsx file to import salaries for {monthLabels[month - 1]} {year}. Paid salaries will be skipped.</>
+              }
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <FileDropzone
+            accept=".xlsx"
+            variant="file"
+            value={pendingFile ? [pendingFile] : []}
+            onFiles={(fs) => setPendingFile(fs[0] ?? null)}
+            onRemoveFile={() => setPendingFile(null)}
+            idleText="Drag & drop an .xlsx, or click to browse"
+            hint="Excel .xlsx file"
+          />
           <AlertDialogFooter>
             <AlertDialogCancel onClick={() => setPendingFile(null)}>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmUpload}>Upload</AlertDialogAction>
+            <AlertDialogAction onClick={handleConfirmUpload} disabled={!pendingFile}>Upload</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/ui/__tests__/file-dropzone.test.ts
+++ b/src/components/ui/__tests__/file-dropzone.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { fileMatchesAccept } from "@/components/ui/file-dropzone";
+
+function f(name: string, type: string): File {
+  return new File([new Uint8Array([1])], name, { type });
+}
+
+describe("fileMatchesAccept", () => {
+  it("accepts everything when accept is empty/undefined", () => {
+    expect(fileMatchesAccept(f("a.bin", "application/octet-stream"))).toBe(true);
+    expect(fileMatchesAccept(f("a.bin", "application/octet-stream"), "")).toBe(true);
+  });
+  it("matches a mime glob (image/*)", () => {
+    expect(fileMatchesAccept(f("p.png", "image/png"), "image/*")).toBe(true);
+    expect(fileMatchesAccept(f("d.pdf", "application/pdf"), "image/*")).toBe(false);
+  });
+  it("matches by extension (.xlsx) regardless of mime", () => {
+    expect(fileMatchesAccept(f("data.xlsx", ""), ".xlsx")).toBe(true);
+    expect(fileMatchesAccept(f("data.XLSX", ""), ".xlsx")).toBe(true); // case-insensitive
+    expect(fileMatchesAccept(f("data.csv", "text/csv"), ".xlsx")).toBe(false);
+  });
+  it("matches an exact mime (application/pdf)", () => {
+    expect(fileMatchesAccept(f("d.pdf", "application/pdf"), "application/pdf")).toBe(true);
+    expect(fileMatchesAccept(f("p.png", "image/png"), "application/pdf")).toBe(false);
+  });
+  it("matches any token in a comma list", () => {
+    const accept = "application/pdf,image/*";
+    expect(fileMatchesAccept(f("d.pdf", "application/pdf"), accept)).toBe(true);
+    expect(fileMatchesAccept(f("p.jpg", "image/jpeg"), accept)).toBe(true);
+    expect(fileMatchesAccept(f("s.xlsx", ""), accept)).toBe(false);
+  });
+});

--- a/src/components/ui/file-dropzone.tsx
+++ b/src/components/ui/file-dropzone.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import * as React from "react";
+import { UploadCloud, X, FileText } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+export interface FileDropzoneProps {
+  /** Called with the validated files chosen (drop or browse). For single mode, the array has 0–1 items. */
+  onFiles: (files: File[]) => void;
+  /** Accept filter, e.g. "image/*", ".xlsx", "application/pdf,image/*". */
+  accept?: string;
+  /** Allow selecting more than one file. Default false. */
+  multiple?: boolean;
+  /** Per-file size cap in MB. Default 10. */
+  maxSizeMB?: number;
+  /** Currently selected file(s) to preview. */
+  value?: File[] | null;
+  /** Remove a picked file by index. */
+  onRemoveFile?: (index: number) => void;
+  /** Edit mode: URL of an already-saved file to show as the current value. */
+  existingUrl?: string | null;
+  /** Called when the user clears the existing (saved) file. */
+  onRemoveExisting?: () => void;
+  /** "image" shows thumbnails, "file" shows name chips, "auto" decides per file. Default "auto". */
+  variant?: "image" | "file" | "auto";
+  disabled?: boolean;
+  /** Primary call-to-action line. */
+  idleText?: string;
+  /** Secondary hint line (e.g. "PNG/JPG up to 5MB"). */
+  hint?: string;
+  className?: string;
+  id?: string;
+}
+
+/** True if `file` satisfies the `accept` string (mime globs like image/*, exact mimes, or .ext). */
+export function fileMatchesAccept(file: File, accept?: string): boolean {
+  if (!accept || !accept.trim()) return true;
+  const tokens = accept.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
+  const name = file.name.toLowerCase();
+  const type = (file.type || "").toLowerCase();
+  return tokens.some((tok) => {
+    if (tok.startsWith(".")) return name.endsWith(tok);
+    if (tok.endsWith("/*")) return type.startsWith(tok.slice(0, -1)); // e.g. "image/"
+    return type === tok;
+  });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function isImageFile(file: File): boolean {
+  return (file.type || "").startsWith("image/");
+}
+
+function isImageUrl(url: string): boolean {
+  return /\.(png|jpe?g|gif|webp|avif|bmp|svg)(\?|#|$)/i.test(url);
+}
+
+export function FileDropzone({
+  onFiles,
+  accept,
+  multiple = false,
+  maxSizeMB = 10,
+  value,
+  onRemoveFile,
+  existingUrl,
+  onRemoveExisting,
+  variant = "auto",
+  disabled = false,
+  idleText,
+  hint,
+  className,
+  id,
+}: FileDropzoneProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [dragActive, setDragActive] = React.useState(false);
+
+  const files = value ?? [];
+
+  // Object URLs for image previews — created in a memo and revoked on change/unmount.
+  const previews = React.useMemo(
+    () =>
+      files.map((f) => {
+        const image = isImageFile(f);
+        return { file: f, image, url: image ? URL.createObjectURL(f) : null };
+      }),
+    [files]
+  );
+  React.useEffect(
+    () => () => previews.forEach((p) => p.url && URL.revokeObjectURL(p.url)),
+    [previews]
+  );
+
+  const validate = React.useCallback(
+    (incoming: File[]): File[] => {
+      const max = maxSizeMB * 1024 * 1024;
+      const ok: File[] = [];
+      for (const f of incoming) {
+        if (!fileMatchesAccept(f, accept)) {
+          toast.error(`"${f.name}" is not an accepted file type`);
+          continue;
+        }
+        if (f.size > max) {
+          toast.error(`"${f.name}" is larger than ${maxSizeMB}MB`);
+          continue;
+        }
+        ok.push(f);
+      }
+      return multiple ? ok : ok.slice(0, 1);
+    },
+    [accept, maxSizeMB, multiple]
+  );
+
+  const handleIncoming = React.useCallback(
+    (list: FileList | null) => {
+      if (!list || list.length === 0) return;
+      const valid = validate(Array.from(list));
+      if (valid.length > 0) onFiles(valid);
+    },
+    [validate, onFiles]
+  );
+
+  const openPicker = () => {
+    if (!disabled) inputRef.current?.click();
+  };
+
+  const showExisting = !!existingUrl && files.length === 0;
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      {/* Drop area */}
+      <div
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-disabled={disabled}
+        onClick={openPicker}
+        onKeyDown={(e) => {
+          if (disabled) return;
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            openPicker();
+          }
+        }}
+        onDragOver={(e) => {
+          if (disabled) return;
+          e.preventDefault();
+          setDragActive(true);
+        }}
+        onDragLeave={(e) => {
+          e.preventDefault();
+          setDragActive(false);
+        }}
+        onDrop={(e) => {
+          if (disabled) return;
+          e.preventDefault();
+          setDragActive(false);
+          handleIncoming(e.dataTransfer.files);
+        }}
+        className={cn(
+          "flex flex-col items-center justify-center gap-1.5 rounded-lg border border-dashed px-4 py-6 text-center transition-colors",
+          disabled
+            ? "cursor-not-allowed opacity-60"
+            : "cursor-pointer hover:border-primary/50 hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          dragActive ? "border-primary bg-primary/5" : "border-border"
+        )}
+      >
+        <UploadCloud className="h-6 w-6 text-muted-foreground" />
+        <div className="text-[13px] font-medium text-foreground">
+          {idleText ?? (
+            <>
+              <span className="text-primary">Click to upload</span> or drag & drop
+            </>
+          )}
+        </div>
+        {hint && <div className="text-[11.5px] text-muted-foreground">{hint}</div>}
+      </div>
+
+      <input
+        ref={inputRef}
+        id={id}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        disabled={disabled}
+        className="hidden"
+        onChange={(e) => {
+          handleIncoming(e.target.files);
+          // reset so picking the same file again re-fires onChange
+          e.target.value = "";
+        }}
+      />
+
+      {/* Existing (saved) value */}
+      {showExisting && (
+        <div className="flex items-center gap-3 rounded-md border bg-muted/30 p-2">
+          {isImageUrl(existingUrl!) ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={existingUrl!} alt="Current file" className="h-12 w-12 flex-none rounded object-cover" />
+          ) : (
+            <FileText className="h-5 w-5 flex-none text-muted-foreground" />
+          )}
+          <a
+            href={existingUrl!}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="min-w-0 flex-1 truncate text-[13px] text-muted-foreground hover:underline"
+          >
+            Current file
+          </a>
+          {onRemoveExisting && (
+            <button
+              type="button"
+              onClick={onRemoveExisting}
+              disabled={disabled}
+              aria-label="Remove current file"
+              className="flex-none rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Picked files */}
+      {previews.length > 0 && (
+        <div className={cn(variant === "image" ? "flex flex-wrap gap-2" : "space-y-2")}>
+          {previews.map((p, i) => {
+            const asImage = variant === "image" || (variant === "auto" && p.image);
+            if (asImage && p.url) {
+              return (
+                <div key={i} className="relative">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={p.url} alt={p.file.name} className="h-16 w-16 rounded border object-cover" />
+                  {onRemoveFile && (
+                    <button
+                      type="button"
+                      onClick={() => onRemoveFile(i)}
+                      disabled={disabled}
+                      aria-label={`Remove ${p.file.name}`}
+                      className="absolute -right-1.5 -top-1.5 rounded-full bg-background p-0.5 text-muted-foreground shadow ring-1 ring-border hover:text-foreground"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </div>
+              );
+            }
+            return (
+              <div key={i} className="flex items-center gap-2.5 rounded-md border bg-muted/30 p-2">
+                <FileText className="h-5 w-5 flex-none text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium text-foreground">{p.file.name}</div>
+                  <div className="text-[11px] text-muted-foreground">{formatBytes(p.file.size)}</div>
+                </div>
+                {onRemoveFile && (
+                  <button
+                    type="button"
+                    onClick={() => onRemoveFile(i)}
+                    disabled={disabled}
+                    aria-label={`Remove ${p.file.name}`}
+                    className="flex-none rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/file-dropzone.tsx
+++ b/src/components/ui/file-dropzone.tsx
@@ -78,22 +78,44 @@ export function FileDropzone({
 }: FileDropzoneProps) {
   const inputRef = React.useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = React.useState(false);
+  const dragDepthRef = React.useRef(0);
 
   const files = React.useMemo(() => value ?? [], [value]);
 
-  // Object URLs for image previews — created in a memo and revoked on change/unmount.
-  const previews = React.useMemo(
-    () =>
-      files.map((f) => {
-        const image = isImageFile(f);
-        return { file: f, image, url: image ? URL.createObjectURL(f) : null };
-      }),
-    [files]
-  );
-  React.useEffect(
-    () => () => previews.forEach((p) => p.url && URL.revokeObjectURL(p.url)),
-    [previews]
-  );
+  // Object URLs for image previews, cached per File so the same file keeps its URL
+  // across renders. Call sites often pass a fresh array each render (e.g.
+  // `value={f ? [f] : []}`); keying the cache on the File object (not the array
+  // reference) avoids churning create/revoke — and the flicker — on every keystroke.
+  const urlCacheRef = React.useRef<Map<File, string>>(new Map());
+  const previews = files.map((f) => {
+    const image = isImageFile(f);
+    if (!image) return { file: f, image, url: null as string | null };
+    let url = urlCacheRef.current.get(f);
+    if (!url) {
+      url = URL.createObjectURL(f);
+      urlCacheRef.current.set(f, url);
+    }
+    return { file: f, image, url };
+  });
+  // Revoke URLs for files no longer present.
+  React.useEffect(() => {
+    const cache = urlCacheRef.current;
+    const present = new Set(files);
+    for (const [f, url] of cache) {
+      if (!present.has(f)) {
+        URL.revokeObjectURL(url);
+        cache.delete(f);
+      }
+    }
+  }, [files]);
+  // Revoke everything on unmount.
+  React.useEffect(() => {
+    const cache = urlCacheRef.current;
+    return () => {
+      for (const url of cache.values()) URL.revokeObjectURL(url);
+      cache.clear();
+    };
+  }, []);
 
   const validate = React.useCallback(
     (incoming: File[]): File[] => {
@@ -145,18 +167,27 @@ export function FileDropzone({
             openPicker();
           }
         }}
-        onDragOver={(e) => {
+        onDragEnter={(e) => {
           if (disabled) return;
           e.preventDefault();
+          dragDepthRef.current += 1;
           setDragActive(true);
+        }}
+        onDragOver={(e) => {
+          if (disabled) return;
+          e.preventDefault(); // required so the drop event fires
         }}
         onDragLeave={(e) => {
           e.preventDefault();
-          setDragActive(false);
+          // Only deactivate when the cursor truly leaves the dropzone, not when it
+          // moves over a child element (which also fires dragleave).
+          dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+          if (dragDepthRef.current === 0) setDragActive(false);
         }}
         onDrop={(e) => {
           if (disabled) return;
           e.preventDefault();
+          dragDepthRef.current = 0;
           setDragActive(false);
           handleIncoming(e.dataTransfer.files);
         }}

--- a/src/components/ui/file-dropzone.tsx
+++ b/src/components/ui/file-dropzone.tsx
@@ -26,7 +26,7 @@ export interface FileDropzoneProps {
   variant?: "image" | "file" | "auto";
   disabled?: boolean;
   /** Primary call-to-action line. */
-  idleText?: string;
+  idleText?: React.ReactNode;
   /** Secondary hint line (e.g. "PNG/JPG up to 5MB"). */
   hint?: string;
   className?: string;
@@ -79,7 +79,7 @@ export function FileDropzone({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const [dragActive, setDragActive] = React.useState(false);
 
-  const files = value ?? [];
+  const files = React.useMemo(() => value ?? [], [value]);
 
   // Object URLs for image previews — created in a memo and revoked on change/unmount.
   const previews = React.useMemo(

--- a/src/components/users/deduction-settings-page.tsx
+++ b/src/components/users/deduction-settings-page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from 'react'
 import * as XLSX from 'xlsx'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
-import { Download, Upload, AlertCircle } from 'lucide-react'
+import { FileDropzone } from '@/components/ui/file-dropzone'
+import { Download, AlertCircle } from 'lucide-react'
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '@/components/ui/table'
@@ -35,6 +36,7 @@ export function DeductionSettingsPage() {
   const [uploading, setUploading] = useState(false)
   const [importErrors, setImportErrors] = useState<ImportError[]>([])
   const [showErrorDialog, setShowErrorDialog] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
 
   async function load() {
     setLoading(true)
@@ -73,13 +75,11 @@ export function DeductionSettingsPage() {
     XLSX.writeFile(wb, `deduction-settings-${new Date().toISOString().slice(0, 10)}.xlsx`)
   }
 
-  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]
-    if (!file) return
+  async function handleUpload(uploadFile: File) {
     setUploading(true)
     setImportErrors([])
     try {
-      const buf = await file.arrayBuffer()
+      const buf = await uploadFile.arrayBuffer()
       const wb = XLSX.read(buf)
       const sheet = wb.Sheets[wb.SheetNames[0]]
       const parsed = XLSX.utils.sheet_to_json(sheet) as Array<Record<string, unknown>>
@@ -95,13 +95,13 @@ export function DeductionSettingsPage() {
         return
       }
       toast.success(`Updated ${result.updated} users`)
+      setFile(null)
       await load()
     } catch (err) {
       toast.error('Upload failed')
       console.error(err)
     } finally {
       setUploading(false)
-      e.target.value = ''
     }
   }
 
@@ -115,22 +115,29 @@ export function DeductionSettingsPage() {
             PF is not yet active.
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex items-end gap-2">
           <Button onClick={handleDownload} variant="outline">
             <Download className="w-4 h-4 mr-2" />Download Excel
           </Button>
-          <label className="inline-flex">
-            <input
-              type="file"
+          <div className="flex flex-col gap-2">
+            <FileDropzone
               accept=".xlsx,.xls"
-              className="hidden"
-              onChange={handleUpload}
+              variant="file"
+              value={file ? [file] : []}
+              onFiles={(fs) => setFile(fs[0] ?? null)}
+              onRemoveFile={() => setFile(null)}
+              idleText="Drag & drop an Excel file, or click to browse"
+              hint=".xlsx or .xls"
               disabled={uploading}
             />
-            <Button asChild disabled={uploading}>
-              <span><Upload className="w-4 h-4 mr-2" />{uploading ? 'Uploading…' : 'Upload Excel'}</span>
+            <Button
+              onClick={() => { if (file) handleUpload(file) }}
+              disabled={!file || uploading}
+              variant="outline"
+            >
+              {uploading ? 'Uploading…' : 'Import Excel'}
             </Button>
-          </label>
+          </div>
         </div>
       </div>
 

--- a/src/components/users/user-data-import-export.tsx
+++ b/src/components/users/user-data-import-export.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { FileDropzone } from "@/components/ui/file-dropzone";
 import {
   Dialog,
   DialogContent,
@@ -49,6 +49,7 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
   const [isUploading, setIsUploading] = useState(false);
   const [showUploadDialog, setShowUploadDialog] = useState(false);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [file, setFile] = useState<File | null>(null);
 
   const handleDownload = async () => {
     try {
@@ -183,12 +184,11 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
     return errors;
   };
 
-  const handleUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleUpload = async () => {
+    if (!file) return;
     try {
       setIsUploading(true);
       setValidationErrors([]);
-      const file = event.target.files?.[0];
-      if (!file) return;
 
       const reader = new FileReader();
       reader.onload = async (e) => {
@@ -274,6 +274,7 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
 
           toast.success('Users imported successfully');
           setShowUploadDialog(false);
+          setFile(null);
           onImportComplete?.();
         } catch (error) {
           console.error('Import failed:', error);
@@ -297,7 +298,7 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
         Upload Users
       </Button>
 
-      <Dialog open={showUploadDialog} onOpenChange={setShowUploadDialog}>
+      <Dialog open={showUploadDialog} onOpenChange={(open) => { setShowUploadDialog(open); if (!open) { setFile(null); setValidationErrors([]); } }}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Upload Users Data</DialogTitle>
@@ -321,16 +322,24 @@ export function UserDataImportExport({ onImportComplete }: UserDataImportExportP
               </Alert>
             )}
 
-            <div className="grid w-full max-w-sm items-center gap-1.5">
-              <Input
-                type="file"
+            <div className="space-y-3">
+              <FileDropzone
                 accept=".xlsx,.xls"
-                onChange={handleUpload}
+                variant="file"
+                value={file ? [file] : []}
+                onFiles={(fs) => setFile(fs[0] ?? null)}
+                onRemoveFile={() => setFile(null)}
+                idleText="Drag & drop an Excel file, or click to browse"
+                hint=".xlsx or .xls"
                 disabled={isUploading}
               />
-              <p className="text-sm text-muted-foreground">
-                Only Excel files (.xlsx, .xls) are supported
-              </p>
+              <Button
+                onClick={handleUpload}
+                disabled={!file || isUploading}
+                className="w-full"
+              >
+                {isUploading ? 'Uploading...' : 'Upload'}
+              </Button>
             </div>
           </div>
         </DialogContent>

--- a/src/components/users/user-document-upload.tsx
+++ b/src/components/users/user-document-upload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -30,7 +30,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Upload, Loader2, FileText } from "lucide-react";
+import { FileDropzone } from "@/components/ui/file-dropzone";
+import { Upload, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { DocumentType } from "@/models/models";
 
@@ -50,7 +51,6 @@ export function UserDocumentUpload({ userId, documentTypes = [] }: UserDocumentU
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<z.infer<typeof documentFormSchema>>({
     resolver: zodResolver(documentFormSchema),
@@ -59,33 +59,6 @@ export function UserDocumentUpload({ userId, documentTypes = [] }: UserDocumentU
       description: "",
     },
   });
-
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    const allowedTypes = [
-      'application/pdf',
-      'image/jpeg',
-      'image/jpg',
-      'image/png',
-      'image/gif',
-      'application/zip',
-      'application/x-zip-compressed'
-    ];
-
-    if (!allowedTypes.includes(file.type)) {
-      toast.error('Invalid file type. Only PDF, images, and ZIP files are allowed');
-      return;
-    }
-
-    if (file.size > 10 * 1024 * 1024) {
-      toast.error('File size must be less than 10MB');
-      return;
-    }
-
-    setSelectedFile(file);
-  };
 
   const onSubmit = async (values: z.infer<typeof documentFormSchema>) => {
     if (!selectedFile) {
@@ -123,10 +96,6 @@ export function UserDocumentUpload({ userId, documentTypes = [] }: UserDocumentU
     } finally {
       setIsLoading(false);
     }
-  };
-
-  const handleButtonClick = () => {
-    fileInputRef.current?.click();
   };
 
   return (
@@ -204,36 +173,17 @@ export function UserDocumentUpload({ userId, documentTypes = [] }: UserDocumentU
 
             <div>
               <label className="block text-sm font-medium mb-2">File</label>
-              <Button
-                type="button"
-                variant="outline"
-                className="w-full"
-                onClick={handleButtonClick}
-                disabled={isLoading}
-              >
-                {selectedFile ? (
-                  <>
-                    <FileText className="mr-2 h-4 w-4" />
-                    {selectedFile.name}
-                  </>
-                ) : (
-                  <>
-                    <Upload className="mr-2 h-4 w-4" />
-                    Select File
-                  </>
-                )}
-              </Button>
-              <input
-                type="file"
-                ref={fileInputRef}
-                className="hidden"
+              <FileDropzone
+                variant="file"
                 accept=".pdf,.jpg,.jpeg,.png,.gif,.zip"
-                onChange={handleFileChange}
+                maxSizeMB={10}
+                value={selectedFile ? [selectedFile] : []}
+                onFiles={(fs) => setSelectedFile(fs[0] ?? null)}
+                onRemoveFile={() => setSelectedFile(null)}
+                idleText="Drag & drop a file, or click to browse"
+                hint="PDF, image, or ZIP — up to 10MB"
                 disabled={isLoading}
               />
-              <p className="text-xs text-muted-foreground mt-1">
-                Supported: PDF, Images, ZIP. Max size: 10MB
-              </p>
             </div>
 
             <div className="flex gap-2 pt-4">

--- a/src/components/users/user-image-upload.tsx
+++ b/src/components/users/user-image-upload.tsx
@@ -21,12 +21,10 @@ export function UserImageUpload({userId, currentImage, onImageUpdate, userName}:
   const [isUploading, setIsUploading] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(currentImage || null);
   const [isViewerOpen, setIsViewerOpen] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
+  const processFile = async (file: File) => {
     // Validate file size (max 5MB)
     if (file.size > 5 * 1024 * 1024) {
       toast.error('File size must be less than 5MB');
@@ -76,6 +74,11 @@ export function UserImageUpload({userId, currentImage, onImageUpdate, userName}:
     }
   };
 
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) processFile(file);
+  };
+
   const handleButtonClick = () => {
     fileInputRef.current?.click();
   };
@@ -86,7 +89,12 @@ export function UserImageUpload({userId, currentImage, onImageUpdate, userName}:
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <div className="relative">
+      <div
+        className={`relative rounded-full transition-all duration-150 ${dragActive ? 'ring-2 ring-primary ring-offset-2' : ''}`}
+        onDragOver={(e) => { e.preventDefault(); setDragActive(true); }}
+        onDragLeave={(e) => { e.preventDefault(); setDragActive(false); }}
+        onDrop={(e) => { e.preventDefault(); setDragActive(false); const f = e.dataTransfer.files?.[0]; if (f) processFile(f); }}
+      >
         <button
           type="button"
           onClick={handleAvatarClick}
@@ -101,6 +109,11 @@ export function UserImageUpload({userId, currentImage, onImageUpdate, userName}:
             </AvatarFallback>
           </Avatar>
         </button>
+        {dragActive && (
+          <div className="absolute inset-0 flex items-center justify-center rounded-full bg-primary/20 pointer-events-none">
+            <span className="text-xs font-medium text-primary">Drop</span>
+          </div>
+        )}
         <Button
           size="icon"
           variant="secondary"
@@ -124,7 +137,7 @@ export function UserImageUpload({userId, currentImage, onImageUpdate, userName}:
         disabled={isUploading}
       />
       <p className="text-sm text-muted-foreground">
-        Supported formats: JPG, PNG, GIF. Max size: 5MB
+        Click the camera or drag a photo here · JPG/PNG/GIF, max 5MB
       </p>
 
       <Dialog open={isViewerOpen} onOpenChange={setIsViewerOpen}>

--- a/src/components/users/warning-form.tsx
+++ b/src/components/users/warning-form.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { FileDropzone } from "@/components/ui/file-dropzone";
 import {
   Select,
   SelectContent,
@@ -42,7 +42,7 @@ export function WarningForm({ userId, userName, onSuccess, trigger, open: extern
   const [loadingTypes, setLoadingTypes] = useState(false);
   const [warningTypes, setWarningTypes] = useState<WarningType[]>([]);
   const [selectedType, setSelectedType] = useState<string>("");
-  const fileRef = useRef<HTMLInputElement>(null);
+  const [photo, setPhoto] = useState<File | null>(null);
 
   // Use external control if provided, otherwise use internal state
   const isControlled = externalOpen !== undefined;
@@ -80,7 +80,6 @@ export function WarningForm({ userId, userName, onSuccess, trigger, open: extern
     try {
       const formData = new FormData(formEl);
       const reason = (formData.get("reason") as string | null)?.trim();
-      const file = fileRef.current?.files?.[0];
 
       if (!selectedType) {
         toast.error("Warning type is required");
@@ -91,16 +90,8 @@ export function WarningForm({ userId, userName, onSuccess, trigger, open: extern
       payload.append("warningTypeId", selectedType);
       payload.append("reason", reason || "");
 
-      if (file) {
-        if (file.size > 5 * 1024 * 1024) {
-          toast.error("Photo size must be less than 5MB");
-          return;
-        }
-        if (!file.type.startsWith("image/")) {
-          toast.error("Photo must be an image");
-          return;
-        }
-        payload.append("file", file);
+      if (photo) {
+        payload.append("file", photo);
       }
 
       const response = await fetch(`/api/users/${userId}/warnings`, {
@@ -115,7 +106,7 @@ export function WarningForm({ userId, userName, onSuccess, trigger, open: extern
 
       toast.success("Warning registered");
       formEl.reset();
-      if (fileRef.current) fileRef.current.value = "";
+      setPhoto(null);
       setSelectedType("");
       setOpen(false);
       onSuccess?.();
@@ -170,9 +161,17 @@ export function WarningForm({ userId, userName, onSuccess, trigger, open: extern
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="file">Photo (optional)</Label>
-            <Input id="file" name="file" type="file" accept="image/*" ref={fileRef} />
-            <p className="text-xs text-muted-foreground">Supported formats: JPG/PNG/GIF. Max size: 5MB</p>
+            <Label>Photo (optional)</Label>
+            <FileDropzone
+              variant="image"
+              accept="image/*"
+              maxSizeMB={5}
+              value={photo ? [photo] : []}
+              onFiles={(fs) => setPhoto(fs[0] ?? null)}
+              onRemoveFile={() => setPhoto(null)}
+              idleText="Drag & drop a photo, or click to browse"
+              hint="Image up to 5MB"
+            />
           </div>
           <Button type="submit" disabled={loading}>
             {loading ? "Saving..." : "Save Warning"}


### PR DESCRIPTION
Adds a reusable drag-and-drop uploader and rolls it out to **all 11 file-upload sites**.

## New component
`src/components/ui/file-dropzone.tsx` — `FileDropzone`: a validated drag-&-drop + click uploader with image-thumbnail or file-chip previews, single/multiple, existing-value display + remove, keyboard-accessible. Validates `accept` + `maxSizeMB` (toasts on reject). Unit-tested accept-matching (mime globs, exact mimes, extensions).

## Retrofitted (submit/parse logic unchanged — only the file-picking UI changed)
- **Equipment:** asset photo, maintenance bill + photos (multiple), equipment XLSX bulk import.
- **Bulk imports (XLSX):** salary, user-data, deduction settings, equipment.
- **Documents:** user documents, branch documents.
- **Photos:** warning incident photo.
- **Avatar:** the user image uploader now also accepts a photo **dropped onto the avatar** (camera button kept; not a dashed box).

## Behavior notes
- The two client-parsed XLSX imports (user-data, deduction) changed from **upload-on-pick** to **pick-then-click-Import** (you can review/remove before committing) — same parse + POST.
- Client size caps now match each server limit (images 5MB, docs 10MB, equipment XLSX 5MB).

## Verification
Full `tsc` clean, eslint clean, dropzone test 5/5, **production build exit 0**. Independent review: MERGE-READY (the one finding — a 10MB vs server-5MB mismatch on equipment bulk import — is fixed).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>