### PR TITLE
feat(equipment): modernize asset image viewer into a frameless lightbox

### DIFF
--- a/src/components/equipment/asset-image-viewer.tsx
+++ b/src/components/equipment/asset-image-viewer.tsx
@@ -12,8 +12,10 @@ interface AssetImageViewerProps {
 }
 
 /**
- * A thumbnail that opens the image full-size in a dialog on click — same pattern as the
- * user profile photo viewer. Use for the asset photo on the equipment detail page.
+ * A thumbnail that opens the image full-size in a clean, frameless lightbox on
+ * click. shadcn/ui has no dedicated gallery component, so this builds on Dialog:
+ * the image is the hero (contained, rounded), with a caption scrim and a sleek
+ * close affordance. Clicking the dimmed backdrop or pressing Esc closes it.
  */
 export function AssetImageViewer({ src, alt, className }: AssetImageViewerProps) {
   const [open, setOpen] = useState(false);
@@ -34,14 +36,27 @@ export function AssetImageViewer({ src, alt, className }: AssetImageViewerProps)
       </button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-3xl border-0 bg-black/90 p-2 [&>button]:rounded-full [&>button]:bg-white/10 [&>button]:p-1 [&>button]:text-white [&>button]:opacity-100 [&>button]:hover:bg-white/20">
+        <DialogContent
+          className={cn(
+            // Frameless: shrink-wrap the image so the surrounding dim area stays
+            // the overlay (click-outside-to-close still works).
+            "w-auto max-w-[95vw] gap-0 border-0 bg-transparent p-0 shadow-none sm:rounded-none",
+            // Sleek round close button (the built-in DialogClose).
+            "[&>button]:right-3 [&>button]:top-3 [&>button]:z-10 [&>button]:flex [&>button]:h-9 [&>button]:w-9 [&>button]:items-center [&>button]:justify-center [&>button]:rounded-full [&>button]:bg-black/55 [&>button]:text-white [&>button]:opacity-100 [&>button]:backdrop-blur-sm [&>button]:ring-offset-0 [&>button]:transition-colors [&>button]:hover:bg-black/75 [&>button>svg]:h-[18px] [&>button>svg]:w-[18px]"
+          )}
+        >
           <DialogTitle className="sr-only">{alt}</DialogTitle>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={src}
-            alt={alt}
-            className="max-h-[80vh] w-full rounded object-contain"
-          />
+          <figure className="relative m-0">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={src}
+              alt={alt}
+              className="max-h-[88dvh] w-auto max-w-[95vw] rounded-xl object-contain shadow-2xl ring-1 ring-white/10"
+            />
+            <figcaption className="pointer-events-none absolute inset-x-0 bottom-0 rounded-b-xl bg-gradient-to-t from-black/75 via-black/30 to-transparent px-4 pb-3 pt-12 text-[13px] font-medium text-white">
+              {alt}
+            </figcaption>
+          </figure>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
## What
Redesigns the asset photo viewer (`src/components/equipment/asset-image-viewer.tsx`) from a dated, "rustic" framed box into a clean, modern lightbox.

**Before:** chunky `bg-black/90` rounded box, framed rounded image, tiny white close circle.
**After:** frameless — the image is the hero (contained, rounded, subtle `ring-white/10`), a bottom gradient scrim shows the asset name, and a sleek round close button sits top-right. Click-outside (dimmed backdrop) and Esc still close it.

Shared component, so the **detail page and the items list both** get the new look.

## Why on Dialog (not a new dep)
shadcn/ui has **no dedicated gallery/lightbox component** — its guidance is to build overlays on `Dialog`, which this already does. No new dependency.

## Verification
Verified in a local dev preview via a throwaway test page (since local data has no images): dialog opens, image loads contained with rounded corners + ring, caption scrim shows the asset name and hugs the image bottom, round close button renders, backdrop dims. Test page was removed before commit. `tsc --noEmit` passes.

Screenshot (landscape sample):
- Full-bleed contained image, bottom scrim caption "3-Burner Gas Range", round close top-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)