### PR TITLE
feat(equipment): make list thumbnails open the full-size image dialog

### DIFF
--- a/src/components/equipment/equipment-cards.tsx
+++ b/src/components/equipment/equipment-cards.tsx
@@ -18,6 +18,7 @@ import {
 import { setEquipmentStatus } from "@/lib/equipment-actions";
 import { CategoryPill, StatusBadge } from "@/components/equipment/ui";
 import { CategoryIcon } from "@/components/equipment/category-icon";
+import { AssetImageViewer } from "@/components/equipment/asset-image-viewer";
 import { SnoozeDialog } from "@/components/equipment/snooze-dialog";
 import { ArchiveDialog } from "@/components/equipment/archive-dialog";
 import { CATEGORY_META } from "@/lib/equipment-display";
@@ -98,8 +99,13 @@ function ItemCard({ row, canManage, canSnooze, canLog, onSnooze, onArchive, sele
         )}
         {/* Category icon tile or asset photo */}
         {row.imageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={row.imageUrl} alt="" className="h-8 w-8 flex-none rounded object-cover" />
+          <span className="flex-none" onClick={(e) => e.stopPropagation()}>
+            <AssetImageViewer
+              src={row.imageUrl}
+              alt={row.name}
+              className="h-8 w-8 rounded"
+            />
+          </span>
         ) : (
           <div
             className="flex h-[38px] w-[38px] flex-none items-center justify-center rounded-[9px]"

--- a/src/components/equipment/equipment-table.tsx
+++ b/src/components/equipment/equipment-table.tsx
@@ -7,6 +7,7 @@ import { MapPin, MoreHorizontal, Archive, ArchiveRestore, Printer, Search, X } f
 import { toast } from "sonner";
 import { setEquipmentStatus } from "@/lib/equipment-actions";
 import { EquipmentCards } from "@/components/equipment/equipment-cards";
+import { AssetImageViewer } from "@/components/equipment/asset-image-viewer";
 import {
   Table,
   TableBody,
@@ -312,8 +313,13 @@ export function EquipmentTable({
                 <TableCell>
                   <div className="flex items-center gap-2">
                     {row.imageUrl ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={row.imageUrl} alt="" className="h-8 w-8 flex-none rounded object-cover" />
+                      <span className="flex-none" onClick={(e) => e.stopPropagation()}>
+                        <AssetImageViewer
+                          src={row.imageUrl}
+                          alt={row.name}
+                          className="h-8 w-8 rounded"
+                        />
+                      </span>
                     ) : null}
                     <span className="font-semibold text-foreground">{row.name}</span>
                     {isRetired && (


### PR DESCRIPTION
## What
On the maintenance items list, the asset thumbnail was a static `<img>` and did nothing on click. Now clicking it opens the **same full-size image dialog** used on the detail page.

## How
Reuse the existing `AssetImageViewer` component (added in #64 for the detail page) in both list views:
- `src/components/equipment/equipment-table.tsx`
- `src/components/equipment/equipment-cards.tsx`

The thumbnail is wrapped in a `<span onClick={stopPropagation}>` so clicking it opens the viewer **instead of** navigating to the item detail — same pattern the row's selection checkbox already uses.

## Verification
- `tsc --noEmit` passes; list page renders 50 items locally with no console errors.
- Could not click-test the dialog locally (no local items have images, and the dev DB is treated as production so I couldn't seed one). Behaviour reuses the already-proven detail-page viewer + the established checkbox `stopPropagation` pattern; no button-in-button nesting (rows are `tr`/`div`, not buttons). Worth a quick click-check on a Chandivali item after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)