### PR TITLE
feat(maintenance): click the asset photo to view it full-size

### DIFF
--- a/src/app/(auth)/equipment/[id]/page.tsx
+++ b/src/app/(auth)/equipment/[id]/page.tsx
@@ -10,6 +10,7 @@ import { assetTag } from "@/lib/asset-tag";
 import { CATEGORY_META, formatINR, formatDateIST } from "@/lib/equipment-display";
 import { CategoryPill, StatusBadge, EquipmentEmptyState } from "@/components/equipment/ui";
 import { CategoryIcon } from "@/components/equipment/category-icon";
+import { AssetImageViewer } from "@/components/equipment/asset-image-viewer";
 import { DetailActions } from "@/components/equipment/detail-actions";
 import { MaintenanceHistory } from "@/components/equipment/maintenance-history";
 import type { HistoryRecord } from "@/components/equipment/maintenance-history";
@@ -158,13 +159,12 @@ export default async function EquipmentDetailPage({ params, searchParams }: Prop
       <div className="rounded-xl border bg-card p-4 md:p-[22px] shadow-sm">
         {/* Top row: icon + name/badges + actions */}
         <div className="flex items-start gap-3 md:gap-4">
-          {/* Category icon tile or asset photo */}
+          {/* Category icon tile or asset photo (click to view full size) */}
           {item.imageUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            <AssetImageViewer
               src={item.imageUrl}
               alt={item.name}
-              className="h-[44px] w-[44px] flex-none rounded-[11px] object-cover"
+              className="h-[44px] w-[44px] flex-none rounded-[11px]"
             />
           ) : (
             <div

--- a/src/components/equipment/asset-image-viewer.tsx
+++ b/src/components/equipment/asset-image-viewer.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+interface AssetImageViewerProps {
+  src: string;
+  alt: string;
+  /** Classes for the clickable thumbnail (size, rounding, flex, …). */
+  className?: string;
+}
+
+/**
+ * A thumbnail that opens the image full-size in a dialog on click — same pattern as the
+ * user profile photo viewer. Use for the asset photo on the equipment detail page.
+ */
+export function AssetImageViewer({ src, alt, className }: AssetImageViewerProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`View photo of ${alt}`}
+        className={cn(
+          "block cursor-zoom-in overflow-hidden transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          className
+        )}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={src} alt={alt} className="h-full w-full object-cover" />
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-3xl border-0 bg-black/90 p-2 [&>button]:rounded-full [&>button]:bg-white/10 [&>button]:p-1 [&>button]:text-white [&>button]:opacity-100 [&>button]:hover:bg-white/20">
+          <DialogTitle className="sr-only">{alt}</DialogTitle>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={src}
+            alt={alt}
+            className="max-h-[80vh] w-full rounded object-contain"
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
The asset photo on the equipment detail page was a static thumbnail — no way to enlarge it (unlike the user profile photo, which opens a viewer on click).

Adds **`AssetImageViewer`** — a reusable thumbnail that opens the image **full-size in a dialog** on click (dark backdrop, contained image, `cursor-zoom-in`, keyboard-focusable, esc/overlay to close), mirroring the profile-photo viewer pattern. Wired into the detail-page header where the asset photo shows.

`tsc` + eslint clean, production build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>