### PR TITLE
feat(documents): edit branch documents with file version history

### DIFF
--- a/docs/superpowers/specs/2026-06-20-branch-document-edit-versioning-design.md
+++ b/docs/superpowers/specs/2026-06-20-branch-document-edit-versioning-design.md
@@ -1,0 +1,119 @@
+# Branch Document Edit + File Version History — Design
+
+**Date:** 2026-06-20
+**Status:** Approved (design)
+
+## Problem
+
+Branch documents (`BranchDocument`) today support create / list / download / delete but **no edit**. When a document expires and is renewed, a MANAGEMENT user must delete the old entry and create a new one from scratch — losing continuity and any record of what changed. We want in-place editing, plus a version history of file replacements with an audit trail of *what changed and by whom*.
+
+## Goals
+
+- Edit an existing branch document in place: `name`, `description`, `documentType`, `renewalDate`, `reminderDate`, and **optionally replace the file**.
+- Keep a **version history of file replacements** (who replaced it, when, the metadata it held), each historical file downloadable.
+- Bounded storage: retain files for the latest **N = 5** versions; prune older blobs but keep their audit record.
+- Record metadata-only edits in the existing activity log.
+
+## Non-goals (YAGNI)
+
+- No versioning of pure metadata/date edits (activity-log only).
+- No branch-manager edit rights (view/download only, unchanged).
+- No diff storage — field-level "before → after" is derived by diffing consecutive snapshots in the UI.
+- No restore/rollback action in this iteration (history is read-only; download + re-upload covers it).
+
+## Decisions (from brainstorming)
+
+1. File on edit: **optional replace, old blob retained as a version** (not discarded).
+2. Versioning trigger: **only file replacements** create a version row. Metadata-only edits update in place + log activity.
+3. Retention: **keep recent N (=5)** version files; prune older blobs, keep the record.
+
+## Data model
+
+New model `BranchDocumentVersion` (new table `branch_document_versions`, requires migration):
+
+```prisma
+model BranchDocumentVersion {
+  id             String   @id @default(cuid())
+  numId          Int      @default(autoincrement()) @map("num_id")
+  documentId     String   @map("document_id")
+  versionNumber  Int      @map("version_number")     // 1,2,3… per file replacement
+  // Snapshot of the SUPERSEDED file:
+  fileName       String   @map("file_name")
+  fileUrl        String?  @map("file_url")            // null once pruned by retention
+  fileSize       Int      @map("file_size")
+  fileType       String   @map("file_type")
+  filePruned     Boolean  @default(false) @map("file_pruned")
+  // Snapshot of the document metadata at the time this file was active:
+  name           String
+  description    String?
+  renewalDate    DateTime @map("renewal_date")
+  reminderDate   DateTime @map("reminder_date")
+  documentTypeId String?  @map("document_type_id")
+  // Audit:
+  changedById    String   @map("changed_by_id")      // who performed the replacement
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  document  BranchDocument @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  changedBy User           @relation("BranchDocumentVersionChangedBy", fields: [changedById], references: [id])
+
+  @@index([documentId])
+  @@map("branch_document_versions")
+}
+```
+
+`BranchDocument` gains `versions BranchDocumentVersion[]`. `User` gains the inverse relation. No other column changes to `BranchDocument`.
+
+Constant: `MAX_DOCUMENT_VERSION_FILES = 5` (single source, easy to change).
+
+## API
+
+### `PATCH /api/branches/[branchId]/documents/[documentId]`
+- **Auth:** MANAGEMENT only (matches create/delete).
+- **Input:** FormData (carries optional file) — `name`, `description?`, `documentTypeId?`, `renewalDate`, `reminderDate`, optional `file` (PDF/JPG/PNG/GIF/ZIP, ≤10 MB — same validation as create).
+- **Logic:**
+  1. Load the document; verify it belongs to `branchId` (404 otherwise).
+  2. Compute changed fields vs current values.
+  3. **If a new file is present:**
+     - Upload the new file to Azure (`branch-documents/`). Keep the old blob.
+     - In a transaction: create a `BranchDocumentVersion` snapshotting the **pre-edit** file + metadata (`versionNumber` = existing count + 1, `changedById` = editor); update the live `BranchDocument` with new file fields + edited metadata.
+     - **Retention:** after commit, if the number of non-pruned version files exceeds `MAX_DOCUMENT_VERSION_FILES`, delete the oldest version's blob (`deleteByUrl`), set its `fileUrl = null`, `filePruned = true`. Best-effort; a blob-delete failure is logged, not fatal.
+  4. **If no file:** update the metadata fields in place. No version row.
+  5. Log activity via `logActivity` with a new `ActivityType.DOCUMENT_UPDATED` (the enum currently has `DOCUMENT_UPLOADED/DELETED/EXPIRY_ALERT` but no update value — add it in the same migration), recording the changed fields, actor, document + branch.
+  6. Return the updated document (with relations).
+- **Failure handling:** if the new file uploaded but the DB transaction fails, delete the just-uploaded blob (mirror the maintenance-records cleanup pattern).
+
+### History read
+- The branch documents page already loads documents server-side; include `versions` (ordered `versionNumber desc`, `changedBy` selected) so the History dialog renders without an extra fetch. (No separate GET endpoint needed; add one only if history is opened lazily — deferred.)
+
+### Delete cleanup
+- Extend the existing `DELETE` route: before deleting the record, delete the current blob **and** every non-pruned version blob. Cascade removes version rows.
+
+## UI
+
+`src/components/branches/branch-documents-list.tsx` actions dropdown gains:
+- **Edit** (MANAGEMENT) → opens the document form dialog in **edit mode**, pre-filled; dropzone labelled "Replace file (optional)". Submits FormData to the PATCH route.
+- **History** (MANAGEMENT + BRANCH_MANAGER) → opens a timeline dialog.
+
+Form reuse: refactor `branch-document-upload.tsx` into a shared form that supports **create** and **edit** modes via an optional `document` prop (one schema, file required on create / optional on edit). Keeps the two flows in sync.
+
+History dialog (`branch-document-history.tsx`, new): newest-first list. Each entry:
+`v{n} · {changed fields, e.g. "file replaced, renewal 01 Jan 2026 → 01 Jan 2027"} · {changedBy.name} · {date} · [Download]`.
+Field-level transitions are derived by diffing each version snapshot against the next-newer one (or the live doc for the latest). Pruned entries show "file no longer retained" instead of a Download button.
+
+## Permissions
+
+| Action | Roles |
+|--------|-------|
+| Edit (PATCH) | MANAGEMENT |
+| View history | MANAGEMENT, BRANCH_MANAGER (own branch) |
+| Create / Delete | MANAGEMENT (unchanged) |
+
+## Testing
+
+- Unit: changed-field computation; retention prune selects the oldest non-pruned version; version number increments correctly.
+- Route: PATCH with file (creates version, updates doc), PATCH without file (no version), retention prune past N, branch mismatch → 404, non-MANAGEMENT → 403, upload-then-DB-failure cleans the new blob.
+- UI smoke: edit dialog pre-fills and submits; history timeline renders diffs and download links; pruned entry shows the retained-record state.
+
+## Deployment
+
+Adds a table **and** a new `ActivityType.DOCUMENT_UPDATED` enum value → run `prisma migrate deploy` on production (migration generated locally). Otherwise web-app deploy as usual. No Azure config change. No change to the daily expiry cron.

--- a/prisma/migrations/20260620120000_add_branch_document_versions/migration.sql
+++ b/prisma/migrations/20260620120000_add_branch_document_versions/migration.sql
@@ -24,6 +24,9 @@ CREATE TABLE "branch_document_versions" (
 );
 
 -- CreateIndex
+CREATE UNIQUE INDEX "branch_document_versions_document_id_version_number_key" ON "branch_document_versions"("document_id", "version_number");
+
+-- CreateIndex
 CREATE INDEX "branch_document_versions_document_id_idx" ON "branch_document_versions"("document_id");
 
 -- AddForeignKey

