### PR TITLE
fix(maintenance): unify Clear/Reset (both clear filters + search) + fix stale-debounce re-add

### DIFF
--- a/src/components/equipment/equipment-filters.tsx
+++ b/src/components/equipment/equipment-filters.tsx
@@ -81,6 +81,7 @@ export function EquipmentFilters({
     params.delete("category");
     params.delete("status");
     params.delete("lifecycle");
+    params.delete("q"); // also clear the search so "Clear all" matches the table's Reset
     router.push(`${pathname}?${params.toString()}`);
   }
 
@@ -201,7 +202,7 @@ export function EquipmentFilters({
             className="h-[34px] flex-none gap-1.5 text-[13px]"
           >
             <X size={13} />
-            Clear
+            Clear all
           </Button>
         )}
       </div>
@@ -333,7 +334,7 @@ export function EquipmentFilters({
                 className="flex-1"
                 onClick={clearAll}
               >
-                Clear
+                Clear all
               </Button>
               <SheetTrigger asChild>
                 <Button className="flex-1">Show results</Button>
@@ -351,7 +352,7 @@ export function EquipmentFilters({
             className="h-8 gap-1 text-[12px] text-muted-foreground"
           >
             <X size={12} />
-            Clear
+            Clear all
           </Button>
         )}
       </div>

--- a/src/components/equipment/equipment-table.tsx
+++ b/src/components/equipment/equipment-table.tsx
@@ -122,7 +122,9 @@ export function EquipmentTable({
   // shareable like the dropdown filters. Filtering itself stays instant/client-side.
   useEffect(() => {
     const t = setTimeout(() => {
-      const params = new URLSearchParams(searchParams.toString());
+      // Read the LIVE URL (not the captured searchParams) — otherwise a Reset or filter
+      // change that navigates during the debounce gets undone by a stale snapshot.
+      const params = new URLSearchParams(window.location.search);
       const trimmed = query.trim();
       if ((params.get("q") ?? "") === trimmed) return;
       if (trimmed) params.set("q", trimmed);
@@ -131,7 +133,7 @@ export function EquipmentTable({
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
     }, 350);
     return () => clearTimeout(t);
-  }, [query, searchParams, pathname, router]);
+  }, [query, pathname, router]);
 
   const toggle = (id: string) => {
     setSelected((prev) => {
@@ -201,7 +203,7 @@ export function EquipmentTable({
             onClick={resetAll}
             className="font-medium text-primary hover:underline"
           >
-            Reset
+            Clear all
           </button>
         </div>
       )}


### PR DESCRIPTION
**The bug:** the summary's **Reset** *was* coded to clear the dropdown filters + search, but the debounced `?q=` search-sync effect captured a **stale `searchParams`** in its closure. After Reset navigated to the cleared URL, that pending debounce fired ~350 ms later with the *old* params (filters still present) and `router.replace`'d them back — so Reset appeared to "only change the text query". Meanwhile the filter bar's **Clear** wiped the dropdowns but left the search. Hence the two behaved differently.

**Fixes:**
- The debounce now reads the **live `window.location.search`** at fire time instead of the captured snapshot — a Reset/filter navigation during the debounce window is no longer undone.
- **Unified both affordances:** the filter bar's button now also clears the search (`q`), both are labelled **"Clear all"**, and both wipe every dropdown filter *and* the search (preserving a branch manager's locked outlet).

`tsc` + eslint clean, production build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>