### PR TITLE
fix(equipment): prevent detail header title from collapsing next to actions

### DIFF
--- a/src/app/(auth)/equipment/[id]/page.tsx
+++ b/src/app/(auth)/equipment/[id]/page.tsx
@@ -158,7 +158,7 @@ export default async function EquipmentDetailPage({ params, searchParams }: Prop
       {/* Info header card */}
       <div className="rounded-xl border bg-card p-4 md:p-[22px] shadow-sm">
         {/* Top row: icon + name/badges + actions */}
-        <div className="flex items-start gap-3 md:gap-4">
+        <div className="flex flex-wrap items-start gap-3 md:gap-4">
           {/* Category icon tile or asset photo (click to view full size) */}
           {item.imageUrl ? (
             <AssetImageViewer
@@ -176,7 +176,7 @@ export default async function EquipmentDetailPage({ params, searchParams }: Prop
           )}
 
           {/* Name + category + location */}
-          <div className="min-w-0 flex-1">
+          <div className="flex-1 min-w-[240px]">
             <div className="flex flex-wrap items-center gap-[10px]">
               <h1 className="text-[19px] font-bold tracking-[-0.02em] md:text-[21px]">
                 {item.name}
@@ -211,7 +211,7 @@ export default async function EquipmentDetailPage({ params, searchParams }: Prop
           </div>
 
           {/* Actions — hidden on mobile, shown inline on sm+ */}
-          <div className="hidden sm:block">
+          <div className="hidden shrink-0 sm:block">
             <DetailActions
               equipmentId={item.id}
               equipmentName={item.name}


### PR DESCRIPTION
## Problem
On the asset detail page, a longer item name wraps **one word per line** into a thin column while the action buttons keep their full width.

The header row is `flex items-start` with three children: the thumbnail, the title block (`flex-1 min-w-0`), and the action group. The action group sizes to its **max-content** (all buttons on one line) and the title's `min-w-0` lets it collapse to nothing — so on tighter widths the title gets crushed instead of the buttons wrapping.

| Before | After |
|---|---|
| Title crushed to `2-`/`Burner`/`Chinese`/… | Title keeps its width; buttons drop to their own line when space is tight |

## Fix
Three className changes in `src/app/(auth)/equipment/[id]/page.tsx`:
- Header row: `flex` → `flex flex-wrap` so the action group can wrap below.
- Title block: `min-w-0 flex-1` → `flex-1 min-w-[240px]` so it has a width floor and forces the wrap instead of collapsing.
- Action group: add `shrink-0` so the buttons drop as a unit rather than compressing the title.

## Verification
Reproduced locally with a long-named item and confirmed the title no longer collapses and the action group wraps cleanly at narrow widths (mobile path — the separate stacked `sm:hidden` actions — is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)