--- a/prisma/migrations/20260620120000_add_branch_document_versions/migration.sql
+++ b/prisma/migrations/20260620120000_add_branch_document_versions/migration.sql
@@ -1,0 +1,33 @@
+-- AlterEnum: document update activity type
+ALTER TYPE "ActivityType" ADD VALUE IF NOT EXISTS 'DOCUMENT_UPDATED';
+
+-- CreateTable
+CREATE TABLE "branch_document_versions" (
+    "id" TEXT NOT NULL,
+    "num_id" SERIAL NOT NULL,
+    "document_id" TEXT NOT NULL,
+    "version_number" INTEGER NOT NULL,
+    "file_name" TEXT NOT NULL,
+    "file_url" TEXT,
+    "file_size" INTEGER NOT NULL,
+    "file_type" TEXT NOT NULL,
+    "file_pruned" BOOLEAN NOT NULL DEFAULT false,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "renewal_date" TIMESTAMP(3) NOT NULL,
+    "reminder_date" TIMESTAMP(3) NOT NULL,
+    "document_type_id" TEXT,
+    "changed_by_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "branch_document_versions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "branch_document_versions_document_id_idx" ON "branch_document_versions"("document_id");
+
+-- AddForeignKey
+ALTER TABLE "branch_document_versions" ADD CONSTRAINT "branch_document_versions_document_id_fkey" FOREIGN KEY ("document_id") REFERENCES "branch_documents"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "branch_document_versions" ADD CONSTRAINT "branch_document_versions_changed_by_id_fkey" FOREIGN KEY ("changed_by_id") REFERENCES "users1"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -223,6 +223,7 @@ model User {
 
   // --- Branch Document Relations ---
   uploadedBranchDocuments BranchDocument[] @relation("BranchDocumentUploads")
+  changedBranchDocumentVersions BranchDocumentVersion[] @relation("BranchDocumentVersionChangedBy")
 
   // --- User Document Relations ---
   userDocuments         UserDocument[]
@@ -402,6 +403,7 @@ model BranchDocument {
   uploadedBy   User          @relation("BranchDocumentUploads", fields: [uploadedById], references: [id])
   branch       Branch        @relation(fields: [branchId], references: [id], onDelete: Cascade)
   documentType DocumentType? @relation(fields: [documentTypeId], references: [id])
+  versions     BranchDocumentVersion[]
 
   @@index([branchId])
   @@index([uploadedById])
@@ -409,6 +411,37 @@ model BranchDocument {
   @@index([reminderDate])
   @@index([documentTypeId])
   @@map("branch_documents")
+}
+
+// A historical snapshot of a branch document's FILE, captured each time the file
+// is replaced via edit. Older blobs are pruned past MAX_DOCUMENT_VERSION_FILES,
+// but the audit record (who/when/which dates) is retained.
+model BranchDocumentVersion {
+  id             String   @id @default(cuid())
+  numId          Int      @default(autoincrement()) @map("num_id")
+  documentId     String   @map("document_id")
+  versionNumber  Int      @map("version_number")
+  // Superseded file (fileUrl null once the blob is pruned by retention):
+  fileName       String   @map("file_name")
+  fileUrl        String?  @map("file_url")
+  fileSize       Int      @map("file_size")
+  fileType       String   @map("file_type")
+  filePruned     Boolean  @default(false) @map("file_pruned")
+  // Document metadata at the time this file was active:
+  name           String
+  description    String?
+  renewalDate    DateTime @map("renewal_date")
+  reminderDate   DateTime @map("reminder_date")
+  documentTypeId String?  @map("document_type_id")
+  // Audit:
+  changedById    String   @map("changed_by_id")
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  document  BranchDocument @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  changedBy User           @relation("BranchDocumentVersionChangedBy", fields: [changedById], references: [id])
+
+  @@index([documentId])
+  @@map("branch_document_versions")
 }
 
 // --- User Documents ---
@@ -763,6 +796,7 @@ enum ActivityType {
   UNIFORM_RETURNED
   DOCUMENT_UPLOADED
   DOCUMENT_DELETED
+  DOCUMENT_UPDATED
   DOCUMENT_EXPIRY_ALERT
   BRANCH_CREATED
   BRANCH_UPDATED

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -440,6 +440,7 @@ model BranchDocumentVersion {
   document  BranchDocument @relation(fields: [documentId], references: [id], onDelete: Cascade)
   changedBy User           @relation("BranchDocumentVersionChangedBy", fields: [changedById], references: [id])
 
+  @@unique([documentId, versionNumber])
   @@index([documentId])
   @@map("branch_document_versions")
 }

--- a/src/app/(auth)/branches/[branchId]/documents/page.tsx
+++ b/src/app/(auth)/branches/[branchId]/documents/page.tsx
@@ -85,7 +85,7 @@ export default async function BranchDocumentsPage({ params }: Props) {
           </div>
         )}
         
-        <BranchDocumentsList branchId={branch.id} canUpload={canUpload} branchName={branch.name} />
+        <BranchDocumentsList branchId={branch.id} canUpload={canUpload} branchName={branch.name} documentTypes={documentTypes} />
       </div>
     </div>
   );

--- a/src/app/(auth)/branches/[branchId]/edit/page.tsx
+++ b/src/app/(auth)/branches/[branchId]/edit/page.tsx
@@ -74,7 +74,7 @@ export default async function EditBranchPage({ params }: Props) {
           <h3 className="text-2xl font-bold">Upload Documents</h3>
           <BranchDocumentUpload branchId={branch.id} branchName={branch.name} documentTypes={documentTypes} />
         </div>
-        <BranchDocumentsList branchId={branch.id} canUpload={true} branchName={branch.name} />
+        <BranchDocumentsList branchId={branch.id} canUpload={true} branchName={branch.name} documentTypes={documentTypes} />
       </div>
     </div>
   );

--- a/src/app/api/branches/[branchId]/documents/[documentId]/route.ts
+++ b/src/app/api/branches/[branchId]/documents/[documentId]/route.ts
@@ -2,8 +2,194 @@ import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { AzureStorageService } from "@/lib/azure-storage";
+import { logActivity } from "@/lib/services/activity-log";
+import { ActivityType } from "@prisma/client";
+import {
+  computeDocumentChanges,
+  describeDocumentChanges,
+  versionsToPrune,
+  DOCUMENT_ALLOWED_FILE_TYPES,
+  DOCUMENT_MAX_FILE_BYTES,
+} from "@/lib/services/branch-document-versions";
 
 const BRANCH_DOCUMENTS_FOLDER = 'branch-documents';
+
+const DOCUMENT_INCLUDE = {
+  uploadedBy: { select: { id: true, name: true } },
+  documentType: { select: { id: true, name: true, mandatory: true } },
+} as const;
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ branchId: string; documentId: string }> }
+) {
+  let uploadedFileUrl: string | null = null;
+  try {
+    const session = await auth();
+    // @ts-expect-error - role is not in the User type
+    const role = session?.user?.role;
+    if (!session || role !== "MANAGEMENT") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { branchId, documentId } = await params;
+    const userId = session.user!.id as string;
+
+    const document = await prisma.branchDocument.findFirst({
+      where: { id: documentId, branchId },
+    });
+    if (!document) {
+      return NextResponse.json({ error: "Document not found" }, { status: 404 });
+    }
+
+    const formData = await req.formData();
+    const name = formData.get("name") as string | null;
+    const description = formData.get("description") as string | null;
+    const renewalDate = formData.get("renewalDate") as string | null;
+    const reminderDate = formData.get("reminderDate") as string | null;
+    const documentTypeId = formData.get("documentTypeId") as string | null;
+    const file = formData.get("file");
+    const hasFile = file instanceof File && file.size > 0;
+
+    if (!name || !renewalDate || !reminderDate) {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
+
+    if (hasFile) {
+      if (!(DOCUMENT_ALLOWED_FILE_TYPES as readonly string[]).includes(file.type)) {
+        return NextResponse.json(
+          { error: "Invalid file type. Only PDF, images, and ZIP files are allowed" },
+          { status: 400 }
+        );
+      }
+      if (file.size > DOCUMENT_MAX_FILE_BYTES) {
+        return NextResponse.json({ error: "File size must be less than 10MB" }, { status: 400 });
+      }
+    }
+
+    const incoming = {
+      name,
+      description: description || null,
+      documentTypeId: documentTypeId || null,
+      renewalDate: new Date(renewalDate),
+      reminderDate: new Date(reminderDate),
+    };
+    const changedFields = computeDocumentChanges(
+      {
+        name: document.name,
+        description: document.description,
+        documentTypeId: document.documentTypeId,
+        renewalDate: document.renewalDate,
+        reminderDate: document.reminderDate,
+      },
+      incoming,
+      hasFile
+    );
+
+    if (changedFields.length === 0) {
+      // Nothing changed — return the document as-is (with relations).
+      const unchanged = await prisma.branchDocument.findUnique({
+        where: { id: documentId },
+        include: DOCUMENT_INCLUDE,
+      });
+      return NextResponse.json(unchanged);
+    }
+
+    const azureStorage = new AzureStorageService();
+
+    // Upload the replacement file first (old blob stays — it becomes a version).
+    let newFileData: { fileName: string; fileUrl: string; fileSize: number; fileType: string } | null = null;
+    if (hasFile) {
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const filename = `${branchId}-${Date.now()}-${file.name}`;
+      uploadedFileUrl = await azureStorage.uploadImage(buffer, filename, BRANCH_DOCUMENTS_FOLDER, file.type);
+      newFileData = { fileName: file.name, fileUrl: uploadedFileUrl, fileSize: file.size, fileType: file.type };
+    }
+
+    // Apply the edit. When the file changes, snapshot the superseded file+metadata
+    // into a version row in the same transaction.
+    const updated = await prisma.$transaction(async (tx) => {
+      if (newFileData) {
+        const priorVersions = await tx.branchDocumentVersion.count({ where: { documentId } });
+        await tx.branchDocumentVersion.create({
+          data: {
+            documentId,
+            versionNumber: priorVersions + 1,
+            fileName: document.fileName,
+            fileUrl: document.fileUrl,
+            fileSize: document.fileSize,
+            fileType: document.fileType,
+            name: document.name,
+            description: document.description,
+            renewalDate: document.renewalDate,
+            reminderDate: document.reminderDate,
+            documentTypeId: document.documentTypeId,
+            changedById: userId,
+          },
+        });
+      }
+      return tx.branchDocument.update({
+        where: { id: documentId },
+        data: {
+          name: incoming.name,
+          description: incoming.description,
+          documentTypeId: incoming.documentTypeId,
+          renewalDate: incoming.renewalDate,
+          reminderDate: incoming.reminderDate,
+          ...(newFileData ?? {}),
+        },
+        include: DOCUMENT_INCLUDE,
+      });
+    });
+
+    // Retention: prune the oldest version blobs beyond the cap (best-effort).
+    if (newFileData) {
+      try {
+        const versions = await prisma.branchDocumentVersion.findMany({
+          where: { documentId },
+          select: { id: true, versionNumber: true, fileUrl: true, filePruned: true },
+        });
+        for (const v of versionsToPrune(versions)) {
+          if (v.fileUrl) {
+            try {
+              await azureStorage.deleteByUrl(v.fileUrl);
+            } catch (e) {
+              console.error("Version blob prune failed for", v.id, e);
+            }
+            await prisma.branchDocumentVersion.update({
+              where: { id: v.id },
+              data: { fileUrl: null, filePruned: true },
+            });
+          }
+        }
+      } catch (e) {
+        console.error("Version retention pass failed for document", documentId, e);
+      }
+    }
+
+    await logActivity({
+      activityType: ActivityType.DOCUMENT_UPDATED,
+      userId,
+      targetId: documentId,
+      entityType: "BranchDocument",
+      description: `Updated document "${updated.name}" (${describeDocumentChanges(changedFields)})`,
+      metadata: { branchId, changedFields, fileReplaced: hasFile },
+    });
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("Error updating document:", error);
+    // Roll back the orphaned upload if the DB write failed.
+    if (uploadedFileUrl) {
+      try {
+        await new AzureStorageService().deleteByUrl(uploadedFileUrl);
+      } catch (e) {
+        console.error("Failed to clean up orphaned upload:", e);
+      }
+    }
+    return NextResponse.json({ error: "Failed to update document" }, { status: 500 });
+  }
+}
 
 export async function DELETE(
   req: Request,
@@ -29,6 +215,7 @@ export async function DELETE(
         id: documentId,
         branchId,
       },
+      include: { versions: { select: { fileUrl: true } } },
     });
 
     if (!document) {
@@ -38,19 +225,21 @@ export async function DELETE(
       );
     }
 
-    // Delete from Azure
-    try {
-      const azureStorage = new AzureStorageService();
-      const filename = document.fileUrl.split('/').pop();
-      if (filename) {
-        await azureStorage.deleteImage(filename, BRANCH_DOCUMENTS_FOLDER);
+    // Delete the current file + every retained version blob from Azure (best-effort).
+    const azureStorage = new AzureStorageService();
+    const blobUrls = [document.fileUrl, ...document.versions.map((v) => v.fileUrl)].filter(
+      (u): u is string => Boolean(u)
+    );
+    for (const url of blobUrls) {
+      try {
+        await azureStorage.deleteByUrl(url);
+      } catch (error) {
+        console.error("Error deleting file from Azure:", error);
+        // Continue with database deletion even if Azure deletion fails
       }
-    } catch (error) {
-      console.error("Error deleting file from Azure:", error);
-      // Continue with database deletion even if Azure deletion fails
     }
 
-    // Delete from database
+    // Delete from database (versions cascade via FK)
     await prisma.branchDocument.delete({
       where: { id: documentId },
     });
@@ -63,4 +252,4 @@ export async function DELETE(
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/api/branches/[branchId]/documents/[documentId]/route.ts
+++ b/src/app/api/branches/[branchId]/documents/[documentId]/route.ts
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { AzureStorageService } from "@/lib/azure-storage";
 import { logActivity } from "@/lib/services/activity-log";
-import { ActivityType } from "@prisma/client";
+import { ActivityType, Prisma } from "@prisma/client";
 import {
   computeDocumentChanges,
   describeDocumentChanges,
@@ -186,6 +186,13 @@ export async function PATCH(
       } catch (e) {
         console.error("Failed to clean up orphaned upload:", e);
       }
+    }
+    // Unique violation on (documentId, versionNumber) => a concurrent edit raced us.
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json(
+        { error: "This document was just modified by someone else. Please reopen and try again." },
+        { status: 409 }
+      );
     }
     return NextResponse.json({ error: "Failed to update document" }, { status: 500 });
   }

--- a/src/app/api/branches/[branchId]/documents/[documentId]/versions/route.ts
+++ b/src/app/api/branches/[branchId]/documents/[documentId]/versions/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+// Version history for a single branch document. Lazy-loaded by the History dialog
+// so the documents list payload stays lean.
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ branchId: string; documentId: string }> }
+) {
+  try {
+    const session = await auth();
+    // @ts-expect-error - role is not in the User type
+    const role = session?.user?.role;
+    if (!session || !["MANAGEMENT", "BRANCH_MANAGER"].includes(role)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { branchId, documentId } = await params;
+
+    // Branch managers may only read their own branch's documents.
+    if (role === "BRANCH_MANAGER") {
+      const user = await prisma.user.findUnique({
+        where: { id: session.user!.id as string },
+        select: { managedBranchId: true },
+      });
+      if (user?.managedBranchId !== branchId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      }
+    }
+
+    // Ensure the document exists in this branch before exposing its versions.
+    const document = await prisma.branchDocument.findFirst({
+      where: { id: documentId, branchId },
+      select: { id: true },
+    });
+    if (!document) {
+      return NextResponse.json({ error: "Document not found" }, { status: 404 });
+    }
+
+    const versions = await prisma.branchDocumentVersion.findMany({
+      where: { documentId },
+      orderBy: { versionNumber: "desc" },
+      include: { changedBy: { select: { id: true, name: true } } },
+    });
+
+    return NextResponse.json(versions);
+  } catch (error) {
+    console.error("Error fetching document versions:", error);
+    return NextResponse.json({ error: "Failed to fetch versions" }, { status: 500 });
+  }
+}

--- a/src/app/api/branches/[branchId]/documents/route.ts
+++ b/src/app/api/branches/[branchId]/documents/route.ts
@@ -189,6 +189,10 @@ export async function GET(
             mandatory: true,
           },
         },
+        versions: {
+          orderBy: { versionNumber: "desc" },
+          include: { changedBy: { select: { id: true, name: true } } },
+        },
       },
       orderBy: {
         createdAt: "desc",

--- a/src/app/api/branches/[branchId]/documents/route.ts
+++ b/src/app/api/branches/[branchId]/documents/route.ts
@@ -189,10 +189,7 @@ export async function GET(
             mandatory: true,
           },
         },
-        versions: {
-          orderBy: { versionNumber: "desc" },
-          include: { changedBy: { select: { id: true, name: true } } },
-        },
+        _count: { select: { versions: true } },
       },
       orderBy: {
         createdAt: "desc",

--- a/src/components/activity-logs/activity-logs-view.tsx
+++ b/src/components/activity-logs/activity-logs-view.tsx
@@ -77,6 +77,7 @@ const activityTypeLabels: Record<ActivityType, string> = {
   UNIFORM_RETURNED: "Uniform Returned",
   DOCUMENT_UPLOADED: "Document Uploaded",
   DOCUMENT_DELETED: "Document Deleted",
+  DOCUMENT_UPDATED: "Document Updated",
   DOCUMENT_EXPIRY_ALERT: "Document Expiry Alert",
   BRANCH_CREATED: "Branch Created",
   BRANCH_UPDATED: "Branch Updated",

--- a/src/components/branches/branch-document-form-dialog.tsx
+++ b/src/components/branches/branch-document-form-dialog.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -37,6 +38,9 @@ import { BranchDocument, DocumentType } from "@/models/models";
 
 const NO_TYPE = "__none__";
 
+/** Fired after a successful create/edit so the (client-fetched) documents list refetches. */
+export const BRANCH_DOCUMENTS_CHANGED = "branch-documents:changed";
+
 const documentFormSchema = z.object({
   name: z.string().min(2, "Document name must be at least 2 characters"),
   description: z.string().optional(),
@@ -55,8 +59,6 @@ interface BranchDocumentFormDialogProps {
   document?: BranchDocument;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Called after a successful save (e.g. to refetch the list). Falls back to router.refresh(). */
-  onSaved?: () => void;
 }
 
 export function BranchDocumentFormDialog({
@@ -66,7 +68,6 @@ export function BranchDocumentFormDialog({
   document,
   open,
   onOpenChange,
-  onSaved,
 }: BranchDocumentFormDialogProps) {
   const router = useRouter();
   const isEdit = mode === "edit";
@@ -129,8 +130,10 @@ export function BranchDocumentFormDialog({
       onOpenChange(false);
       setSelectedFile(null);
       form.reset();
-      if (onSaved) onSaved();
-      else router.refresh();
+      // Refresh the client-fetched documents list, and any server-rendered
+      // document-dependent UI (reminder banners, dashboard counts).
+      window.dispatchEvent(new CustomEvent(BRANCH_DOCUMENTS_CHANGED, { detail: { branchId } }));
+      router.refresh();
     } catch (error) {
       console.error(error);
       toast.error(error instanceof Error ? error.message : "Failed to save document");
@@ -144,6 +147,11 @@ export function BranchDocumentFormDialog({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit Document" : "Upload Branch Document"}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Update the document details, or replace the file to record a new version."
+              : "Add a document with its renewal and reminder dates."}
+          </DialogDescription>
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">

--- a/src/components/branches/branch-document-form-dialog.tsx
+++ b/src/components/branches/branch-document-form-dialog.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import * as z from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { DateInput } from "@/components/ui/date-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { FileDropzone } from "@/components/ui/file-dropzone";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { BranchDocument, DocumentType } from "@/models/models";
+
+const NO_TYPE = "__none__";
+
+const documentFormSchema = z.object({
+  name: z.string().min(2, "Document name must be at least 2 characters"),
+  description: z.string().optional(),
+  documentTypeId: z.string().optional(),
+  renewalDate: z.date({ required_error: "Renewal date is required" }),
+  reminderDate: z.date({ required_error: "Reminder date is required" }),
+});
+
+type FormValues = z.infer<typeof documentFormSchema>;
+
+interface BranchDocumentFormDialogProps {
+  branchId: string;
+  documentTypes?: DocumentType[];
+  mode: "create" | "edit";
+  /** Required in edit mode — the document to pre-fill and update. */
+  document?: BranchDocument;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after a successful save (e.g. to refetch the list). Falls back to router.refresh(). */
+  onSaved?: () => void;
+}
+
+export function BranchDocumentFormDialog({
+  branchId,
+  documentTypes = [],
+  mode,
+  document,
+  open,
+  onOpenChange,
+  onSaved,
+}: BranchDocumentFormDialogProps) {
+  const router = useRouter();
+  const isEdit = mode === "edit";
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(documentFormSchema),
+    defaultValues: { name: "", description: "", documentTypeId: NO_TYPE },
+  });
+
+  // Pre-fill (edit) or clear (create) whenever the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    setSelectedFile(null);
+    if (isEdit && document) {
+      form.reset({
+        name: document.name,
+        description: document.description ?? "",
+        documentTypeId: document.documentTypeId ?? NO_TYPE,
+        renewalDate: new Date(document.renewalDate),
+        reminderDate: new Date(document.reminderDate),
+      });
+    } else {
+      form.reset({ name: "", description: "", documentTypeId: NO_TYPE });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, isEdit, document?.id]);
+
+  const onSubmit = async (values: FormValues) => {
+    if (!isEdit && !selectedFile) {
+      toast.error("Please select a file");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const formData = new FormData();
+      formData.append("name", values.name);
+      formData.append("description", values.description || "");
+      formData.append(
+        "documentTypeId",
+        values.documentTypeId && values.documentTypeId !== NO_TYPE ? values.documentTypeId : ""
+      );
+      formData.append("renewalDate", values.renewalDate.toISOString());
+      formData.append("reminderDate", values.reminderDate.toISOString());
+      if (selectedFile) formData.append("file", selectedFile);
+
+      const url = isEdit
+        ? `/api/branches/${branchId}/documents/${document!.id}`
+        : `/api/branches/${branchId}/documents`;
+      const response = await fetch(url, { method: isEdit ? "PATCH" : "POST", body: formData });
+
+      if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.error || `Failed to ${isEdit ? "update" : "upload"} document`);
+      }
+
+      toast.success(isEdit ? "Document updated" : "Document uploaded successfully");
+      onOpenChange(false);
+      setSelectedFile(null);
+      form.reset();
+      if (onSaved) onSaved();
+      else router.refresh();
+    } catch (error) {
+      console.error(error);
+      toast.error(error instanceof Error ? error.message : "Failed to save document");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? "Edit Document" : "Upload Branch Document"}</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Document Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="License Certificate" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description (Optional)</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} placeholder="Brief description of the document" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="documentTypeId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Document Type (Optional)</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value || NO_TYPE}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a document type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value={NO_TYPE}>No type</SelectItem>
+                      {documentTypes.map((docType) => (
+                        <SelectItem key={docType.id} value={docType.id}>
+                          <div className="flex items-center gap-2">
+                            <span>{docType.name}</span>
+                            {docType.mandatory && <span className="text-xs text-red-500">*</span>}
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div>
+              <label className="block text-sm font-medium mb-2">
+                {isEdit ? "Replace file (optional)" : "File"}
+              </label>
+              <FileDropzone
+                variant="file"
+                accept=".pdf,.jpg,.jpeg,.png,.gif,.zip"
+                maxSizeMB={10}
+                value={selectedFile ? [selectedFile] : []}
+                onFiles={(fs) => setSelectedFile(fs[0] ?? null)}
+                onRemoveFile={() => setSelectedFile(null)}
+                idleText="Drag & drop a file, or click to browse"
+                hint="PDF, image, or ZIP — up to 10MB"
+                disabled={isLoading}
+              />
+              {isEdit && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Leave empty to keep the current file: {document?.fileName}
+                </p>
+              )}
+            </div>
+
+            <FormField
+              control={form.control}
+              name="renewalDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Renewal Date</FormLabel>
+                  <FormControl>
+                    <DateInput {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="reminderDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Reminder Date</FormLabel>
+                  <FormControl>
+                    <DateInput {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex gap-2 pt-4">
+              <Button type="submit" className="flex-1" disabled={isLoading}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {isEdit ? "Saving..." : "Uploading..."}
+                  </>
+                ) : isEdit ? (
+                  "Save Changes"
+                ) : (
+                  "Upload Document"
+                )}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/branches/branch-document-history-dialog.tsx
+++ b/src/components/branches/branch-document-history-dialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Download, History, FileX } from "lucide-react";
+import { BranchDocument, BranchDocumentVersion } from "@/models/models";
+import { formatDateOnly } from "@/lib/utils";
+import { computeDocumentChanges } from "@/lib/services/branch-document-versions";
+
+interface BranchDocumentHistoryDialogProps {
+  document: BranchDocument | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function toSnapshot(d: BranchDocument | BranchDocumentVersion) {
+  return {
+    name: d.name,
+    description: d.description ?? null,
+    documentTypeId: d.documentTypeId ?? null,
+    renewalDate: new Date(d.renewalDate),
+    reminderDate: new Date(d.reminderDate),
+  };
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  name: "name",
+  description: "description",
+  documentType: "document type",
+  renewalDate: "renewal date",
+  reminderDate: "reminder date",
+  file: "file",
+};
+
+export function BranchDocumentHistoryDialog({
+  document,
+  open,
+  onOpenChange,
+}: BranchDocumentHistoryDialogProps) {
+  const versions = document?.versions ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <History className="h-5 w-5" />
+            Version history
+          </DialogTitle>
+          <DialogDescription>
+            {document ? document.name : ""} — file replacements, newest first.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] space-y-3 overflow-y-auto pr-1">
+          {/* Current live version */}
+          {document && (
+            <div className="rounded-lg border bg-muted/30 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <Badge>Current</Badge>
+                  <span className="text-sm font-medium">{document.fileName}</span>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => window.open(document.fileUrl, "_blank")}
+                >
+                  <Download className="mr-1.5 h-3.5 w-3.5" />
+                  Download
+                </Button>
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                Renewal {formatDateOnly(document.renewalDate)} · Reminder{" "}
+                {formatDateOnly(document.reminderDate)}
+              </div>
+            </div>
+          )}
+
+          {versions.length === 0 && (
+            <p className="py-4 text-center text-sm text-muted-foreground">
+              No previous versions yet. A version is recorded each time the file is replaced.
+            </p>
+          )}
+
+          {versions.map((version, i) => {
+            // The state this version became: the next-newer snapshot (current doc for i=0).
+            const newer = i === 0 ? document! : versions[i - 1];
+            const changed = computeDocumentChanges(toSnapshot(version), toSnapshot(newer), true);
+            const summary = changed.map((f) => FIELD_LABELS[f]).join(", ");
+            return (
+              <div key={version.id} className="rounded-lg border p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary">v{version.versionNumber}</Badge>
+                    <span className="text-sm font-medium">{version.fileName}</span>
+                  </div>
+                  {version.filePruned || !version.fileUrl ? (
+                    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                      <FileX className="h-3.5 w-3.5" />
+                      File no longer retained
+                    </span>
+                  ) : (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => window.open(version.fileUrl!, "_blank")}
+                    >
+                      <Download className="mr-1.5 h-3.5 w-3.5" />
+                      Download
+                    </Button>
+                  )}
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Replaced by {version.changedBy?.name ?? "Unknown"} on{" "}
+                  {formatDateOnly(version.createdAt)}
+                  {summary ? ` · changed: ${summary}` : ""}
+                </div>
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  Held renewal {formatDateOnly(version.renewalDate)} · reminder{" "}
+                  {formatDateOnly(version.reminderDate)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/branches/branch-document-history-dialog.tsx
+++ b/src/components/branches/branch-document-history-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -9,42 +10,76 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Download, History, FileX } from "lucide-react";
+import { Download, History, FileX, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { BranchDocument, BranchDocumentVersion } from "@/models/models";
 import { formatDateOnly } from "@/lib/utils";
-import { computeDocumentChanges } from "@/lib/services/branch-document-versions";
 
 interface BranchDocumentHistoryDialogProps {
+  branchId: string;
   document: BranchDocument | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-function toSnapshot(d: BranchDocument | BranchDocumentVersion) {
-  return {
-    name: d.name,
-    description: d.description ?? null,
-    documentTypeId: d.documentTypeId ?? null,
-    renewalDate: new Date(d.renewalDate),
-    reminderDate: new Date(d.reminderDate),
-  };
+type Snapshot = Pick<
+  BranchDocument | BranchDocumentVersion,
+  "name" | "description" | "documentTypeId" | "renewalDate" | "reminderDate"
+>;
+
+/** Human-readable old→new transitions between a version and the state it became. */
+function describeTransition(older: Snapshot, newer: Snapshot, fileReplaced: boolean): string[] {
+  const out: string[] = [];
+  if (fileReplaced) out.push("file replaced");
+  if (older.name !== newer.name) out.push(`name: “${older.name}” → “${newer.name}”`);
+  if (
+    new Date(older.renewalDate).getTime() !== new Date(newer.renewalDate).getTime()
+  )
+    out.push(`renewal ${formatDateOnly(older.renewalDate)} → ${formatDateOnly(newer.renewalDate)}`);
+  if (
+    new Date(older.reminderDate).getTime() !== new Date(newer.reminderDate).getTime()
+  )
+    out.push(`reminder ${formatDateOnly(older.reminderDate)} → ${formatDateOnly(newer.reminderDate)}`);
+  if ((older.description ?? null) !== (newer.description ?? null)) out.push("description updated");
+  if ((older.documentTypeId ?? null) !== (newer.documentTypeId ?? null)) out.push("document type changed");
+  return out;
 }
 
-const FIELD_LABELS: Record<string, string> = {
-  name: "name",
-  description: "description",
-  documentType: "document type",
-  renewalDate: "renewal date",
-  reminderDate: "reminder date",
-  file: "file",
-};
-
 export function BranchDocumentHistoryDialog({
+  branchId,
   document,
   open,
   onOpenChange,
 }: BranchDocumentHistoryDialogProps) {
-  const versions = document?.versions ?? [];
+  const [versions, setVersions] = useState<BranchDocumentVersion[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !document) return;
+    let cancelled = false;
+    setIsLoading(true);
+    fetch(`/api/branches/${branchId}/documents/${document.id}/versions`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load history");
+        return r.json();
+      })
+      .then((data: BranchDocumentVersion[]) => {
+        if (!cancelled) setVersions(data);
+      })
+      .catch((e) => {
+        console.error(e);
+        if (!cancelled) {
+          setVersions([]);
+          toast.error("Failed to load version history");
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, branchId, document]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -84,52 +119,61 @@ export function BranchDocumentHistoryDialog({
             </div>
           )}
 
-          {versions.length === 0 && (
+          {isLoading && (
+            <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading history…
+            </div>
+          )}
+
+          {!isLoading && versions.length === 0 && (
             <p className="py-4 text-center text-sm text-muted-foreground">
               No previous versions yet. A version is recorded each time the file is replaced.
             </p>
           )}
 
-          {versions.map((version, i) => {
-            // The state this version became: the next-newer snapshot (current doc for i=0).
-            const newer = i === 0 ? document! : versions[i - 1];
-            const changed = computeDocumentChanges(toSnapshot(version), toSnapshot(newer), true);
-            const summary = changed.map((f) => FIELD_LABELS[f]).join(", ");
-            return (
-              <div key={version.id} className="rounded-lg border p-3">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2">
-                    <Badge variant="secondary">v{version.versionNumber}</Badge>
-                    <span className="text-sm font-medium">{version.fileName}</span>
+          {!isLoading &&
+            versions.map((version, i) => {
+              // The state this version became: the next-newer snapshot (current doc for i=0).
+              const newer = i === 0 ? document! : versions[i - 1];
+              const transitions = describeTransition(version, newer, true);
+              return (
+                <div key={version.id} className="rounded-lg border p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="secondary">v{version.versionNumber}</Badge>
+                      <span className="text-sm font-medium">{version.fileName}</span>
+                    </div>
+                    {version.filePruned || !version.fileUrl ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                        <FileX className="h-3.5 w-3.5" />
+                        File no longer retained
+                      </span>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => window.open(version.fileUrl!, "_blank")}
+                      >
+                        <Download className="mr-1.5 h-3.5 w-3.5" />
+                        Download
+                      </Button>
+                    )}
                   </div>
-                  {version.filePruned || !version.fileUrl ? (
-                    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                      <FileX className="h-3.5 w-3.5" />
-                      File no longer retained
-                    </span>
-                  ) : (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => window.open(version.fileUrl!, "_blank")}
-                    >
-                      <Download className="mr-1.5 h-3.5 w-3.5" />
-                      Download
-                    </Button>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    Replaced by {version.changedBy?.name ?? "Unknown"} on{" "}
+                    {formatDateOnly(version.createdAt)}
+                  </div>
+                  {transitions.length > 0 && (
+                    <ul className="mt-1 list-disc pl-4 text-xs text-muted-foreground">
+                      {transitions.map((t, idx) => (
+                        <li key={idx}>{t}</li>
+                      ))}
+                    </ul>
                   )}
                 </div>
-                <div className="mt-1 text-xs text-muted-foreground">
-                  Replaced by {version.changedBy?.name ?? "Unknown"} on{" "}
-                  {formatDateOnly(version.createdAt)}
-                  {summary ? ` · changed: ${summary}` : ""}
-                </div>
-                <div className="mt-0.5 text-xs text-muted-foreground">
-                  Held renewal {formatDateOnly(version.renewalDate)} · reminder{" "}
-                  {formatDateOnly(version.reminderDate)}
-                </div>
-              </div>
-            );
-          })}
+              );
+            })}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/branches/branch-document-upload.tsx
+++ b/src/components/branches/branch-document-upload.tsx
@@ -2,256 +2,35 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm } from "react-hook-form";
-import * as z from "zod";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { DateInput } from "@/components/ui/date-input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { FileDropzone } from "@/components/ui/file-dropzone";
-import { Upload, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { Upload } from "lucide-react";
 import { DocumentType } from "@/models/models";
-
-const documentFormSchema = z.object({
-  name: z.string().min(2, "Document name must be at least 2 characters"),
-  description: z.string().optional(),
-  documentTypeId: z.string().optional(),
-  renewalDate: z.date({
-    required_error: "Renewal date is required",
-  }),
-  reminderDate: z.date({
-    required_error: "Reminder date is required",
-  }),
-});
+import { BranchDocumentFormDialog } from "@/components/branches/branch-document-form-dialog";
 
 interface BranchDocumentUploadProps {
   branchId: string;
-  branchName: string;
+  branchName?: string;
   documentTypes?: DocumentType[];
 }
 
 export function BranchDocumentUpload({ branchId, documentTypes = [] }: BranchDocumentUploadProps) {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-
-  const form = useForm<z.infer<typeof documentFormSchema>>({
-    resolver: zodResolver(documentFormSchema),
-    defaultValues: {
-      name: "",
-      description: "",
-    },
-  });
-
-  const onSubmit = async (values: z.infer<typeof documentFormSchema>) => {
-    if (!selectedFile) {
-      toast.error("Please select a file");
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      const formData = new FormData();
-      formData.append("file", selectedFile);
-      formData.append("name", values.name);
-      formData.append("description", values.description || "");
-      formData.append("documentTypeId", values.documentTypeId || "");
-      formData.append("renewalDate", values.renewalDate.toISOString());
-      formData.append("reminderDate", values.reminderDate.toISOString());
-
-      const response = await fetch(`/api/branches/${branchId}/documents`, {
-        method: "POST",
-        body: formData,
-      });
-
-      if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || "Failed to upload document");
-      }
-
-      toast.success("Document uploaded successfully");
-      setIsOpen(false);
-      setSelectedFile(null);
-      form.reset();
-      router.refresh();
-    } catch (error) {
-      console.error(error);
-      toast.error(error instanceof Error ? error.message : "Failed to upload document");
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogTrigger asChild>
-        <Button>
-          <Upload className="mr-2 h-4 w-4" />
-          Upload Document
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>Upload Branch Document</DialogTitle>
-        </DialogHeader>
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Document Name</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder="License Certificate" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Description (Optional)</FormLabel>
-                  <FormControl>
-                    <Textarea {...field} placeholder="Brief description of the document" />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="documentTypeId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Document Type (Optional)</FormLabel>
-                  <Select onValueChange={field.onChange} defaultValue={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select a document type" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {documentTypes.length > 0 ? (
-                        documentTypes.map((docType) => (
-                          <SelectItem key={docType.id} value={docType.id}>
-                            <div className="flex items-center gap-2">
-                              <span>{docType.name}</span>
-                              {docType.mandatory && (
-                                <span className="text-xs text-red-500">*</span>
-                              )}
-                            </div>
-                          </SelectItem>
-                        ))
-                      ) : (
-                        <SelectItem value="no_types" disabled>
-                          No document types available
-                        </SelectItem>
-                      )}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div>
-              <label className="block text-sm font-medium mb-2">File</label>
-              <FileDropzone
-                variant="file"
-                accept=".pdf,.jpg,.jpeg,.png,.gif,.zip"
-                maxSizeMB={10}
-                value={selectedFile ? [selectedFile] : []}
-                onFiles={(fs) => setSelectedFile(fs[0] ?? null)}
-                onRemoveFile={() => setSelectedFile(null)}
-                idleText="Drag & drop a file, or click to browse"
-                hint="PDF, image, or ZIP — up to 10MB"
-                disabled={isLoading}
-              />
-            </div>
-
-            <FormField
-              control={form.control}
-              name="renewalDate"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Renewal Date</FormLabel>
-                  <FormControl>
-                    <DateInput {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="reminderDate"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Reminder Date</FormLabel>
-                  <FormControl>
-                    <DateInput {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="flex gap-2 pt-4">
-              <Button type="submit" className="flex-1" disabled={isLoading}>
-                {isLoading ? (
-                  <>
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    Uploading...
-                  </>
-                ) : (
-                  "Upload Document"
-                )}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setIsOpen(false)}
-                disabled={isLoading}
-              >
-                Cancel
-              </Button>
-            </div>
-          </form>
-        </Form>
-      </DialogContent>
-    </Dialog>
+    <>
+      <Button onClick={() => setIsOpen(true)}>
+        <Upload className="mr-2 h-4 w-4" />
+        Upload Document
+      </Button>
+      <BranchDocumentFormDialog
+        mode="create"
+        branchId={branchId}
+        documentTypes={documentTypes}
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        onSaved={() => router.refresh()}
+      />
+    </>
   );
-} 
+}

--- a/src/components/branches/branch-document-upload.tsx
+++ b/src/components/branches/branch-document-upload.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Upload } from "lucide-react";
 import { DocumentType } from "@/models/models";
@@ -14,7 +13,6 @@ interface BranchDocumentUploadProps {
 }
 
 export function BranchDocumentUpload({ branchId, documentTypes = [] }: BranchDocumentUploadProps) {
-  const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
 
   return (
@@ -29,7 +27,6 @@ export function BranchDocumentUpload({ branchId, documentTypes = [] }: BranchDoc
         documentTypes={documentTypes}
         open={isOpen}
         onOpenChange={setIsOpen}
-        onSaved={() => router.refresh()}
       />
     </>
   );

--- a/src/components/branches/branch-documents-list.tsx
+++ b/src/components/branches/branch-documents-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -24,7 +24,7 @@ import {
   Download,
   Trash,
   FileText,
-  Image,
+  Image as ImageIcon,
   Archive,
   AlertTriangle,
   Calendar,
@@ -42,7 +42,7 @@ import {
 import { toast } from "sonner";
 import { BranchDocument, DocumentType } from "@/models/models";
 import { formatDateOnly } from "@/lib/utils";
-import { BranchDocumentFormDialog } from "@/components/branches/branch-document-form-dialog";
+import { BranchDocumentFormDialog, BRANCH_DOCUMENTS_CHANGED } from "@/components/branches/branch-document-form-dialog";
 import { BranchDocumentHistoryDialog } from "@/components/branches/branch-document-history-dialog";
 
 interface BranchDocumentsListProps {
@@ -64,11 +64,7 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
   const [historyDocument, setHistoryDocument] = useState<BranchDocument | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
 
-  useEffect(() => {
-    fetchDocuments();
-  }, [branchId]);
-
-  const fetchDocuments = async () => {
+  const fetchDocuments = useCallback(async () => {
     try {
       const response = await fetch(`/api/branches/${branchId}/documents`);
       if (!response.ok) {
@@ -82,7 +78,23 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [branchId]);
+
+  useEffect(() => {
+    fetchDocuments();
+  }, [fetchDocuments]);
+
+  // Refetch when a create/edit (e.g. the separate Upload button) changes this
+  // branch's documents — the list is client-fetched, so router.refresh() alone
+  // wouldn't update it.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ branchId?: string }>).detail;
+      if (!detail?.branchId || detail.branchId === branchId) fetchDocuments();
+    };
+    window.addEventListener(BRANCH_DOCUMENTS_CHANGED, handler);
+    return () => window.removeEventListener(BRANCH_DOCUMENTS_CHANGED, handler);
+  }, [branchId, fetchDocuments]);
 
   const handleDelete = async (document: BranchDocument) => {
     setDocumentToDelete(document);
@@ -123,7 +135,7 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
 
   const getFileIcon = (fileType: string) => {
     if (fileType.startsWith('image/')) {
-      return <Image className="h-4 w-4" />;
+      return <ImageIcon className="h-4 w-4" />;
     } else if (fileType === 'application/pdf') {
       return <FileText className="h-4 w-4" />;
     } else if (fileType.includes('zip')) {
@@ -355,7 +367,6 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
         document={editDocument ?? undefined}
         open={editOpen}
         onOpenChange={setEditOpen}
-        onSaved={fetchDocuments}
       />
 
       {/* History Dialog */}

--- a/src/components/branches/branch-documents-list.tsx
+++ b/src/components/branches/branch-documents-list.tsx
@@ -305,9 +305,9 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
                             >
                               <History className="mr-2 h-4 w-4" />
                               History
-                              {document.versions && document.versions.length > 0 && (
+                              {document._count && document._count.versions > 0 && (
                                 <Badge variant="secondary" className="ml-auto text-xs">
-                                  {document.versions.length}
+                                  {document._count.versions}
                                 </Badge>
                               )}
                             </DropdownMenuItem>
@@ -357,6 +357,7 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
 
       {/* History Dialog */}
       <BranchDocumentHistoryDialog
+        branchId={branchId}
         document={historyDocument}
         open={historyOpen}
         onOpenChange={setHistoryOpen}

--- a/src/components/branches/branch-documents-list.tsx
+++ b/src/components/branches/branch-documents-list.tsx
@@ -282,7 +282,10 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
                         </div>
                       </TableCell>
                       <TableCell>
-                        <DropdownMenu>
+                        {/* modal={false}: a modal dropdown locks body pointer-events;
+                            opening a Dialog from a menu item then captures that locked
+                            state and leaves the page frozen after the dialog closes. */}
+                        <DropdownMenu modal={false}>
                           <DropdownMenuTrigger asChild>
                             <Button variant="ghost" className="h-8 w-8 p-0">
                               <span className="sr-only">Open menu</span>

--- a/src/components/branches/branch-documents-list.tsx
+++ b/src/components/branches/branch-documents-list.tsx
@@ -19,15 +19,17 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { 
-  MoreHorizontal, 
-  Download, 
-  Trash, 
-  FileText, 
-  Image, 
+import {
+  MoreHorizontal,
+  Download,
+  Trash,
+  FileText,
+  Image,
   Archive,
   AlertTriangle,
-  Calendar
+  Calendar,
+  Pencil,
+  History
 } from "lucide-react";
 import {
   Dialog,
@@ -38,22 +40,29 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { BranchDocument } from "@/models/models";
+import { BranchDocument, DocumentType } from "@/models/models";
 import { formatDateOnly } from "@/lib/utils";
+import { BranchDocumentFormDialog } from "@/components/branches/branch-document-form-dialog";
+import { BranchDocumentHistoryDialog } from "@/components/branches/branch-document-history-dialog";
 
 interface BranchDocumentsListProps {
   branchId: string;
   canUpload?: boolean;
   showHeading?: boolean;
   branchName?: string;
+  documentTypes?: DocumentType[];
 }
 
-export function BranchDocumentsList({ branchId, canUpload = false, showHeading = true, branchName }: BranchDocumentsListProps) {
+export function BranchDocumentsList({ branchId, canUpload = false, showHeading = true, branchName, documentTypes = [] }: BranchDocumentsListProps) {
   const [documents, setDocuments] = useState<BranchDocument[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isDeleting, setIsDeleting] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [documentToDelete, setDocumentToDelete] = useState<BranchDocument | null>(null);
+  const [editDocument, setEditDocument] = useState<BranchDocument | null>(null);
+  const [editOpen, setEditOpen] = useState(false);
+  const [historyDocument, setHistoryDocument] = useState<BranchDocument | null>(null);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   useEffect(() => {
     fetchDocuments();
@@ -288,6 +297,31 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
                               <Download className="mr-2 h-4 w-4" />
                               Download
                             </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setHistoryDocument(document);
+                                setHistoryOpen(true);
+                              }}
+                            >
+                              <History className="mr-2 h-4 w-4" />
+                              History
+                              {document.versions && document.versions.length > 0 && (
+                                <Badge variant="secondary" className="ml-auto text-xs">
+                                  {document.versions.length}
+                                </Badge>
+                              )}
+                            </DropdownMenuItem>
+                            {canUpload && (
+                              <DropdownMenuItem
+                                onClick={() => {
+                                  setEditDocument(document);
+                                  setEditOpen(true);
+                                }}
+                              >
+                                <Pencil className="mr-2 h-4 w-4" />
+                                Edit
+                              </DropdownMenuItem>
+                            )}
                             {canUpload && (
                               <DropdownMenuItem
                                 onClick={() => handleDelete(document)}
@@ -309,6 +343,24 @@ export function BranchDocumentsList({ branchId, canUpload = false, showHeading =
           )}
         </CardContent>
       </Card>
+
+      {/* Edit Dialog */}
+      <BranchDocumentFormDialog
+        mode="edit"
+        branchId={branchId}
+        documentTypes={documentTypes}
+        document={editDocument ?? undefined}
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        onSaved={fetchDocuments}
+      />
+
+      {/* History Dialog */}
+      <BranchDocumentHistoryDialog
+        document={historyDocument}
+        open={historyOpen}
+        onOpenChange={setHistoryOpen}
+      />
 
       {/* Delete Confirmation Dialog */}
       <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>

--- a/src/lib/services/__tests__/branch-document-versions.test.ts
+++ b/src/lib/services/__tests__/branch-document-versions.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeDocumentChanges,
+  describeDocumentChanges,
+  versionsToPrune,
+  MAX_DOCUMENT_VERSION_FILES,
+  type DocumentFieldsSnapshot,
+} from "../branch-document-versions";
+
+const base: DocumentFieldsSnapshot = {
+  name: "FSSAI License",
+  description: "kitchen license",
+  documentTypeId: "dt1",
+  renewalDate: new Date("2026-01-01"),
+  reminderDate: new Date("2025-12-15"),
+};
+
+describe("computeDocumentChanges", () => {
+  it("returns no changes when nothing differs and no file", () => {
+    expect(computeDocumentChanges(base, { ...base }, false)).toEqual([]);
+  });
+
+  it("detects metadata changes", () => {
+    const incoming = {
+      ...base,
+      name: "FSSAI License 2027",
+      renewalDate: new Date("2027-01-01"),
+    };
+    expect(computeDocumentChanges(base, incoming, false)).toEqual(["name", "renewalDate"]);
+  });
+
+  it("treats null vs same description as unchanged, and null change as changed", () => {
+    expect(computeDocumentChanges(base, { ...base, description: "kitchen license" }, false)).toEqual([]);
+    expect(computeDocumentChanges(base, { ...base, description: null }, false)).toEqual(["description"]);
+  });
+
+  it("compares dates by value, not identity", () => {
+    const incoming = { ...base, renewalDate: new Date("2026-01-01") };
+    expect(computeDocumentChanges(base, incoming, false)).toEqual([]);
+  });
+
+  it("appends 'file' when the file was replaced", () => {
+    expect(computeDocumentChanges(base, { ...base }, true)).toEqual(["file"]);
+    expect(computeDocumentChanges(base, { ...base, name: "x" }, true)).toEqual(["name", "file"]);
+  });
+
+  it("detects documentType change", () => {
+    expect(computeDocumentChanges(base, { ...base, documentTypeId: null }, false)).toEqual(["documentType"]);
+  });
+});
+
+describe("describeDocumentChanges", () => {
+  it("renders friendly labels", () => {
+    expect(describeDocumentChanges(["file", "renewalDate"])).toBe("file, renewal date");
+  });
+});
+
+describe("versionsToPrune", () => {
+  const mk = (n: number, opts: Partial<{ filePruned: boolean; fileUrl: string | null }> = {}) => ({
+    versionNumber: n,
+    filePruned: opts.filePruned ?? false,
+    fileUrl: opts.fileUrl === undefined ? `url-${n}` : opts.fileUrl,
+  });
+
+  it("prunes nothing when at or under the cap", () => {
+    const versions = [mk(1), mk(2), mk(3)];
+    expect(versionsToPrune(versions, 5)).toEqual([]);
+    expect(versionsToPrune([mk(1), mk(2), mk(3), mk(4), mk(5)], 5)).toEqual([]);
+  });
+
+  it("prunes the oldest beyond the cap", () => {
+    const versions = [mk(3), mk(1), mk(2), mk(4), mk(5), mk(6)]; // unsorted, 6 files, cap 5
+    const pruned = versionsToPrune(versions, 5);
+    expect(pruned.map((v) => v.versionNumber)).toEqual([1]); // only the single oldest
+  });
+
+  it("ignores already-pruned versions when counting", () => {
+    const versions = [
+      mk(1, { filePruned: true, fileUrl: null }),
+      mk(2, { filePruned: true, fileUrl: null }),
+      mk(3),
+      mk(4),
+      mk(5),
+      mk(6),
+    ];
+    // 4 live files (3..6) under cap 5 → nothing to prune
+    expect(versionsToPrune(versions, 5)).toEqual([]);
+  });
+
+  it("prunes multiple when far over the cap", () => {
+    const versions = [mk(1), mk(2), mk(3), mk(4), mk(5), mk(6), mk(7)];
+    expect(versionsToPrune(versions, 5).map((v) => v.versionNumber)).toEqual([1, 2]);
+  });
+
+  it("defaults to MAX_DOCUMENT_VERSION_FILES", () => {
+    const versions = Array.from({ length: MAX_DOCUMENT_VERSION_FILES + 2 }, (_, i) => mk(i + 1));
+    expect(versionsToPrune(versions).map((v) => v.versionNumber)).toEqual([1, 2]);
+  });
+});

--- a/src/lib/services/branch-document-versions.ts
+++ b/src/lib/services/branch-document-versions.ts
@@ -1,0 +1,84 @@
+// Pure helpers for branch-document editing + file version history.
+// Kept side-effect free so they can be unit-tested without a DB or Azure.
+
+/** How many historical version FILES to retain per document (older blobs are pruned). */
+export const MAX_DOCUMENT_VERSION_FILES = 5;
+
+/** Allowed upload types — mirrors the create route's validation. */
+export const DOCUMENT_ALLOWED_FILE_TYPES = [
+  "application/pdf",
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/gif",
+  "application/zip",
+  "application/x-zip-compressed",
+] as const;
+
+export const DOCUMENT_MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export interface DocumentFieldsSnapshot {
+  name: string;
+  description: string | null;
+  documentTypeId: string | null;
+  renewalDate: Date;
+  reminderDate: Date;
+}
+
+export type DocumentChangeField =
+  | "name"
+  | "description"
+  | "documentType"
+  | "renewalDate"
+  | "reminderDate"
+  | "file";
+
+/**
+ * Field-level diff between the stored document and an incoming edit.
+ * `fileReplaced` appends "file" when the user uploaded a new file.
+ */
+export function computeDocumentChanges(
+  current: DocumentFieldsSnapshot,
+  incoming: DocumentFieldsSnapshot,
+  fileReplaced: boolean
+): DocumentChangeField[] {
+  const changed: DocumentChangeField[] = [];
+  if (current.name !== incoming.name) changed.push("name");
+  if ((current.description ?? null) !== (incoming.description ?? null)) changed.push("description");
+  if ((current.documentTypeId ?? null) !== (incoming.documentTypeId ?? null)) changed.push("documentType");
+  if (current.renewalDate.getTime() !== incoming.renewalDate.getTime()) changed.push("renewalDate");
+  if (current.reminderDate.getTime() !== incoming.reminderDate.getTime()) changed.push("reminderDate");
+  if (fileReplaced) changed.push("file");
+  return changed;
+}
+
+const CHANGE_LABELS: Record<DocumentChangeField, string> = {
+  name: "name",
+  description: "description",
+  documentType: "document type",
+  renewalDate: "renewal date",
+  reminderDate: "reminder date",
+  file: "file",
+};
+
+/** Human-readable summary for activity logs, e.g. "file, renewal date". */
+export function describeDocumentChanges(fields: DocumentChangeField[]): string {
+  return fields.map((f) => CHANGE_LABELS[f]).join(", ");
+}
+
+/**
+ * After a new file version is added, decide which historical versions' blobs to
+ * prune so that at most `max` versions still retain a file. Prunes oldest first
+ * (lowest versionNumber); only versions that currently hold a file are candidates.
+ * The live document's current file is NOT part of `versions` and is never pruned.
+ */
+export function versionsToPrune<
+  T extends { versionNumber: number; filePruned: boolean; fileUrl: string | null }
+>(versions: T[], max: number = MAX_DOCUMENT_VERSION_FILES): T[] {
+  const withFile = versions
+    .filter((v) => !v.filePruned && v.fileUrl)
+    .sort((a, b) => a.versionNumber - b.versionNumber); // oldest first
+  const excess = withFile.length - max;
+  if (excess <= 0) return [];
+  return withFile.slice(0, excess);
+}

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -209,6 +209,26 @@ export interface BranchDocument {
   uploadedBy: User;
   branch: Branch;
   documentType?: DocumentType | null;
+  versions?: BranchDocumentVersion[];
+}
+
+export interface BranchDocumentVersion {
+  id: string;
+  documentId: string;
+  versionNumber: number;
+  fileName: string;
+  fileUrl: string | null;
+  fileSize: number;
+  fileType: string;
+  filePruned: boolean;
+  name: string;
+  description?: string | null;
+  renewalDate: Date;
+  reminderDate: Date;
+  documentTypeId?: string | null;
+  changedById: string;
+  createdAt: Date;
+  changedBy?: { id: string; name: string } | null;
 }
 
 export type DocumentScope = "BRANCH" | "USER";

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -210,6 +210,7 @@ export interface BranchDocument {
   branch: Branch;
   documentType?: DocumentType | null;
   versions?: BranchDocumentVersion[];
+  _count?: { versions: number };
 }
 
 export interface BranchDocumentVersion {


### PR DESCRIPTION
## What
Adds in-place **editing** of branch documents so renewals no longer require delete-then-recreate, plus a **file version history** with an audit trail.

Spec: `docs/superpowers/specs/2026-06-20-branch-document-edit-versioning-design.md`

## Behaviour
- **Edit** (MANAGEMENT) in the documents list → prefilled dialog (name, description, type, renewal/reminder dates) with an optional **Replace file**.
- **Replacing the file** snapshots the prior file + metadata into a `BranchDocumentVersion` (who/when), retaining the latest **5** version files; older blobs are pruned but the audit record stays.
- **Metadata-only edits** update in place and are recorded via a new `ActivityType.DOCUMENT_UPDATED` (no version row).
- **History** (MANAGEMENT + branch managers) → timeline of file revisions with per-version download (or "file no longer retained" when pruned) and a derived "what changed" summary.
- **Delete** now cleans up the current blob **and** every retained version blob.

## Key files
- `prisma/schema.prisma` + migration `20260620120000_add_branch_document_versions` (new table + `DOCUMENT_UPDATED` enum value)
- `src/lib/services/branch-document-versions.ts` — pure diff/retention helpers (unit-tested)
- `PATCH /api/branches/[branchId]/documents/[documentId]` (+ DELETE cleanup, GET includes versions)
- Shared `branch-document-form-dialog.tsx` (create + edit), `branch-document-history-dialog.tsx`, list wiring

## Permissions
Edit/Delete = MANAGEMENT. History view = MANAGEMENT + BRANCH_MANAGER (own branch). Branch managers remain non-editors.

## Verification
- New unit tests for change-diff + retention (12) plus full suite (269 passing).
- `tsc` clean; `npm run build` succeeds.
- Could **not** live click-test locally: the new table isn't in the local DB (DDL sandbox-blocked here), so the versions-include query can't run locally. Recommend a click-through on a deployed preview.

## Deploy
Run **`prisma migrate deploy`** on production (adds a table + enum value), then the usual web-app deploy. No Azure/cron changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)